### PR TITLE
add changelog, more formatting

### DIFF
--- a/.github/workflows/caching-example.yml
+++ b/.github/workflows/caching-example.yml
@@ -3,15 +3,15 @@ name: "Caching Example"
 on:
   pull_request:
     branches:
-    - '*'
+      - "*"
   push:
     branches:
-    - 'master'
+      - "master"
 
 jobs:
   caching-example:
     name: Caching
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
       - name: Cache conda
@@ -21,7 +21,9 @@ jobs:
           CACHE_NUMBER: 2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('etc/example-environment.yml') }}
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('etc/example-environment.yml') }}
       - uses: ./
         with:
           activate-environment: anaconda-client-env

--- a/.github/workflows/example-1.yml
+++ b/.github/workflows/example-1.yml
@@ -3,10 +3,10 @@ name: "Example 1: Basic usage"
 on:
   pull_request:
     branches:
-    - '*'
+      - "*"
   push:
     branches:
-    - 'master'
+      - "master"
 
 jobs:
   example-1:
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '2.7']
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.7", "2.7"]
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/.github/workflows/example-2.yml
+++ b/.github/workflows/example-2.yml
@@ -3,20 +3,20 @@ name: "Example 2: Other shells"
 on:
   pull_request:
     branches:
-    - '*'
+      - "*"
   push:
     branches:
-    - 'master'
+      - "master"
 
 jobs:
   example-2-linux:
     name: Ex2 Linux
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
       - uses: ./
         with:
-          miniconda-version: 'latest'
+          miniconda-version: "latest"
           activate-environment: foo
       - name: Bash
         shell: bash -l {0}
@@ -33,12 +33,12 @@ jobs:
 
   example-2-mac:
     name: Ex2 Mac
-    runs-on: 'macos-latest'
+    runs-on: "macos-latest"
     steps:
       - uses: actions/checkout@v2
       - uses: ./
         with:
-          miniconda-version: 'latest'
+          miniconda-version: "latest"
           activate-environment: foo
       - name: Sh
         shell: sh -l {0}
@@ -61,7 +61,7 @@ jobs:
 
   example-2-win:
     name: Ex2 Windows
-    runs-on: 'windows-latest'
+    runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v2
       - uses: ./
@@ -96,6 +96,4 @@ jobs:
       - name: Cmd.exe
         shell: cmd /C CALL {0}
         run: >-
-          conda info &&
-          conda list  &&
-          SET
+          conda info && conda list  && SET

--- a/.github/workflows/example-3.yml
+++ b/.github/workflows/example-3.yml
@@ -3,15 +3,15 @@ name: "Example 3: Other options"
 on:
   pull_request:
     branches:
-    - '*'
+      - "*"
   push:
     branches:
-    - 'master'
+      - "master"
 
 jobs:
   example-3:
     name: Ex3 Linux
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
       - uses: ./
@@ -28,10 +28,9 @@ jobs:
           conda list
           printenv | sort
 
-
   example-3-no-name:
     name: Ex3-no-name Linux
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/.github/workflows/example-4.yml
+++ b/.github/workflows/example-4.yml
@@ -3,15 +3,15 @@ name: "Example 4: Channels"
 on:
   pull_request:
     branches:
-    - '*'
+      - "*"
   push:
     branches:
-    - 'master'
+      - "master"
 
 jobs:
   example-4:
     name: Ex4 Linux
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/.github/workflows/example-5.yml
+++ b/.github/workflows/example-5.yml
@@ -3,15 +3,15 @@ name: "Example 5: Custom installer"
 on:
   pull_request:
     branches:
-    - '*'
+      - "*"
   push:
     branches:
-    - 'master'
+      - "master"
 
 jobs:
   example-5-linux:
     name: Ex5 PyPy Linux
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
       - uses: ./
@@ -29,7 +29,7 @@ jobs:
 
   example-5-mac:
     name: Ex5 PyPy MacOS
-    runs-on: 'macos-latest'
+    runs-on: "macos-latest"
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/.github/workflows/example-6.yml
+++ b/.github/workflows/example-6.yml
@@ -3,15 +3,15 @@ name: "Example 6: Mamba"
 on:
   pull_request:
     branches:
-    - '*'
+      - "*"
   push:
     branches:
-    - 'master'
+      - "master"
 
 jobs:
   example-6:
     name: Ex6 Mamba
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/.github/workflows/example-7.yml
+++ b/.github/workflows/example-7.yml
@@ -3,10 +3,10 @@ name: "Example 7: Explicit Environment Specification"
 on:
   pull_request:
     branches:
-    - '*'
+      - "*"
   push:
     branches:
-    - 'master'
+      - "master"
 
 jobs:
   example-7:
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,15 +3,15 @@ name: "Linting"
 on:
   pull_request:
     branches:
-    - '*'
+      - "*"
   push:
     branches:
-    - 'master'
+      - "master"
 
 jobs:
   lint:
     name: Lint
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
       - shell: bash -l {0}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "proseWrap": "always"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,162 @@
+# CHANGELOG
+
+## _Unreleased_
+
+### Fixes
+
+- [#79][] fixes GitHub deprecation warnings [#78][]
+
+### Features
+
+- [#61][], [#74][] add support for explicit environment specifications.
+
+[#61]: https://github.com/conda-incubator/setup-miniconda/pull/61
+[#74]: https://github.com/conda-incubator/setup-miniconda/pull/74
+[#78]: https://github.com/conda-incubator/setup-miniconda/pull/78
+[#79]: https://github.com/conda-incubator/setup-miniconda/pull/79
+
+## [v1.7.0][] (2020-08-19)
+
+### Fixes
+
+- [#64][] fixes a bug on post section with removing conda files.
+
+### Features
+
+- [???](#) adds x32 support for some machines.
+
+[v1.7.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.7.0
+[#64]: https://github.com/conda-incubator/setup-miniconda/pull/64
+
+## [v1.6.0][] (2020-07-11)
+
+### Features
+
+- [#47][] adds support for installing and using `mamba` instead of `conda`
+
+[v1.6.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.6.0
+[#47]: https://github.com/conda-incubator/setup-miniconda/pull/47
+
+## [v1.5.0][] (2020-05-28)
+
+### Features
+
+- [???](#) fixes conflicting channels on `environment.yml` files and the action input channels
+
+### Fixes
+
+- [#43][] adds support for custom installers, e.g. `miniforge`
+
+[v1.5.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.5.0
+[#43]: https://github.com/conda-incubator/setup-miniconda/pull/43
+
+## [v1.4.1][] (2020-05-22)
+
+### Fixes
+
+- [???](#) fixes a small regression on windows systems.
+
+[v1.4.1]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.4.1
+
+## [v1.4.0][] (2020-05-22)
+
+### Features
+
+- [???](#) adds a post step to remove any uncompressed packages found in the packages dir, so the cache can also save packages that were installed in different steps from the action step.
+
+[v1.4.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.4.0
+
+## [v1.3.1][] (2020-05-17)
+
+### Fixes
+
+- [???](#) fixes regression in systems where the cache folder has not been created.
+
+[v1.3.1]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.3.1
+
+## [v1.3.0][] (2020-05-14)
+
+### Features
+
+- [???](#) adds the possibility of using the cache action to cache downloaded conda packages and (hopefully) reduce build times.
+
+[v1.3.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.3.0
+
+## [v1.2.0][] (2020-05-11)
+
+### Features
+
+- adds additional configuration options to the action input, including:
+
+```yaml
+allow-softlinks
+channel-priority
+show-channel-urls
+use-only-tar-bz2
+```
+
+[v1.2.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.2.0
+
+## [v1.1.4][] (2020-05-06)
+
+### Fixes
+
+- [???](#) fixes regression
+
+[v1.1.4]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.1.4
+
+## [v1.1.3][] (2020-05-06)
+
+### Fixes
+
+- [???](#) Minor fixes
+
+### Features
+
+- [???](#) adds new URL for downloading packages
+
+[v1.1.3]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.1.3
+
+## [v1.1.2][] (2020-04-11)
+
+### Fixes
+
+- [???](#) fixes regression with file permissions
+
+[v1.1.2]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.1.2
+
+## [v1.1.1][] (2020-04-11)
+
+### ???
+
+- [???](#) ???
+
+[v1.1.1]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.1.1
+
+## [v1.1.0][] (2020-04-11)
+
+### Fixes
+
+- [???](#) fix issues
+
+### Features
+
+- [???](#) add `channels` support
+
+[v1.1.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.1.0
+
+## [v1.0.2][] (2019-12-23)
+
+### Fixes
+
+- [???](#) fixes windows environment activation
+
+[v1.0.2]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.0.2
+
+## [v1.0.1][] (2019-12-19)
+
+### Features
+
+- first official release!
+
+[v1.0.1]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@
 
 ### Features
 
-- [???](#) fixes conflicting channels on `environment.yml` files and the action input channels
+- [???](#) fixes conflicting channels on `environment.yml` files and the action
+  input channels
 
 ### Fixes
 
@@ -62,7 +63,9 @@
 
 ### Features
 
-- [???](#) adds a post step to remove any uncompressed packages found in the packages dir, so the cache can also save packages that were installed in different steps from the action step.
+- [???](#) adds a post step to remove any uncompressed packages found in the
+  packages dir, so the cache can also save packages that were installed in
+  different steps from the action step.
 
 [v1.4.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.4.0
 
@@ -70,7 +73,8 @@
 
 ### Fixes
 
-- [???](#) fixes regression in systems where the cache folder has not been created.
+- [???](#) fixes regression in systems where the cache folder has not been
+  created.
 
 [v1.3.1]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.3.1
 
@@ -78,7 +82,8 @@
 
 ### Features
 
-- [???](#) adds the possibility of using the cache action to cache downloaded conda packages and (hopefully) reduce build times.
+- [???](#) adds the possibility of using the cache action to cache downloaded
+  conda packages and (hopefully) reduce build times.
 
 [v1.3.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.3.0
 
@@ -89,10 +94,7 @@
 - adds additional configuration options to the action input, including:
 
 ```yaml
-allow-softlinks
-channel-priority
-show-channel-urls
-use-only-tar-bz2
+allow-softlinks channel-priority show-channel-urls use-only-tar-bz2
 ```
 
 [v1.2.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## _Unreleased_
+## [v2.0.0][] (2020-11-04)
 
 ### Fixes
 
@@ -10,6 +10,7 @@
 
 - [#61][], [#74][] adds support for explicit environment specifications.
 
+[v2.0.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v2.0.0
 [#61]: https://github.com/conda-incubator/setup-miniconda/pull/61
 [#74]: https://github.com/conda-incubator/setup-miniconda/pull/74
 [#78]: https://github.com/conda-incubator/setup-miniconda/pull/78

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Fixes
 
-- [#79][] fixes GitHub deprecation warnings [#78][]
+- [#79][] fixes GitHub deprecation warnings [#78][].
 
 ### Features
 
-- [#61][], [#74][] add support for explicit environment specifications.
+- [#61][], [#74][] adds support for explicit environment specifications.
 
 [#61]: https://github.com/conda-incubator/setup-miniconda/pull/61
 [#74]: https://github.com/conda-incubator/setup-miniconda/pull/74
@@ -21,41 +21,46 @@
 
 - [#64][] fixes a bug on post section with removing conda files.
 
+
 ### Features
 
-- [???](#) adds x32 support for some machines.
+- [#52][] adds x32 support for some machines.
+- [#53][] allows environment files to omit the `name` field.
 
 [v1.7.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.7.0
 [#64]: https://github.com/conda-incubator/setup-miniconda/pull/64
+[#53]: https://github.com/conda-incubator/setup-miniconda/pull/53
+[#52]: https://github.com/conda-incubator/setup-miniconda/pull/52
 
 ## [v1.6.0][] (2020-07-11)
 
 ### Features
 
-- [#47][] adds support for installing and using `mamba` instead of `conda`
+- [#47][] adds support for installing and using `mamba` instead of `conda`.
 
 [v1.6.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.6.0
 [#47]: https://github.com/conda-incubator/setup-miniconda/pull/47
 
 ## [v1.5.0][] (2020-05-28)
 
-### Features
-
-- [???](#) fixes conflicting channels on `environment.yml` files and the action
-  input channels
-
 ### Fixes
+
+- [#46][] fixes conflicting channels on `environment.yml` files and the action
+  input channels.
+
+### Features
 
 - [#43][] adds support for custom installers, e.g. `miniforge`
 
 [v1.5.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.5.0
 [#43]: https://github.com/conda-incubator/setup-miniconda/pull/43
+[#47]: https://github.com/conda-incubator/setup-miniconda/pull/47
 
 ## [v1.4.1][] (2020-05-22)
 
 ### Fixes
 
-- [???](#) fixes a small regression on windows systems.
+- fixes a small regression on windows systems.
 
 [v1.4.1]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.4.1
 
@@ -63,47 +68,54 @@
 
 ### Features
 
-- [???](#) adds a post step to remove any uncompressed packages found in the
+- [#41][] adds a post step to remove any uncompressed packages found in the
   packages dir, so the cache can also save packages that were installed in
   different steps from the action step.
 
 [v1.4.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.4.0
+[#41]: https://github.com/conda-incubator/setup-miniconda/pull/41
 
 ## [v1.3.1][] (2020-05-17)
 
 ### Fixes
 
-- [???](#) fixes regression in systems where the cache folder has not been
+- [#47][] fixes regression in systems where the cache folder has not been
   created.
 
 [v1.3.1]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.3.1
+[#47]: https://github.com/conda-incubator/setup-miniconda/pull/47
 
 ## [v1.3.0][] (2020-05-14)
 
 ### Features
 
-- [???](#) adds the possibility of using the cache action to cache downloaded
+- [#35][] adds the possibility of using the cache action to cache downloaded
   conda packages and (hopefully) reduce build times.
 
 [v1.3.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.3.0
+[#35]: https://github.com/conda-incubator/setup-miniconda/pull/35
 
 ## [v1.2.0][] (2020-05-11)
 
 ### Features
 
-- adds additional configuration options to the action input, including:
+- [#33][] adds additional configuration options to the action input, including:
 
 ```yaml
-allow-softlinks channel-priority show-channel-urls use-only-tar-bz2
+- allow-softlinks
+- channel-priority
+- show-channel-urls
+- use-only-tar-bz2
 ```
 
 [v1.2.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.2.0
+[#33]: https://github.com/conda-incubator/setup-miniconda/pull/33
 
 ## [v1.1.4][] (2020-05-06)
 
 ### Fixes
 
-- [???](#) fixes regression
+- fixes regression on shell environment variable checking.
 
 [v1.1.4]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.1.4
 
@@ -111,27 +123,29 @@ allow-softlinks channel-priority show-channel-urls use-only-tar-bz2
 
 ### Fixes
 
-- [???](#) Minor fixes
+- [#28][] fixes some small issues.
 
 ### Features
 
-- [???](#) adds new URL for downloading packages
+- [#22][] adds new URL for downloading packages.
 
 [v1.1.3]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.1.3
+[#22]: https://github.com/conda-incubator/setup-miniconda/pull/22
+[#28]: https://github.com/conda-incubator/setup-miniconda/pull/28
 
 ## [v1.1.2][] (2020-04-11)
 
 ### Fixes
 
-- [???](#) fixes regression with file permissions
+- fixes regression with file permissions.
 
 [v1.1.2]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.1.2
 
 ## [v1.1.1][] (2020-04-11)
 
-### ???
+### Fixes
 
-- [???](#) ???
+- fixes some channel issues.
 
 [v1.1.1]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.1.1
 
@@ -139,21 +153,25 @@ allow-softlinks channel-priority show-channel-urls use-only-tar-bz2
 
 ### Fixes
 
-- [???](#) fix issues
+- [#11][] fix pipefail issues.
 
 ### Features
 
-- [???](#) add `channels` support
+- [#17][] add `channels` support.
 
 [v1.1.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.1.0
+[#11]: https://github.com/conda-incubator/setup-miniconda/pull/11
+[#17]: https://github.com/conda-incubator/setup-miniconda/pull/17
+
 
 ## [v1.0.2][] (2019-12-23)
 
 ### Fixes
 
-- [???](#) fixes windows environment activation
+- [#6][] fixes windows environment activation
 
 [v1.0.2]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v1.0.2
+[#6]: https://github.com/conda-incubator/setup-miniconda/pull/6
 
 ## [v1.0.1][] (2019-12-19)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,20 +5,19 @@
 The build step transpiles the `src/` to `dist/`, with `ncc`. These files, by
 convention, are also checked in.
 
-- Create Conda env
+- Create Conda env with `nodejs`:
 
 ```bash
 conda create -n github-action nodejs -c conda-forge
 ```
 
-- Install NodeJS
+- Install NodeJS dependencies:
 
 ```bash
-conda activate github-action
 npm install
 ```
 
-- Ensure the files in `dist` has been rebuilt
+- Ensure the files in `dist` have been rebuilt:
 
 ```bash
 npm run format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,19 +2,30 @@
 
 ## Build
 
-The build steps transpiles the `src/main.ts` to `lib/main.js` and then packs to
-`dist/index.js`. It is handled by Typescript compiler.
+The build step transpiles the `src/` to `dist/`, with `ncc`. These files, by
+convention, are also checked in.
+
+- Create Conda env
+
+```bash
+conda create -n github-action nodejs -c conda-forge
+```
 
 - Install NodeJS
 
 ```bash
+conda activate github-action
 npm install
 ```
 
-- To update the code
+- Ensure the files in `dist` has been rebuilt
 
 ```bash
 npm run format
 npm run check
 npm run build
 ```
+
+## Release
+
+See the [release documentation](./RELEASE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 ## Build
 
-The build steps transpiles the `src/main.ts` to `lib/main.js` and then packs to `dist/index.js`. It is handled by Typescript compiler.
+The build steps transpiles the `src/main.ts` to `lib/main.js` and then packs to
+`dist/index.js`. It is handled by Typescript compiler.
 
 - Install NodeJS
 

--- a/README.md
+++ b/README.md
@@ -9,21 +9,33 @@
 ![Caching Example](https://github.com/conda-incubator/setup-miniconda/workflows/Caching%20Example/badge.svg?branch=master)
 ![Linting](https://github.com/conda-incubator/setup-miniconda/workflows/Linting/badge.svg?branch=master)
 
-This action sets up a [Miniconda](https://docs.conda.io/en/latest/miniconda.html) installation to use the [Conda](https://docs.conda.io/projects/conda/en/latest/) package and environment manager by either locating the Miniconda installation bundled with the available runners or by installing a specific Miniconda3 version. By default this action will also create a test environment.
+This action sets up a
+[Miniconda](https://docs.conda.io/en/latest/miniconda.html) installation to use
+the [Conda](https://docs.conda.io/projects/conda/en/latest/) package and
+environment manager by either locating the Miniconda installation bundled with
+the available runners or by installing a specific Miniconda3 version. By default
+this action will also create a test environment.
 
-Miniconda `condabin/` folder is added to `PATH` and conda is correctly initialized across all platforms.
+Miniconda `condabin/` folder is added to `PATH` and conda is correctly
+initialized across all platforms.
 
-This action correctly handles activation of conda environments and offers the possibility of automatically activating the test environment on all shells.
+This action correctly handles activation of conda environments and offers the
+possibility of automatically activating the test environment on all shells.
 
-See the **[IMPORTANT](#IMPORTANT)** notes on additional information on environment activation.
+See the **[IMPORTANT](#IMPORTANT)** notes on additional information on
+environment activation.
 
 ## Usage examples
 
-For a full list of available inputs for this action see [action.yml](action.yml).
+For a full list of available inputs for this action see
+[action.yml](action.yml).
 
 ### Example 1: Basic usage
 
-This example shows how to set a basic python workflow with conda using the crossplatform available shells: `bash` and `pwsh`. On this example an environment named `test` will be created with the specific `python-version` installed for each opearating system, resulting on 6 build workers.
+This example shows how to set a basic python workflow with conda using the
+crossplatform available shells: `bash` and `pwsh`. On this example an
+environment named `test` will be created with the specific `python-version`
+installed for each opearating system, resulting on 6 build workers.
 
 ```yaml
 jobs:
@@ -50,7 +62,9 @@ jobs:
 
 ### Example 2: Other shells
 
-This example shows how to use all other available shells for specific operating systems. On this example we select to download the latest anaconda version available and create and activate by default an environment named `foo`.
+This example shows how to use all other available shells for specific operating
+systems. On this example we select to download the latest anaconda version
+available and create and activate by default an environment named `foo`.
 
 ```yaml
 jobs:
@@ -123,13 +137,17 @@ jobs:
       - name: Cmd.exe
         shell: cmd /C CALL {0}
         run: >-
-          conda info &&
-          conda list
+          conda info && conda list
 ```
 
 ### Example 3: Other options
 
-This example shows how to use [environment.yml](etc/example-environment.yml) for easier creation of test/build environments and [.condarc](etc/example-condarc.yml) files for fine grained configuration management. On this example we use a custom configuration file, install an environment from a yaml file and disable autoactivating the base environment before activating the `anaconda-client-env`.
+This example shows how to use [environment.yml](etc/example-environment.yml) for
+easier creation of test/build environments and
+[.condarc](etc/example-condarc.yml) files for fine grained configuration
+management. On this example we use a custom configuration file, install an
+environment from a yaml file and disable autoactivating the base environment
+before activating the `anaconda-client-env`.
 
 ```yaml
 jobs:
@@ -153,8 +171,9 @@ jobs:
 
 ### Example 4: Conda options
 
-This example shows how to use `channels` option and other extra options. The priority will be set by the order of the channels.
-In this example it will result in:
+This example shows how to use `channels` option and other extra options. The
+priority will be set by the order of the channels. In this example it will
+result in:
 
 - conda-forge
 - spyder-ide
@@ -187,10 +206,10 @@ jobs:
 ### Example 5: Custom installer
 
 Any installer created with [constructor](https://github.com/conda/constructor)
-which includes `conda` can be used in place of Miniconda.
-For example, [conda-forge](https://conda-forge.org/) maintains additional builds
-of [miniforge](https://github.com/conda-forge/miniforge/releases) for platforms
-not yet supported by Miniconda.
+which includes `conda` can be used in place of Miniconda. For example,
+[conda-forge](https://conda-forge.org/) maintains additional builds of
+[miniforge](https://github.com/conda-forge/miniforge/releases) for platforms not
+yet supported by Miniconda.
 
 ```yaml
 jobs:
@@ -215,7 +234,10 @@ jobs:
 
 ### Example 6: Mamba
 
-Experimental! Use `mamba` to handle conda installs in a faster way. `mamba-version` accepts a version string `x.y` (including `"*"`). It requires you specify `conda-forge` as part of the channels, ideally with the highest priority.
+Experimental! Use `mamba` to handle conda installs in a faster way.
+`mamba-version` accepts a version string `x.y` (including `"*"`). It requires
+you specify `conda-forge` as part of the channels, ideally with the highest
+priority.
 
 ```yaml
 jobs:
@@ -245,24 +267,26 @@ jobs:
 
 ### Example 7: Explicit Specification
 
-`conda list --explicit` and [conda-lock][] support generating
-[explicit environment specifications][spec], which skip the environment
-solution step altogether, as they contain the _ordered_ list of exact URLs needed
-to reproduce the environment.
+`conda list --explicit` and [conda-lock][] support generating [explicit
+environment specifications][spec], which skip the environment solution step
+altogether, as they contain the _ordered_ list of exact URLs needed to reproduce
+the environment.
 
 This means explicitly-defined environments...
 
 - are _much faster_ to install, as several expensive steps are skipped:
   - channels are not queried for their repo data
   - no solver is run
-- are not cross-platform, as the URLs almost always contain platform/architecture information
+- are not cross-platform, as the URLs almost always contain
+  platform/architecture information
 - can become broken if any file becomes unavailable
 
-This approach can be useful as part of a larger system e.g. a separate workflow that
-runs `conda-lock` for all the platforms needed in a separate job.
+This approach can be useful as part of a larger system e.g. a separate workflow
+that runs `conda-lock` for all the platforms needed in a separate job.
 
 [conda-lock]: https://github.com/conda-incubator/conda-lock
-[spec]: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#building-identical-conda-environments
+[spec]:
+  https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#building-identical-conda-environments
 
 ```yaml
 name: "Example 7: Explicit Environment Specification"
@@ -297,7 +321,9 @@ jobs:
 
 ## Caching
 
-If you want to enable package caching for conda you can use the [cache action](https://github.com/actions/cache) using `~/conda_pkgs_dir` as path for conda packages.
+If you want to enable package caching for conda you can use the
+[cache action](https://github.com/actions/cache) using `~/conda_pkgs_dir` as
+path for conda packages.
 
 The cache will use a explicit key for restoring and saving the cache.
 
@@ -321,7 +347,9 @@ jobs:
           CACHE_NUMBER: 0
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('etc/example-environment.yml') }}
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('etc/example-environment.yml') }}
       - uses: conda-incubator/setup-miniconda@v1
         with:
           activate-environment: anaconda-client-env
@@ -330,18 +358,46 @@ jobs:
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
 ```
 
-If you are using pip to resolve any dependencies in your conda environment then you may want to [cache those dependencies separately](https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#caching-dependencies), as they are not included in the conda package cache.
+If you are using pip to resolve any dependencies in your conda environment then
+you may want to
+[cache those dependencies separately](https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#caching-dependencies),
+as they are not included in the conda package cache.
 
 ## IMPORTANT
 
-- Bash shells do not use `~/.profile` or `~/.bashrc` so these shells need to be explicitely declared as `shell: bash -l {0}` on steps that need to be properly activated. This is because bash shells are executed with `bash --noprofile --norc -eo pipefail {0}` thus ignoring updated on bash profile files made by `conda init bash`. See [Github Actions Documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell) and [thread](https://github.community/t5/GitHub-Actions/How-to-share-shell-profile-between-steps-or-how-to-use-nvm-rvm/td-p/33185).
-- Sh shells do not use `~/.profile` or `~/.bashrc` so these shells need to be explicitely declared as `shell: sh -l {0}` on steps that need to be properly activated. This is because sh shells are executed with `sh -e {0}` thus ignoring updated on bash profile files made by `conda init bash`. See [Github Actions Documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell).
-- Cmd shells do not run `Autorun` commands so these shells need to be explicitely declared as `shell: cmd /C call {0}` on steps that need to be properly activated. This is because cmd shells are executed with `%ComSpec% /D /E:ON /V:OFF /S /C "CALL "{0}""` and the `/D` flag disabled execution of `Command Processor/Autorun` windows registry keys, which is what `conda init cmd.exe` sets. See [Github Actions Documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell).
-- For caching to work properly, you will need to set the `use-only-tar-bz2` option to `true`.
-- Some options (e.g. `use-only-tar-bz2`) are not available on the default conda installed on Windows VMs, be sure to use `auto-update-conda` or provide a version of conda compatible with the option.
-- If you plan to use a `environment.yaml` file to set up the environment, the action will read the `channels`listed in the key (if found). If you provide the `channels` input in the action they must not conflict with what was defined in `environment.yaml`, otherwise the conda solver might find conflicts and result in very long install times.
+- Bash shells do not use `~/.profile` or `~/.bashrc` so these shells need to be
+  explicitely declared as `shell: bash -l {0}` on steps that need to be properly
+  activated. This is because bash shells are executed with
+  `bash --noprofile --norc -eo pipefail {0}` thus ignoring updated on bash
+  profile files made by `conda init bash`. See
+  [Github Actions Documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell)
+  and
+  [thread](https://github.community/t5/GitHub-Actions/How-to-share-shell-profile-between-steps-or-how-to-use-nvm-rvm/td-p/33185).
+- Sh shells do not use `~/.profile` or `~/.bashrc` so these shells need to be
+  explicitely declared as `shell: sh -l {0}` on steps that need to be properly
+  activated. This is because sh shells are executed with `sh -e {0}` thus
+  ignoring updated on bash profile files made by `conda init bash`. See
+  [Github Actions Documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell).
+- Cmd shells do not run `Autorun` commands so these shells need to be
+  explicitely declared as `shell: cmd /C call {0}` on steps that need to be
+  properly activated. This is because cmd shells are executed with
+  `%ComSpec% /D /E:ON /V:OFF /S /C "CALL "{0}""` and the `/D` flag disabled
+  execution of `Command Processor/Autorun` windows registry keys, which is what
+  `conda init cmd.exe` sets. See
+  [Github Actions Documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell).
+- For caching to work properly, you will need to set the `use-only-tar-bz2`
+  option to `true`.
+- Some options (e.g. `use-only-tar-bz2`) are not available on the default conda
+  installed on Windows VMs, be sure to use `auto-update-conda` or provide a
+  version of conda compatible with the option.
+- If you plan to use a `environment.yaml` file to set up the environment, the
+  action will read the `channels`listed in the key (if found). If you provide
+  the `channels` input in the action they must not conflict with what was
+  defined in `environment.yaml`, otherwise the conda solver might find conflicts
+  and result in very long install times.
 - Conda activation does not correctly work on `sh`. Please use `bash.
 
 ## License
 
-The scripts and documentation in this project are released under the [MIT License](LICENSE.txt)
+The scripts and documentation in this project are released under the
+[MIT License](LICENSE.txt)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.7", "2.7"]
     steps:
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
@@ -73,7 +73,7 @@ jobs:
     name: Ex2 Linux
     runs-on: "ubuntu-latest"
     steps:
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
           activate-environment: foo
@@ -92,7 +92,7 @@ jobs:
     name: Ex2 Mac
     runs-on: "macos-latest"
     steps:
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
           activate-environment: foo
@@ -116,7 +116,7 @@ jobs:
     name: Ex2 Windows
     runs-on: "windows-latest"
     steps:
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
           activate-environment: foo
@@ -157,7 +157,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: anaconda-client-env
           environment-file: etc/example-environment.yml
@@ -187,7 +187,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: foo
           python-version: 3.6
@@ -219,7 +219,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           installer-url: https://github.com/conda-forge/miniforge/releases/download/4.8.3-2/Miniforge-pypy3-4.8.3-2-Linux-x86_64.sh
           allow-softlinks: true
@@ -247,7 +247,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: 3.6
           mamba-version: "*"
@@ -306,7 +306,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: false
           activate-environment: explicit-env
@@ -351,7 +351,7 @@ jobs:
           key:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('etc/example-environment.yml') }}
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: anaconda-client-env
           channel-priority: strict

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Setup Miniconda
+# `conda-incubator/setup-miniconda`
 
 ![Example 1: Basic usage](https://github.com/conda-incubator/setup-miniconda/workflows/Example%201:%20Basic%20usage/badge.svg?branch=master)
 ![Example 2: Other shells](https://github.com/conda-incubator/setup-miniconda/workflows/Example%202:%20Other%20shells/badge.svg?branch=master)
@@ -9,11 +9,12 @@
 ![Caching Example](https://github.com/conda-incubator/setup-miniconda/workflows/Caching%20Example/badge.svg?branch=master)
 ![Linting](https://github.com/conda-incubator/setup-miniconda/workflows/Linting/badge.svg?branch=master)
 
+
 This action sets up a
 [Miniconda](https://docs.conda.io/en/latest/miniconda.html) installation to use
 the [Conda](https://docs.conda.io/projects/conda/en/latest/) package and
-environment manager by either locating the Miniconda installation bundled with
-the available runners or by installing a specific Miniconda3 version. By default
+environment manager by either locating the Miniconda installation [bundled with
+the available runners](https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-software) or by installing a specific Miniconda3 version. By default
 this action will also create a test environment.
 
 Miniconda `condabin/` folder is added to `PATH` and conda is correctly
@@ -22,7 +23,7 @@ initialized across all platforms.
 This action correctly handles activation of conda environments and offers the
 possibility of automatically activating the test environment on all shells.
 
-See the **[IMPORTANT](#IMPORTANT)** notes on additional information on
+> See the **[IMPORTANT](#IMPORTANT)** notes on additional information on
 environment activation.
 
 ## Usage examples
@@ -396,6 +397,11 @@ as they are not included in the conda package cache.
   defined in `environment.yaml`, otherwise the conda solver might find conflicts
   and result in very long install times.
 - Conda activation does not correctly work on `sh`. Please use `bash.
+
+## Project History and Contributing
+
+See the [CHANGELOG](https://github.com/conda-incubator/setup-miniconda/blob/master/CHANGELOG.md) for project history, or [CONTRIBUTING](https://github.com/conda-incubator/setup-miniconda/blob/master/CONTRIBUTING.md) to get started adding
+features you need.
 
 ## License
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,45 +1,21 @@
 # Release
 
-## Build
+- Update the `version` in [package.json](./package.json).
 
-The build steps transpiles the `src/main.ts` to `lib/main.js` and then packs to
-`dist/index.js`. It is handled by Typescript compiler.
+- Run the [build](./CONTRIBUTING.md#build).
 
-- Conda env
+- Create a new named tag:
 
 ```bash
-conda create -n github-action nodejs -c conda-forge
+git tag -a vX.Y.Z -m 'Release version vX.Y.Z'
 ```
 
-- Install NodeJS
+- Point the old `vX` tag to latest `vX.Y.Z` tag:
 
 ```bash
-conda activate github-action
-npm install
-```
-
-- Update version in package.json
-
-- To update the code
-
-```bash
-npm run format
-npm run check
-npm run build
-```
-
-- Create new named tag
-
-```bash
-git tag -a vX.X.X -m 'Release version vX.X.X'
-```
-
-- Point old v1 tag to latest tag
-
-```bash
-git tag -d v1
-git push origin :refs/tags/v1
-git tag -a v1 -m 'Release version vX.X.X'
+git tag -d vX
+git push origin :refs/tags/vX
+git tag -a vX -m 'Release version vX.Y.Z'
 git push origin --tags
 git push origin master
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,11 @@
 
 - Update the `version` in [package.json](./package.json).
 
+- Ensure the [CHANGELOG](./CHANGELOG.md) is up-to-date.
+
+    - If this release is a major version, update all the example YAML in the [README](./README.md),
+  e.g. `2.0.0` would need `@v1` -> `@v2`.
+
 - Run the [build](./CONTRIBUTING.md#build).
 
 - Create a new named tag:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,8 @@
 
 ## Build
 
-The build steps transpiles the `src/main.ts` to `lib/main.js` and then packs to `dist/index.js`. It is handled by Typescript compiler.
+The build steps transpiles the `src/main.ts` to `lib/main.js` and then packs to
+`dist/index.js`. It is handled by Typescript compiler.
 
 - Conda env
 

--- a/action.yml
+++ b/action.yml
@@ -3,87 +3,194 @@ author: Gonzalo Peña-Castellanos (@goanpeca)
 description: "Set up Conda package and environment manager with Miniconda."
 inputs:
   installer-url:
-    description: "If provided, this installer will be used instead of a miniconda installer. Visit https://github.com/conda/constructor for more information on creating installers"
+    description:
+      "If provided, this installer will be used instead of a miniconda
+      installer. Visit https://github.com/conda/constructor for more information
+      on creating installers"
     required: false
     default: ""
   miniconda-version:
-    description: "If provided, this version of miniconda will be downloaded and installed. Visit https://repo.continuum.io/miniconda/ for more information on available versions."
+    description:
+      "If provided, this version of miniconda will be downloaded and installed.
+      Visit https://repo.continuum.io/miniconda/ for more information on
+      available versions."
     required: false
     default: ""
   conda-version:
-    description: 'Specific version of Conda to install after miniconda is located or installed. See https://anaconda.org/anaconda/conda for available "conda" versions.'
+    description:
+      'Specific version of Conda to install after miniconda is located or
+      installed. See https://anaconda.org/anaconda/conda for available "conda"
+      versions.'
     required: false
     default: ""
   conda-build-version:
-    description: 'Version of conda build to install. If not provided conda-build is not installed. See https://anaconda.org/anaconda/conda-build for available "conda-build" versions.'
+    description:
+      'Version of conda build to install. If not provided conda-build is not
+      installed. See https://anaconda.org/anaconda/conda-build for available
+      "conda-build" versions.'
     required: false
     default: ""
   environment-file:
-    description: "Environment.yml to create an environment. See https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file for more information."
+    description:
+      "Environment.yml to create an environment. See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file
+      for more information."
     required: false
     default: ""
   activate-environment:
-    description: 'Environment to activate by default on all shells. Default is "test". If an empty string is used, no environment is activated by default (For "base" activation see the "auto-activate-base" option). If the environment does not exist, it will be created and activated. If "environment-file" is used and you want that to be the environment used, you need to explicitely provide the name of that environmet on "activate-environment". If using sh/bash/cmd.exe shells please read the IMPORTANT! section on the README.md! to properly activate conda environments on these shells.'
+    description:
+      'Environment to activate by default on all shells. Default is "test". If
+      an empty string is used, no environment is activated by default (For
+      "base" activation see the "auto-activate-base" option). If the environment
+      does not exist, it will be created and activated. If "environment-file" is
+      used and you want that to be the environment used, you need to explicitely
+      provide the name of that environmet on "activate-environment". If using
+      sh/bash/cmd.exe shells please read the IMPORTANT! section on the
+      README.md! to properly activate conda environments on these shells.'
     required: false
     default: "test"
   python-version:
-    description: 'Exact version of a Python version to use on "activate-environment". If provided, this will be installed before the "environment-file". See https://anaconda.org/anaconda/python for available "python" versions.'
+    description:
+      'Exact version of a Python version to use on "activate-environment". If
+      provided, this will be installed before the "environment-file". See
+      https://anaconda.org/anaconda/python for available "python" versions.'
     required: false
     default: ""
   add-anaconda-token:
-    description: 'Conda configuration. When the channel alias is Anaconda.org or an Anaconda Server GUI, you can set the system configuration so that users automatically see private packages. Anaconda.org was formerly known as binstar.org. This uses the Anaconda command-line client, which you can install with conda install anaconda-client, to automatically add the token to the channel URLs. The default is "true". See https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#add-anaconda-org-token-to-automatically-see-private-packages-add-anaconda-token for more information.'
+    description:
+      'Conda configuration. When the channel alias is Anaconda.org or an
+      Anaconda Server GUI, you can set the system configuration so that users
+      automatically see private packages. Anaconda.org was formerly known as
+      binstar.org. This uses the Anaconda command-line client, which you can
+      install with conda install anaconda-client, to automatically add the token
+      to the channel URLs. The default is "true". See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#add-anaconda-org-token-to-automatically-see-private-packages-add-anaconda-token
+      for more information.'
     required: false
     default: ""
   add-pip-as-python-dependency:
-    description: 'Conda configuration. Add pip, wheel, and setuptools as dependencies of Python. This ensures that pip, wheel, and setuptools are always installed any time Python is installed. The default is "true". See https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#add-pip-as-python-dependency-add-pip-as-python-dependency for more information.'
+    description:
+      'Conda configuration. Add pip, wheel, and setuptools as dependencies of
+      Python. This ensures that pip, wheel, and setuptools are always installed
+      any time Python is installed. The default is "true". See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#add-pip-as-python-dependency-add-pip-as-python-dependency
+      for more information.'
     required: false
     default: ""
   allow-softlinks:
-    description: 'Conda configuration. When allow_softlinks is "true", conda uses hard-links when possible and soft-links---symlinks---when hard-links are not possible, such as when installing on a different file system than the one that the package cache is on. When allow_softlinks is "false", conda still uses hard-links when possible, but when it is not possible, conda copies files. Individual packages can override this option, specifying that certain files should never be soft-linked. The default is "true". See https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#disallow-soft-linking-allow-softlinks for more information.'
+    description:
+      'Conda configuration. When allow_softlinks is "true", conda uses
+      hard-links when possible and soft-links---symlinks---when hard-links are
+      not possible, such as when installing on a different file system than the
+      one that the package cache is on. When allow_softlinks is "false", conda
+      still uses hard-links when possible, but when it is not possible, conda
+      copies files. Individual packages can override this option, specifying
+      that certain files should never be soft-linked. The default is "true". See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#disallow-soft-linking-allow-softlinks
+      for more information.'
     required: false
     default: ""
   auto-activate-base:
-    description: 'Conda configuration. If you’d prefer that conda’s base environment not be activated on startup, set the to "false". Default is "true". This setting always overrides if set to "true" or "false". If you want to use the "condarc-file" setting pass and empty string. See https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/ for more information.'
+    description:
+      'Conda configuration. If you’d prefer that conda’s base environment not be
+      activated on startup, set the to "false". Default is "true". This setting
+      always overrides if set to "true" or "false". If you want to use the
+      "condarc-file" setting pass and empty string. See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/
+      for more information.'
     required: false
     default: "true"
   auto-update-conda:
-    description: 'Conda configuration. When "true", conda updates itself any time a user updates or installs a package in the base environment. When "false", conda updates itself only if the user manually issues a conda update command. The default is "true".  This setting always overrides if set to "true" or "false". If you want to use the "condarc-file" setting pass and empty string. See https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/ for more information.'
+    description:
+      'Conda configuration. When "true", conda updates itself any time a user
+      updates or installs a package in the base environment. When "false", conda
+      updates itself only if the user manually issues a conda update command.
+      The default is "true".  This setting always overrides if set to "true" or
+      "false". If you want to use the "condarc-file" setting pass and empty
+      string. See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/
+      for more information.'
     required: false
     default: "false"
   condarc-file:
-    description: 'Conda configuration. Path to a conda configuration file to use for the runner. This file will be copied to "~/.condarc". See https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/ for more information.'
+    description:
+      'Conda configuration. Path to a conda configuration file to use for the
+      runner. This file will be copied to "~/.condarc". See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/
+      for more information.'
     required: false
     default: ""
   channel-alias:
-    description: "Conda configuration. Whenever you use the -c or --channel flag to give conda a channel name that is not a URL, conda prepends the channel_alias to the name that it was given. The default channel_alias is https://conda.anaconda.org. See https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#set-a-channel-alias-channel-alias for more information."
+    description:
+      "Conda configuration. Whenever you use the -c or --channel flag to give
+      conda a channel name that is not a URL, conda prepends the channel_alias
+      to the name that it was given. The default channel_alias is
+      https://conda.anaconda.org. See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#set-a-channel-alias-channel-alias
+      for more information."
     required: false
     default: ""
   channel-priority:
-    description: 'Conda configuration. Accepts values of "strict", "flexible", and "disabled". The default value is "flexible". With strict channel priority, packages in lower priority channels are not considered if a package with the same name appears in a higher priority channel. With flexible channel priority, the solver may reach into lower priority channels to fulfill dependencies, rather than raising an unsatisfiable error. With channel priority disabled, package version takes precedence, and the configured priority of channels is used only to break ties. In previous versions of conda, this parameter was configured as either "true" or "false". "true" is now an alias to "flexible". See https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority for more information.'
+    description:
+      'Conda configuration. Accepts values of "strict", "flexible", and
+      "disabled". The default value is "flexible". With strict channel priority,
+      packages in lower priority channels are not considered if a package with
+      the same name appears in a higher priority channel. With flexible channel
+      priority, the solver may reach into lower priority channels to fulfill
+      dependencies, rather than raising an unsatisfiable error. With channel
+      priority disabled, package version takes precedence, and the configured
+      priority of channels is used only to break ties. In previous versions of
+      conda, this parameter was configured as either "true" or "false". "true"
+      is now an alias to "flexible". See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority
+      for more information.'
     required: false
     default: ""
   channels:
-    description: "Conda configuration. Comma separated list of channels to use in order of priority. See https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/ for more information."
+    description:
+      "Conda configuration. Comma separated list of channels to use in order of
+      priority. See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/
+      for more information."
     required: false
     default: ""
   show-channel-urls:
-    description: 'Conda configuration. Show channel URLs when displaying what is going to be downloaded and in conda list. The default is "false". See https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#show-channel-urls-show-channel-urls for more information.'
+    description:
+      'Conda configuration. Show channel URLs when displaying what is going to
+      be downloaded and in conda list. The default is "false". See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#show-channel-urls-show-channel-urls
+      for more information.'
     required: false
     default: ""
   use-only-tar-bz2:
-    description: 'Conda configuration. Conda 4.7 introduced a new .conda package file format. .conda is a more compact and faster alternative to .tar.bz2 packages. It is thus the preferred file format to use where available. Nevertheless, it is possible to force conda to only download .tar.bz2 packages by setting the use_only_tar_bz2 boolean to "true". The default is "false". See https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#force-conda-to-download-only-tar-bz2-packages-use-only-tar-bz2 for more information.'
+    description:
+      'Conda configuration. Conda 4.7 introduced a new .conda package file
+      format. .conda is a more compact and faster alternative to .tar.bz2
+      packages. It is thus the preferred file format to use where available.
+      Nevertheless, it is possible to force conda to only download .tar.bz2
+      packages by setting the use_only_tar_bz2 boolean to "true". The default is
+      "false". See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#force-conda-to-download-only-tar-bz2-packages-use-only-tar-bz2
+      for more information.'
     required: false
     default: ""
   remove-profiles:
-    description: 'Advanced. Prior to runnning "conda init" all shell profiles will be removed from the runner. Default is "true".'
+    description:
+      'Advanced. Prior to runnning "conda init" all shell profiles will be
+      removed from the runner. Default is "true".'
     required: false
     default: "true"
   mamba-version:
-    description: 'Experimental. Use mamba (https://github.com/QuantStack/mamba) as a faster drop-in replacement for conda installs. Disabled by default. To enable, use "*" or a "x.y" version string.'
+    description:
+      'Experimental. Use mamba (https://github.com/QuantStack/mamba) as a faster
+      drop-in replacement for conda installs. Disabled by default. To enable,
+      use "*" or a "x.y" version string.'
     required: false
     default: ""
   architecture:
-    description: 'Architecture of Miniconda that should be installed. Available options on GitHub-hosted runners are "x86" and "x64". Default is "x64".'
+    description:
+      'Architecture of Miniconda that should be installed. Available options on
+      GitHub-hosted runners are "x86" and "x64". Default is "x64".'
     required: false
     default: "x64"
 runs:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -21324,12 +21324,12 @@ const ARCHITECTURES = {
     x64: "x86_64",
     x86: "x86",
     ARM64: "aarch64",
-    ARM32: "armv7l" // To be supported by github runners
+    ARM32: "armv7l",
 };
 const OS_NAMES = {
     win32: "Windows",
     darwin: "MacOSX",
-    linux: "Linux"
+    linux: "Linux",
 };
 /**
  * errors that are always probably spurious
@@ -21342,7 +21342,7 @@ const IGNORED_WARNINGS = [
     // appear on certain Linux/OSX installers
     `Please run using "bash"`,
     // old condas don't know what to do with these
-    `Key 'use_only_tar_bz2' is not a known primitive parameter.`
+    `Key 'use_only_tar_bz2' is not a known primitive parameter.`,
 ];
 /**
  * avoid spurious conda warnings before we have a chance to update them
@@ -21368,8 +21368,8 @@ function execute(command) {
                         }
                     }
                     core.warning(stringData);
-                }
-            }
+                },
+            },
         };
         try {
             yield exec.exec(command, [], options);
@@ -21467,7 +21467,7 @@ function downloadMiniconda(pythonMajorVersion, minicondaVersion, architecture) {
             if (!versions.includes(minicondaInstallerName)) {
                 return {
                     ok: false,
-                    error: new Error(`Invalid miniconda version!\n\nMust be among ${versions.toString()}`)
+                    error: new Error(`Invalid miniconda version!\n\nMust be among ${versions.toString()}`),
                 };
             }
         }
@@ -21594,7 +21594,7 @@ function createTestEnvironment(activateEnvironment, useBundled, useMamba) {
         else {
             return {
                 ok: false,
-                error: new Error('To activate "base" environment use the "auto-activate-base" action input!')
+                error: new Error('To activate "base" environment use the "auto-activate-base" action input!'),
             };
         }
         return { ok: true, data: "ok" };
@@ -21628,7 +21628,7 @@ function condaInit(activateEnvironment, useBundled, condaConfig, removeProfiles)
                     "shell",
                     "/etc/profile.d/",
                     "/Lib/site-packages/xonsh",
-                    "/etc/profile.d/"
+                    "/etc/profile.d/",
                 ]) {
                     ownPath = path.join(minicondaPath(useBundled).replace("\\", "/"), folder);
                     if (fs.existsSync(ownPath)) {
@@ -21653,7 +21653,7 @@ function condaInit(activateEnvironment, useBundled, condaConfig, removeProfiles)
                 "~/.zshrc",
                 "~/.config/powershell/profile.ps1",
                 "~/Documents/PowerShell/profile.ps1",
-                "~/Documents/WindowsPowerShell/profile.ps1"
+                "~/Documents/WindowsPowerShell/profile.ps1",
             ]) {
                 try {
                     let file = rc.replace("~", os.homedir().replace("\\", "/"));
@@ -21736,24 +21736,24 @@ conda activate ${activateEnvironment}`;
             "~/.xonshrc": bashExtraText,
             "~/.config/powershell/profile.ps1": powerExtraText,
             "~/Documents/PowerShell/profile.ps1": powerExtraText,
-            "~/Documents/WindowsPowerShell/profile.ps1": powerExtraText
+            "~/Documents/WindowsPowerShell/profile.ps1": powerExtraText,
         };
         if (useBundled) {
             extraShells = {
                 "C:/Miniconda/etc/profile.d/conda.sh": bashExtraText,
                 "C:/Miniconda/etc/fish/conf.d/conda.fish": bashExtraText,
-                "C:/Miniconda/condabin/conda_hook.bat": batchExtraText
+                "C:/Miniconda/condabin/conda_hook.bat": batchExtraText,
             };
         }
         else {
             extraShells = {
                 "C:/Miniconda3/etc/profile.d/conda.sh": bashExtraText,
                 "C:/Miniconda3/etc/fish/conf.d/conda.fish": bashExtraText,
-                "C:/Miniconda3/condabin/conda_hook.bat": batchExtraText
+                "C:/Miniconda3/condabin/conda_hook.bat": batchExtraText,
             };
         }
         const allShells = Object.assign(Object.assign({}, shells), extraShells);
-        Object.keys(allShells).forEach(key => {
+        Object.keys(allShells).forEach((key) => {
             let filePath = key.replace("~", os.homedir());
             const text = allShells[key];
             if (fs.existsSync(filePath)) {
@@ -21829,13 +21829,13 @@ function setupMiniconda(installerUrl, minicondaVersion, architecture, condaVersi
             if (pythonVersion && activateEnvironment === "") {
                 return {
                     ok: false,
-                    error: new Error(`"python-version=${pythonVersion}" was provided but "activate-environment" is not defined!`)
+                    error: new Error(`"python-version=${pythonVersion}" was provided but "activate-environment" is not defined!`),
                 };
             }
             if (!condaConfig["channels"].includes("conda-forge") && mambaVersion) {
                 return {
                     ok: false,
-                    error: new Error(`"mamba-version=${mambaVersion}" requires "conda-forge" to be included in "channels!"`)
+                    error: new Error(`"mamba-version=${mambaVersion}" requires "conda-forge" to be included in "channels!"`),
                 };
             }
             try {
@@ -21849,7 +21849,7 @@ function setupMiniconda(installerUrl, minicondaVersion, architecture, condaVersi
                 if (minicondaVersion !== "") {
                     return {
                         ok: false,
-                        error: new Error(`"installer-url" and "miniconda-version" were provided: pick one!`)
+                        error: new Error(`"installer-url" and "miniconda-version" were provided: pick one!`),
                     };
                 }
                 utils.consoleLog("\n# Downloading Custom Installer...\n");
@@ -21864,13 +21864,13 @@ function setupMiniconda(installerUrl, minicondaVersion, architecture, condaVersi
                 if (architecture !== "x64" && minicondaVersion === "") {
                     return {
                         ok: false,
-                        error: new Error(`"architecture" is set to something other than "x64" so "miniconda-version" must be set as well.`)
+                        error: new Error(`"architecture" is set to something other than "x64" so "miniconda-version" must be set as well.`),
                     };
                 }
                 if (architecture === "x86" && process.platform === "linux") {
                     return {
                         ok: false,
-                        error: new Error(`32-bit Linux is not supported by recent versions of Miniconda`)
+                        error: new Error(`32-bit Linux is not supported by recent versions of Miniconda`),
                     };
                 }
                 utils.consoleLog("\n# Downloading Miniconda...\n");
@@ -22102,7 +22102,7 @@ function run() {
                 channel_priority: channelPriority,
                 channels: channels,
                 show_channel_urls: showChannelUrls,
-                use_only_tar_bz2: useOnlyTarBz2
+                use_only_tar_bz2: useOnlyTarBz2,
             };
             const result = yield setupMiniconda(installerUrl, minicondaVersion, architecture, condaVersion, condaBuildVersion, pythonVersion, activateEnvironment, environmentFile, condaFile, condaConfig, removeProfiles, mambaVersion);
             if (!result.ok) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "action-setup-conda",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7421,9 +7421,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "ncc build -o dist/setup src/setup.ts && ncc build -o dist/delete src/delete.ts",
     "format": "npm run prettier:format && npm run eslint:format",
     "check": "npm run prettier:check && npm run eslint:check",
-    "prettier:format": "prettier --list-different --write \"src/**/*.ts\" \"{.,etc,.github}/*.{md,json,yml,js}\"",
-    "prettier:check": "prettier --list-different \"src/**/*.ts\" \"{.,etc,.github}/*.{md,json,yml,js}\"",
+    "prettier:format": "prettier --list-different --write \"src/**/*.ts\" \"{.,etc,.github}/**/*.{md,json,yml,js}\"",
+    "prettier:check": "prettier --list-different \"src/**/*.ts\" \"{.,etc,.github}/**/*.{md,json,yml,js}\"",
     "eslint:format": "eslint --ext .js,.jsx,.ts,.tsx --fix .",
     "eslint:check": "eslint --ext .js,.jsx,.ts,.tsx ."
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "ncc build -o dist/setup src/setup.ts && ncc build -o dist/delete src/delete.ts",
     "format": "npm run prettier:format && npm run eslint:format",
     "check": "npm run prettier:check && npm run eslint:check",
-    "prettier:format": "prettier --write \"src/**/*.ts\" \"{.,etc,.github}/*.{md,json,yml,js}\"",
+    "prettier:format": "prettier --list-different --write \"src/**/*.ts\" \"{.,etc,.github}/*.{md,json,yml,js}\"",
     "prettier:check": "prettier --list-different \"src/**/*.ts\" \"{.,etc,.github}/*.{md,json,yml,js}\"",
     "eslint:format": "eslint --ext .js,.jsx,.ts,.tsx --fix .",
     "eslint:check": "eslint --ext .js,.jsx,.ts,.tsx ."

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "dot-prop": ">=4.2.1",
     "lodash": ">=4.17.19",
     "lint-staged": "^9.5.0",
-    "prettier": "^1.19.1",
+    "prettier": "^2.1.2",
     "shell-quote": "^1.7.2",
     "typescript": "^3.7.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-setup-conda",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "GitHub action for setting up conda from default or custom installers",
   "main": "lib/main.js",
   "scripts": {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -53,13 +53,13 @@ const ARCHITECTURES: IArchitectures = {
   x64: "x86_64",
   x86: "x86",
   ARM64: "aarch64", // To be supported by github runners
-  ARM32: "armv7l" // To be supported by github runners
+  ARM32: "armv7l", // To be supported by github runners
 };
 
 const OS_NAMES: IOperatingSystems = {
   win32: "Windows",
   darwin: "MacOSX",
-  linux: "Linux"
+  linux: "Linux",
 };
 
 /**
@@ -73,7 +73,7 @@ const IGNORED_WARNINGS = [
   // appear on certain Linux/OSX installers
   `Please run using "bash"`,
   // old condas don't know what to do with these
-  `Key 'use_only_tar_bz2' is not a known primitive parameter.`
+  `Key 'use_only_tar_bz2' is not a known primitive parameter.`,
 ];
 
 /**
@@ -101,8 +101,8 @@ async function execute(command: string): Promise<Result> {
           }
         }
         core.warning(stringData);
-      }
-    }
+      },
+    },
   };
 
   try {
@@ -219,7 +219,7 @@ async function downloadMiniconda(
         ok: false,
         error: new Error(
           `Invalid miniconda version!\n\nMust be among ${versions.toString()}`
-        )
+        ),
       };
     }
   }
@@ -370,7 +370,7 @@ async function createTestEnvironment(
       ok: false,
       error: new Error(
         'To activate "base" environment use the "auto-activate-base" action input!'
-      )
+      ),
     };
   }
   return { ok: true, data: "ok" };
@@ -411,7 +411,7 @@ async function condaInit(
         "shell",
         "/etc/profile.d/",
         "/Lib/site-packages/xonsh",
-        "/etc/profile.d/"
+        "/etc/profile.d/",
       ]) {
         ownPath = path.join(
           minicondaPath(useBundled).replace("\\", "/"),
@@ -439,7 +439,7 @@ async function condaInit(
       "~/.zshrc",
       "~/.config/powershell/profile.ps1",
       "~/Documents/PowerShell/profile.ps1",
-      "~/Documents/WindowsPowerShell/profile.ps1"
+      "~/Documents/WindowsPowerShell/profile.ps1",
     ]) {
       try {
         let file: string = rc.replace("~", os.homedir().replace("\\", "/"));
@@ -526,23 +526,23 @@ conda activate ${activateEnvironment}`;
     "~/.xonshrc": bashExtraText,
     "~/.config/powershell/profile.ps1": powerExtraText,
     "~/Documents/PowerShell/profile.ps1": powerExtraText,
-    "~/Documents/WindowsPowerShell/profile.ps1": powerExtraText
+    "~/Documents/WindowsPowerShell/profile.ps1": powerExtraText,
   };
   if (useBundled) {
     extraShells = {
       "C:/Miniconda/etc/profile.d/conda.sh": bashExtraText,
       "C:/Miniconda/etc/fish/conf.d/conda.fish": bashExtraText,
-      "C:/Miniconda/condabin/conda_hook.bat": batchExtraText
+      "C:/Miniconda/condabin/conda_hook.bat": batchExtraText,
     };
   } else {
     extraShells = {
       "C:/Miniconda3/etc/profile.d/conda.sh": bashExtraText,
       "C:/Miniconda3/etc/fish/conf.d/conda.fish": bashExtraText,
-      "C:/Miniconda3/condabin/conda_hook.bat": batchExtraText
+      "C:/Miniconda3/condabin/conda_hook.bat": batchExtraText,
     };
   }
   const allShells: IShells = { ...shells, ...extraShells };
-  Object.keys(allShells).forEach(key => {
+  Object.keys(allShells).forEach((key) => {
     let filePath: string = key.replace("~", os.homedir());
     const text = allShells[key];
     if (fs.existsSync(filePath)) {
@@ -648,7 +648,7 @@ async function setupMiniconda(
         ok: false,
         error: new Error(
           `"python-version=${pythonVersion}" was provided but "activate-environment" is not defined!`
-        )
+        ),
       };
     }
     if (!condaConfig["channels"].includes("conda-forge") && mambaVersion) {
@@ -656,7 +656,7 @@ async function setupMiniconda(
         ok: false,
         error: new Error(
           `"mamba-version=${mambaVersion}" requires "conda-forge" to be included in "channels!"`
-        )
+        ),
       };
     }
 
@@ -673,7 +673,7 @@ async function setupMiniconda(
           ok: false,
           error: new Error(
             `"installer-url" and "miniconda-version" were provided: pick one!`
-          )
+          ),
         };
       }
       utils.consoleLog("\n# Downloading Custom Installer...\n");
@@ -688,7 +688,7 @@ async function setupMiniconda(
           ok: false,
           error: new Error(
             `"architecture" is set to something other than "x64" so "miniconda-version" must be set as well.`
-          )
+          ),
         };
       }
       if (architecture === "x86" && process.platform === "linux") {
@@ -696,7 +696,7 @@ async function setupMiniconda(
           ok: false,
           error: new Error(
             `32-bit Linux is not supported by recent versions of Miniconda`
-          )
+          ),
         };
       }
       utils.consoleLog("\n# Downloading Miniconda...\n");
@@ -990,7 +990,7 @@ async function run(): Promise<void> {
       channel_priority: channelPriority,
       channels: channels,
       show_channel_urls: showChannelUrls,
-      use_only_tar_bz2: useOnlyTarBz2
+      use_only_tar_bz2: useOnlyTarBz2,
     };
     const result = await setupMiniconda(
       installerUrl,


### PR DESCRIPTION
For #83.
 
This adds an in-repo CHANGELOG.

I've also bumped `prettier` and expanded its purview, e.g. `proseWrap` and formatting of the example workflows :crossed_fingers:, while printing out only the changed files, as it was getting pretty noisy on the precommit!

TODO:
- [x] add a link in README (probably ones to RELEASE and CONTRIBUTING, too)
- [x] track down all the issues/PRs referenced in the changelog
- ~~maybe add a PR template, and encourage contributors to add a changelog entry so this is easier in the future~~ (maybe some other time)