### PR TITLE
Update readme for caching

### DIFF
--- a/.github/workflows/caching-example.yml
+++ b/.github/workflows/caching-example.yml
@@ -26,5 +26,5 @@ jobs:
         with:
           activate-environment: anaconda-client-env
           channel-priority: strict
-          environment-file: etc/example-environment.yml
+          environment-file: etc/example-environment-caching.yml
           use-only-tar-bz2: true

--- a/.github/workflows/caching-example.yml
+++ b/.github/workflows/caching-example.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: ./
         with:
           activate-environment: anaconda-client-env
-          python-version: 3.8
           channel-priority: strict
           environment-file: etc/example-environment.yml
           use-only-tar-bz2: true

--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ jobs:
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
 ```
 
+If you are using pip to resolve any dependencies in your conda environment then you may want to [cache those dependencies separately](https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#caching-dependencies), as they are not included in the conda package cache.
+
 ## IMPORTANT
 
 - Bash shells do not use `~/.profile` or `~/.bashrc` so these shells need to be explicitely declared as `shell: bash -l {0}` on steps that need to be properly activated. This is because bash shells are executed with `bash --noprofile --norc -eo pipefail {0}` thus ignoring updated on bash profile files made by `conda init bash`. See [Github Actions Documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell) and [thread](https://github.community/t5/GitHub-Actions/How-to-share-shell-profile-between-steps-or-how-to-use-nvm-rvm/td-p/33185).

--- a/README.md
+++ b/README.md
@@ -273,7 +273,6 @@ jobs:
       - uses: goanpeca/setup-miniconda@v1
         with:
           activate-environment: anaconda-client-env
-          python-version: 3.8
           channel-priority: strict
           environment-file: etc/example-environment.yml
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ jobs:
         with:
           activate-environment: anaconda-client-env
           channel-priority: strict
-          environment-file: etc/example-environment.yml
+          environment-file: etc/example-environment-caching.yml
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
 ```
 

--- a/etc/example-environment-caching.yml
+++ b/etc/example-environment-caching.yml
@@ -1,4 +1,5 @@
 name: anaconda-client-env
 dependencies:
+  - python=3.8
   - black
   - anaconda-client

--- a/etc/example-environment.yml
+++ b/etc/example-environment.yml
@@ -1,4 +1,5 @@
 name: anaconda-client-env
 dependencies:
+  - python=3.8
   - black
   - anaconda-client


### PR DESCRIPTION
Applied suggestions to README.md regarding caching pip packages separately. As per #65 

I've also moved the declaration of the python version for the caching example from inside the workflow, to inside `etc/example-environment.yml`. I don't think that this change should affect the other workflows that use this file, hopefully the github actions will pick up on this. I would carry out further testing but unfortunately I'm about to lose internet access for about a week! Feel free to modify this if needed.

Closes #65