### PR TITLE
Allow explicit conda environment specs

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -21873,7 +21873,14 @@ function setupMiniconda(installerUrl, minicondaVersion, architecture, condaVersi
             if (environmentFile) {
                 try {
                     const sourceEnvironmentPath = path.join(process.env["GITHUB_WORKSPACE"] || "", environmentFile);
-                    environmentYaml = yield yaml.safeLoad(fs.readFileSync(sourceEnvironmentPath, "utf8"));
+                    if (fs
+                        .readFileSync(sourceEnvironmentPath, "utf8")
+                        .includes("\n@EXPLICIT\n")) {
+                        environmentYaml = {};
+                    }
+                    else {
+                        environmentYaml = yield yaml.safeLoad(fs.readFileSync(sourceEnvironmentPath, "utf8"));
+                    }
                 }
                 catch (err) {
                     return { ok: false, error: err };
@@ -21964,7 +21971,14 @@ function setupMiniconda(installerUrl, minicondaVersion, architecture, condaVersi
                 let activateEnvironmentToUse;
                 try {
                     const sourceEnvironmentPath = path.join(process.env["GITHUB_WORKSPACE"] || "", environmentFile);
-                    environmentYaml = yield yaml.safeLoad(fs.readFileSync(sourceEnvironmentPath, "utf8"));
+                    if (fs
+                        .readFileSync(sourceEnvironmentPath, "utf8")
+                        .includes("\n@EXPLICIT\n")) {
+                        environmentYaml = {};
+                    }
+                    else {
+                        environmentYaml = yield yaml.safeLoad(fs.readFileSync(sourceEnvironmentPath, "utf8"));
+                    }
                 }
                 catch (err) {
                     return { ok: false, error: err };
@@ -29090,7 +29104,7 @@ module.exports = defaults;
 /* 771 */
 /***/ (function(module) {
 
-module.exports = {"_args":[["cheerio@1.0.0-rc.3","/Users/bryan/GitHub/setup-miniconda"]],"_from":"cheerio@1.0.0-rc.3","_id":"cheerio@1.0.0-rc.3","_inBundle":false,"_integrity":"sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==","_location":"/cheerio","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"cheerio@1.0.0-rc.3","name":"cheerio","escapedName":"cheerio","rawSpec":"1.0.0-rc.3","saveSpec":null,"fetchSpec":"1.0.0-rc.3"},"_requiredBy":["/get-hrefs"],"_resolved":"https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz","_spec":"1.0.0-rc.3","_where":"/Users/bryan/GitHub/setup-miniconda","author":{"name":"Matt Mueller","email":"mattmuelle@gmail.com","url":"mat.io"},"bugs":{"url":"https://github.com/cheeriojs/cheerio/issues"},"dependencies":{"css-select":"~1.2.0","dom-serializer":"~0.1.1","entities":"~1.1.1","htmlparser2":"^3.9.1","lodash":"^4.15.0","parse5":"^3.0.1"},"description":"Tiny, fast, and elegant implementation of core jQuery designed specifically for the server","devDependencies":{"benchmark":"^2.1.0","coveralls":"^2.11.9","expect.js":"~0.3.1","istanbul":"^0.4.3","jquery":"^3.0.0","jsdom":"^9.2.1","jshint":"^2.9.2","mocha":"^3.1.2","xyz":"~1.1.0"},"engines":{"node":">= 0.6"},"files":["index.js","lib"],"homepage":"https://github.com/cheeriojs/cheerio#readme","keywords":["htmlparser","jquery","selector","scraper","parser","html"],"license":"MIT","main":"./index.js","name":"cheerio","repository":{"type":"git","url":"git://github.com/cheeriojs/cheerio.git"},"scripts":{"test":"make test"},"version":"1.0.0-rc.3"};
+module.exports = {"_args":[["cheerio@1.0.0-rc.3","/Users/mathieu/github/setup-miniconda"]],"_from":"cheerio@1.0.0-rc.3","_id":"cheerio@1.0.0-rc.3","_inBundle":false,"_integrity":"sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==","_location":"/cheerio","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"cheerio@1.0.0-rc.3","name":"cheerio","escapedName":"cheerio","rawSpec":"1.0.0-rc.3","saveSpec":null,"fetchSpec":"1.0.0-rc.3"},"_requiredBy":["/get-hrefs"],"_resolved":"https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz","_spec":"1.0.0-rc.3","_where":"/Users/mathieu/github/setup-miniconda","author":{"name":"Matt Mueller","email":"mattmuelle@gmail.com","url":"mat.io"},"bugs":{"url":"https://github.com/cheeriojs/cheerio/issues"},"dependencies":{"css-select":"~1.2.0","dom-serializer":"~0.1.1","entities":"~1.1.1","htmlparser2":"^3.9.1","lodash":"^4.15.0","parse5":"^3.0.1"},"description":"Tiny, fast, and elegant implementation of core jQuery designed specifically for the server","devDependencies":{"benchmark":"^2.1.0","coveralls":"^2.11.9","expect.js":"~0.3.1","istanbul":"^0.4.3","jquery":"^3.0.0","jsdom":"^9.2.1","jshint":"^2.9.2","mocha":"^3.1.2","xyz":"~1.1.0"},"engines":{"node":">= 0.6"},"files":["index.js","lib"],"homepage":"https://github.com/cheeriojs/cheerio#readme","keywords":["htmlparser","jquery","selector","scraper","parser","html"],"license":"MIT","main":"./index.js","name":"cheerio","repository":{"type":"git","url":"git://github.com/cheeriojs/cheerio.git"},"scripts":{"test":"make test"},"version":"1.0.0-rc.3"};
 
 /***/ }),
 /* 772 */

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -713,9 +713,17 @@ async function setupMiniconda(
           process.env["GITHUB_WORKSPACE"] || "",
           environmentFile
         );
-        environmentYaml = await yaml.safeLoad(
-          fs.readFileSync(sourceEnvironmentPath, "utf8")
-        );
+        if (
+          fs
+            .readFileSync(sourceEnvironmentPath, "utf8")
+            .includes("\n@EXPLICIT\n")
+        ) {
+          environmentYaml = {};
+        } else {
+          environmentYaml = await yaml.safeLoad(
+            fs.readFileSync(sourceEnvironmentPath, "utf8")
+          );
+        }
       } catch (err) {
         return { ok: false, error: err };
       }
@@ -850,9 +858,17 @@ async function setupMiniconda(
           process.env["GITHUB_WORKSPACE"] || "",
           environmentFile
         );
-        environmentYaml = await yaml.safeLoad(
-          fs.readFileSync(sourceEnvironmentPath, "utf8")
-        );
+        if (
+          fs
+            .readFileSync(sourceEnvironmentPath, "utf8")
+            .includes("\n@EXPLICIT\n")
+        ) {
+          environmentYaml = {};
+        } else {
+          environmentYaml = await yaml.safeLoad(
+            fs.readFileSync(sourceEnvironmentPath, "utf8")
+          );
+        }
       } catch (err) {
         return { ok: false, error: err };
       }


### PR DESCRIPTION
Here's a first go at supporting [explicit spec files](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#building-identical-conda-environments). The main upshot is that it bypasses completely the solving step (which can speed up the action significantly) and produces a fixed environment (that can only break if the packages become unavailable).

It's working, but there are currently no safegards nor documentation. There are definitely a few caveats to using explicit conda specs: 
- It usually doesn't make sense to specify a Python version (it's usually already in the spec)
- One must provide an `activate-environment` name (it's not in the spec)
- One must take care to provide a spec for the right platform

I haven't tested what would happen with a bundled miniconda, what happens when using mamba, or how it interacts with caching.

Is there interest in further work on this?