### PR TITLE
Add architecture option to installation candidates

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,10 @@ inputs:
     description: 'Experimental. Use mamba (https://github.com/QuantStack/mamba) as a faster drop-in replacement for conda installs. Disabled by default. To enable, use "*" or a "x.y" version string.'
     required: false
     default: ""
+  architecture:
+    description: 'Architecture of Miniconda that should be installed. Available options on GitHub-hosted runners are "x86" and "x64". Default is "x64".'
+    required: false
+    default: "x64"
 runs:
   using: "node12"
   main: "dist/setup/index.js"

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -21823,10 +21823,16 @@ function setupMiniconda(installerUrl, minicondaVersion, architecture, condaVersi
                 result = yield installMiniconda(result.data, useBundled);
             }
             else if (minicondaVersion !== "" || architecture !== "x64") {
-                if (architecture !== "x64" && minicondaVersion == "") {
+                if (architecture !== "x64" && minicondaVersion === "") {
                     return {
                         ok: false,
                         error: new Error(`"architecture" is set to something other than "x64" so "miniconda-version" must be set as well.`)
+                    };
+                }
+                if (architecture === "x86" && process.platform === "linux") {
+                    return {
+                        ok: false,
+                        error: new Error(`32-bit Linux is not supported by recent versions of Miniconda`)
                     };
                 }
                 utils.consoleLog("\n# Downloading Miniconda...\n");

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -22007,6 +22007,7 @@ function run() {
             let removeProfiles = core.getInput("remove-profiles");
             let showChannelUrls = core.getInput("show-channel-urls");
             let useOnlyTarBz2 = core.getInput("use-only-tar-bz2");
+            let architecture = core.getInput("architecture");
             // Mamba
             let mambaVersion = core.getInput("mamba-version");
             const condaConfig = {
@@ -22021,7 +22022,7 @@ function run() {
                 show_channel_urls: showChannelUrls,
                 use_only_tar_bz2: useOnlyTarBz2
             };
-            const result = yield setupMiniconda(installerUrl, minicondaVersion, "x64", condaVersion, condaBuildVersion, pythonVersion, activateEnvironment, environmentFile, condaFile, condaConfig, removeProfiles, mambaVersion);
+            const result = yield setupMiniconda(installerUrl, minicondaVersion, architecture, condaVersion, condaBuildVersion, pythonVersion, activateEnvironment, environmentFile, condaFile, condaConfig, removeProfiles, mambaVersion);
             if (!result.ok) {
                 throw result.error;
             }
@@ -29066,7 +29067,7 @@ module.exports = defaults;
 /* 771 */
 /***/ (function(module) {
 
-module.exports = {"_args":[["cheerio@1.0.0-rc.3","/Users/goanpeca/Dropbox (Personal)/develop/quansight/setup-miniconda"]],"_from":"cheerio@1.0.0-rc.3","_id":"cheerio@1.0.0-rc.3","_inBundle":false,"_integrity":"sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==","_location":"/cheerio","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"cheerio@1.0.0-rc.3","name":"cheerio","escapedName":"cheerio","rawSpec":"1.0.0-rc.3","saveSpec":null,"fetchSpec":"1.0.0-rc.3"},"_requiredBy":["/get-hrefs"],"_resolved":"https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz","_spec":"1.0.0-rc.3","_where":"/Users/goanpeca/Dropbox (Personal)/develop/quansight/setup-miniconda","author":{"name":"Matt Mueller","email":"mattmuelle@gmail.com","url":"mat.io"},"bugs":{"url":"https://github.com/cheeriojs/cheerio/issues"},"dependencies":{"css-select":"~1.2.0","dom-serializer":"~0.1.1","entities":"~1.1.1","htmlparser2":"^3.9.1","lodash":"^4.15.0","parse5":"^3.0.1"},"description":"Tiny, fast, and elegant implementation of core jQuery designed specifically for the server","devDependencies":{"benchmark":"^2.1.0","coveralls":"^2.11.9","expect.js":"~0.3.1","istanbul":"^0.4.3","jquery":"^3.0.0","jsdom":"^9.2.1","jshint":"^2.9.2","mocha":"^3.1.2","xyz":"~1.1.0"},"engines":{"node":">= 0.6"},"files":["index.js","lib"],"homepage":"https://github.com/cheeriojs/cheerio#readme","keywords":["htmlparser","jquery","selector","scraper","parser","html"],"license":"MIT","main":"./index.js","name":"cheerio","repository":{"type":"git","url":"git://github.com/cheeriojs/cheerio.git"},"scripts":{"test":"make test"},"version":"1.0.0-rc.3"};
+module.exports = {"_args":[["cheerio@1.0.0-rc.3","/Users/bryan/GitHub/setup-miniconda"]],"_from":"cheerio@1.0.0-rc.3","_id":"cheerio@1.0.0-rc.3","_inBundle":false,"_integrity":"sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==","_location":"/cheerio","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"cheerio@1.0.0-rc.3","name":"cheerio","escapedName":"cheerio","rawSpec":"1.0.0-rc.3","saveSpec":null,"fetchSpec":"1.0.0-rc.3"},"_requiredBy":["/get-hrefs"],"_resolved":"https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz","_spec":"1.0.0-rc.3","_where":"/Users/bryan/GitHub/setup-miniconda","author":{"name":"Matt Mueller","email":"mattmuelle@gmail.com","url":"mat.io"},"bugs":{"url":"https://github.com/cheeriojs/cheerio/issues"},"dependencies":{"css-select":"~1.2.0","dom-serializer":"~0.1.1","entities":"~1.1.1","htmlparser2":"^3.9.1","lodash":"^4.15.0","parse5":"^3.0.1"},"description":"Tiny, fast, and elegant implementation of core jQuery designed specifically for the server","devDependencies":{"benchmark":"^2.1.0","coveralls":"^2.11.9","expect.js":"~0.3.1","istanbul":"^0.4.3","jquery":"^3.0.0","jsdom":"^9.2.1","jshint":"^2.9.2","mocha":"^3.1.2","xyz":"~1.1.0"},"engines":{"node":">= 0.6"},"files":["index.js","lib"],"homepage":"https://github.com/cheeriojs/cheerio#readme","keywords":["htmlparser","jquery","selector","scraper","parser","html"],"license":"MIT","main":"./index.js","name":"cheerio","repository":{"type":"git","url":"git://github.com/cheeriojs/cheerio.git"},"scripts":{"test":"make test"},"version":"1.0.0-rc.3"};
 
 /***/ }),
 /* 772 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "action-setup-conda",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -899,6 +899,7 @@ async function run(): Promise<void> {
     let removeProfiles: string = core.getInput("remove-profiles");
     let showChannelUrls: string = core.getInput("show-channel-urls");
     let useOnlyTarBz2: string = core.getInput("use-only-tar-bz2");
+    let architecture: string = core.getInput("architecture");
 
     // Mamba
     let mambaVersion: string = core.getInput("mamba-version");
@@ -918,7 +919,7 @@ async function run(): Promise<void> {
     const result = await setupMiniconda(
       installerUrl,
       minicondaVersion,
-      "x64",
+      architecture,
       condaVersion,
       condaBuildVersion,
       pythonVersion,

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -879,6 +879,7 @@ async function run(): Promise<void> {
     let condaVersion: string = core.getInput("conda-version");
     let condaBuildVersion: string = core.getInput("conda-build-version");
     let pythonVersion: string = core.getInput("python-version");
+    let architecture: string = core.getInput("architecture");
 
     // Environment behavior
     let activateEnvironment: string = core.getInput("activate-environment");
@@ -899,7 +900,6 @@ async function run(): Promise<void> {
     let removeProfiles: string = core.getInput("remove-profiles");
     let showChannelUrls: string = core.getInput("show-channel-urls");
     let useOnlyTarBz2: string = core.getInput("use-only-tar-bz2");
-    let architecture: string = core.getInput("architecture");
 
     // Mamba
     let mambaVersion: string = core.getInput("mamba-version");

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -654,11 +654,19 @@ async function setupMiniconda(
       utils.consoleLog("Installing Custom Installer...");
       result = await installMiniconda(result.data, useBundled);
     } else if (minicondaVersion !== "" || architecture !== "x64") {
-      if (architecture !== "x64" && minicondaVersion == "") {
+      if (architecture !== "x64" && minicondaVersion === "") {
         return {
           ok: false,
           error: new Error(
             `"architecture" is set to something other than "x64" so "miniconda-version" must be set as well.`
+          )
+        };
+      }
+      if (architecture === "x86" && process.platform === "linux") {
+        return {
+          ok: false,
+          error: new Error(
+            `32-bit Linux is not supported by recent versions of Miniconda`
           )
         };
       }


### PR DESCRIPTION
The user can select an architecture supported by their Actions runner as
an option in the with block.

Closes #10