### PR TITLE
[2 of #107] Use native Error

### DIFF
--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -1102,13 +1102,10 @@ function execute(command) {
                 },
             },
         };
-        try {
-            yield exec.exec(command[0], command.slice(1), options);
+        const rc = yield exec.exec(command[0], command.slice(1), options);
+        if (rc !== 0) {
+            throw new Error(`${command[0]} return error code ${rc}`);
         }
-        catch (err) {
-            return { ok: false, error: err };
-        }
-        return { ok: true, data: "ok" };
     });
 }
 exports.execute = execute;

--- a/src/env.ts
+++ b/src/env.ts
@@ -4,7 +4,6 @@ import * as path from "path";
 import * as core from "@actions/core";
 
 import { minicondaPath, condaCommand } from "./conda";
-import { Result } from "./types";
 
 /**
  * Check if a given conda environment exists
@@ -26,8 +25,7 @@ export async function createTestEnvironment(
   activateEnvironment: string,
   useBundled: boolean,
   useMamba: boolean
-): Promise<Result> {
-  let result: Result;
+): Promise<void> {
   if (
     activateEnvironment !== "root" &&
     activateEnvironment !== "base" &&
@@ -35,21 +33,16 @@ export async function createTestEnvironment(
   ) {
     if (!environmentExists(activateEnvironment, useBundled)) {
       core.startGroup("Create test environment...");
-      result = await condaCommand(
+      await condaCommand(
         ["create", "--name", activateEnvironment],
         useBundled,
         useMamba
       );
-      if (!result.ok) return result;
       core.endGroup();
     }
   } else {
-    return {
-      ok: false,
-      error: new Error(
-        'To activate "base" environment use the "auto-activate-base" action input!'
-      ),
-    };
+    throw new Error(
+      'To activate "base" environment use the "auto-activate-base" action input!'
+    );
   }
-  return { ok: true, data: "ok" };
 }

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -6,7 +6,7 @@ import * as core from "@actions/core";
 import * as io from "@actions/io";
 import * as tc from "@actions/tool-cache";
 
-import { ILocalInstallerOpts, Result } from "../types";
+import { ILocalInstallerOpts } from "../types";
 import { minicondaPath } from "../conda";
 import { execute } from "../utils";
 
@@ -89,7 +89,7 @@ export async function ensureLocalInstaller(
 export async function runInstaller(
   installerPath: string,
   useBundled: boolean
-): Promise<Result> {
+): Promise<void> {
   const outputPath: string = minicondaPath(useBundled);
   const installerExtension = path.extname(installerPath);
   let command: string[];
@@ -111,18 +111,10 @@ export async function runInstaller(
       command = ["bash", installerPath, "-f", "-b", "-p", outputPath];
       break;
     default:
-      return {
-        ok: false,
-        error: Error(`Unknown installer extension: ${installerExtension}`),
-      };
+      throw new Error(`Unknown installer extension: ${installerExtension}`);
   }
 
   core.info(`Install Command:\n\t${command}`);
 
-  try {
-    return await execute(command);
-  } catch (err) {
-    core.error(err);
-    return { ok: false, error: err };
-  }
+  return await execute(command);
 }

--- a/src/installer/download-miniconda.ts
+++ b/src/installer/download-miniconda.ts
@@ -12,7 +12,6 @@ import {
   MINICONDA_BASE_URL,
   OS_NAMES,
 } from "../constants";
-import { Result } from "../types";
 
 /**
  * List available Miniconda versions
@@ -48,11 +47,11 @@ export async function downloadMiniconda(
   pythonMajorVersion: number,
   minicondaVersion: string,
   architecture: string
-): Promise<Result> {
+): Promise<string> {
   // Check valid arch
   const arch: string = ARCHITECTURES[architecture];
   if (!arch) {
-    return { ok: false, error: new Error(`Invalid arch "${architecture}"!`) };
+    throw new Error(`Invalid arch "${architecture}"!`);
   }
 
   let extension: string = IS_UNIX ? "sh" : "exe";
@@ -64,24 +63,16 @@ export async function downloadMiniconda(
   let versions: string[] = await minicondaVersions(arch);
   if (versions) {
     if (!versions.includes(minicondaInstallerName)) {
-      return {
-        ok: false,
-        error: new Error(
-          `Invalid miniconda version!\n\nMust be among ${versions.toString()}`
-        ),
-      };
+      throw new Error(
+        `Invalid miniconda version!\n\nMust be among ${versions.toString()}`
+      );
     }
   }
 
-  try {
-    const downloadPath = await ensureLocalInstaller({
-      url: MINICONDA_BASE_URL + minicondaInstallerName,
-      tool: `Miniconda${pythonMajorVersion}`,
-      version: minicondaVersion,
-      arch: arch,
-    });
-    return { ok: true, data: downloadPath };
-  } catch (error) {
-    return { ok: false, error };
-  }
+  return await ensureLocalInstaller({
+    url: MINICONDA_BASE_URL + minicondaInstallerName,
+    tool: `Miniconda${pythonMajorVersion}`,
+    version: minicondaVersion,
+    arch: arch,
+  });
 }

--- a/src/installer/download-url.ts
+++ b/src/installer/download-url.ts
@@ -1,14 +1,8 @@
-import { Result } from "../types";
 import { ensureLocalInstaller } from "./base";
 
 /**
  * @param url A URL for a file with the CLI of a `constructor`-built artifact
  */
-export async function downloadCustomInstaller(url: string): Promise<Result> {
-  try {
-    const downloadPath = await ensureLocalInstaller({ url });
-    return { ok: true, data: downloadPath };
-  } catch (error) {
-    return { ok: false, error };
-  }
+export async function downloadCustomInstaller(url: string): Promise<string> {
+  return await ensureLocalInstaller({ url });
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,4 +1,3 @@
-import { Result } from "./types";
 import { condaCommand } from "./conda";
 
 /**
@@ -9,7 +8,7 @@ export async function setupPython(
   pythonVersion: string,
   useBundled: boolean,
   useMamba: boolean
-): Promise<Result> {
+): Promise<void> {
   return await condaCommand(
     ["install", "--name", activateEnvironment, `python=${pythonVersion}`],
     useBundled,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,6 @@
 //-----------------------------------------------------------------------
 // Types & Interfaces
 //-----------------------------------------------------------------------
-export interface ISucceedResult {
-  ok: true;
-  data: string;
-}
-export interface IFailedResult {
-  ok: false;
-  error: Error;
-}
-export type Result = ISucceedResult | IFailedResult;
 
 export interface IArchitectures {
   [key: string]: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,6 @@ import {
   FORCED_ERRORS,
   IGNORED_WARNINGS,
 } from "./constants";
-import { Result } from "./types";
 
 export function cacheFolder() {
   return path.join(os.homedir(), CONDA_CACHE_FOLDER);
@@ -19,7 +18,7 @@ export function cacheFolder() {
 /**
  * Run exec.exec with error handling
  */
-export async function execute(command: string[]): Promise<Result> {
+export async function execute(command: string[]): Promise<void> {
   let options: exec.ExecOptions = {
     errStream: new stream.Writable(),
     listeners: {
@@ -44,11 +43,8 @@ export async function execute(command: string[]): Promise<Result> {
     },
   };
 
-  try {
-    await exec.exec(command[0], command.slice(1), options);
-  } catch (err) {
-    return { ok: false, error: err };
+  const rc = await exec.exec(command[0], command.slice(1), options);
+  if (rc !== 0) {
+    throw new Error(`${command[0]} return error code ${rc}`);
   }
-
-  return { ok: true, data: "ok" };
 }

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -2,25 +2,19 @@ import * as path from "path";
 
 import * as core from "@actions/core";
 
-import { Result } from "./types";
 import { minicondaPath } from "./conda";
 
 /**
  * Add Conda executable to PATH
  */
-export async function setVariables(useBundled: boolean): Promise<Result> {
-  try {
-    // Set environment variables
-    const condaBin: string = path.join(minicondaPath(useBundled), "condabin");
-    const conda: string = minicondaPath(useBundled);
-    core.info(`Add "${condaBin}" to PATH`);
-    core.addPath(condaBin);
-    if (!useBundled) {
-      core.info(`Set 'CONDA="${conda}"'`);
-      core.exportVariable("CONDA", conda);
-    }
-  } catch (err) {
-    return { ok: false, error: err };
+export async function setVariables(useBundled: boolean): Promise<void> {
+  // Set environment variables
+  const condaBin: string = path.join(minicondaPath(useBundled), "condabin");
+  const conda: string = minicondaPath(useBundled);
+  core.info(`Add "${condaBin}" to PATH`);
+  core.addPath(condaBin);
+  if (!useBundled) {
+    core.info(`Set 'CONDA="${conda}"'`);
+    core.exportVariable("CONDA", conda);
   }
-  return { ok: true, data: "ok" };
 }


### PR DESCRIPTION
The `Result` pattern adds a lot of line noise for the extra `try` and `catch`, and is rather inflexible in its return types. This PR removes _most_ of the `try/catch` blocks, the `*Result` types, and all references to them.

- continues #107 
- includes:
  - #108 
    - recommend viewing only changes from https://github.com/conda-incubator/setup-miniconda/pull/109/commits/0e849fe)... 
    - or better yet, `git diff -w` locally, as a lot of the `setup.ts` diff is unreadable in the web UI