### PR TITLE
Fix "set pipefail" syntax

### DIFF
--- a/src/setup-conda.ts
+++ b/src/setup-conda.ts
@@ -426,7 +426,7 @@ conda activate ${activateEnvironment}`;
   let bashExtraText: string = `
 # ----------------------------------------------------------------------------
 # Conda Setup Action: Basic configuration
-set -e pipefail`;
+set -eo pipefail`;
   if (isValidActivate) {
     bashExtraText += `
 # Conda Setup Action: Custom activation


### PR DESCRIPTION
`set -e pipefail` will not work as intended since `pipefail` must be set with `-o pipefail`. No error occurs at the moment because `set` assigns all the extra arguments to $1, $2, etc.