### PR TITLE
[wip] [5 of #107] add dynamic options

### DIFF
--- a/src/conda.ts
+++ b/src/conda.ts
@@ -10,7 +10,6 @@ import * as core from "@actions/core";
 import * as io from "@actions/io";
 
 import { IS_LINUX, IS_MAC, IS_WINDOWS, MINICONDA_DIR_PATH } from "./constants";
-import { IShells } from "./types";
 import { execute } from "./utils";
 import * as types from "./types";
 
@@ -234,8 +233,8 @@ export async function condaInit(
   @SETLOCAL DisableDelayedExpansion
   :: ---------------------------------------------------------------------------`;
 
-  let extraShells: IShells;
-  const shells: IShells = {
+  let extraShells: types.IShells;
+  const shells: types.IShells = {
     "~/.bash_profile": bashExtraText,
     "~/.profile": bashExtraText,
     "~/.zshrc": bashExtraText,
@@ -259,7 +258,7 @@ export async function condaInit(
       "C:/Miniconda3/condabin/conda_hook.bat": batchExtraText,
     };
   }
-  const allShells: IShells = { ...shells, ...extraShells };
+  const allShells: types.IShells = { ...shells, ...extraShells };
   Object.keys(allShells).forEach((key) => {
     let filePath: string = key.replace("~", os.homedir());
     const text = allShells[key];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 import * as os from "os";
 import * as path from "path";
 
-import { IArchitectures, IOperatingSystems } from "./types";
+import * as types from "./types";
 
 //-----------------------------------------------------------------------
 // Constants
@@ -14,14 +14,14 @@ export const IS_UNIX: boolean = IS_MAC || IS_LINUX;
 export const MINICONDA_BASE_URL: string =
   "https://repo.anaconda.com/miniconda/";
 
-export const ARCHITECTURES: IArchitectures = {
+export const ARCHITECTURES: types.IArchitectures = {
   x64: "x86_64",
   x86: "x86",
   ARM64: "aarch64", // To be supported by github runners
   ARM32: "armv7l", // To be supported by github runners
 };
 
-export const OS_NAMES: IOperatingSystems = {
+export const OS_NAMES: types.IOperatingSystems = {
   win32: "Windows",
   darwin: "MacOSX",
   linux: "Linux",

--- a/src/env.ts
+++ b/src/env.ts
@@ -4,15 +4,19 @@ import * as path from "path";
 import * as core from "@actions/core";
 
 import { minicondaPath, condaCommand } from "./conda";
+import * as types from "./types";
 
 /**
  * Check if a given conda environment exists
  */
-export function environmentExists(name: string, useBundled: boolean): boolean {
+export function environmentExists(
+  inputs: types.IActionInputs,
+  options: types.IDynamicOptions
+): boolean {
   const condaMetaPath: string = path.join(
-    minicondaPath(useBundled),
+    minicondaPath(options),
     "envs",
-    name,
+    inputs.activateEnvironment,
     "conda-meta"
   );
   return fs.existsSync(condaMetaPath);
@@ -22,21 +26,19 @@ export function environmentExists(name: string, useBundled: boolean): boolean {
  * Create test environment
  */
 export async function createTestEnvironment(
-  activateEnvironment: string,
-  useBundled: boolean,
-  useMamba: boolean
+  inputs: types.IActionInputs,
+  options: types.IDynamicOptions
 ): Promise<void> {
   if (
-    activateEnvironment !== "root" &&
-    activateEnvironment !== "base" &&
-    activateEnvironment !== ""
+    inputs.activateEnvironment !== "root" &&
+    inputs.activateEnvironment !== "base" &&
+    inputs.activateEnvironment !== ""
   ) {
-    if (!environmentExists(activateEnvironment, useBundled)) {
+    if (!environmentExists(inputs, options)) {
       core.startGroup("Create test environment...");
       await condaCommand(
-        ["create", "--name", activateEnvironment],
-        useBundled,
-        useMamba
+        ["create", "--name", inputs.activateEnvironment],
+        options
       );
       core.endGroup();
     }

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -9,6 +9,7 @@ import * as tc from "@actions/tool-cache";
 import { ILocalInstallerOpts } from "../types";
 import { minicondaPath } from "../conda";
 import { execute } from "../utils";
+import * as types from "../types";
 
 /** Get the path for a locally-executable installer from cache, or as downloaded
  *
@@ -88,9 +89,9 @@ export async function ensureLocalInstaller(
  */
 export async function runInstaller(
   installerPath: string,
-  useBundled: boolean
+  options: types.IDynamicOptions
 ): Promise<void> {
-  const outputPath: string = minicondaPath(useBundled);
+  const outputPath: string = minicondaPath(options);
   const installerExtension = path.extname(installerPath);
   let command: string[];
 

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -6,7 +6,6 @@ import * as core from "@actions/core";
 import * as io from "@actions/io";
 import * as tc from "@actions/tool-cache";
 
-import { ILocalInstallerOpts } from "../types";
 import { minicondaPath } from "../conda";
 import { execute } from "../utils";
 import * as types from "../types";
@@ -23,7 +22,7 @@ import * as types from "../types";
  * - or has been renamed during a build process
  */
 export async function ensureLocalInstaller(
-  options: ILocalInstallerOpts
+  options: types.ILocalInstallerOpts
 ): Promise<string> {
   core.startGroup("Ensuring Installer...");
 

--- a/src/installer/download-miniconda.ts
+++ b/src/installer/download-miniconda.ts
@@ -13,6 +13,8 @@ import {
   OS_NAMES,
 } from "../constants";
 
+import * as types from "../types";
+
 /**
  * List available Miniconda versions
  *
@@ -45,18 +47,17 @@ async function minicondaVersions(arch: string): Promise<string[]> {
  */
 export async function downloadMiniconda(
   pythonMajorVersion: number,
-  minicondaVersion: string,
-  architecture: string
+  inputs: types.IActionInputs
 ): Promise<string> {
   // Check valid arch
-  const arch: string = ARCHITECTURES[architecture];
+  const arch: string = ARCHITECTURES[inputs.architecture];
   if (!arch) {
-    throw new Error(`Invalid arch "${architecture}"!`);
+    throw new Error(`Invalid arch "${inputs.architecture}"!`);
   }
 
   let extension: string = IS_UNIX ? "sh" : "exe";
   let osName: string = OS_NAMES[process.platform];
-  const minicondaInstallerName: string = `Miniconda${pythonMajorVersion}-${minicondaVersion}-${osName}-${arch}.${extension}`;
+  const minicondaInstallerName: string = `Miniconda${pythonMajorVersion}-${inputs.minicondaVersion}-${osName}-${arch}.${extension}`;
   core.info(minicondaInstallerName);
 
   // Check version name
@@ -72,7 +73,7 @@ export async function downloadMiniconda(
   return await ensureLocalInstaller({
     url: MINICONDA_BASE_URL + minicondaInstallerName,
     tool: `Miniconda${pythonMajorVersion}`,
-    version: minicondaVersion,
+    version: inputs.minicondaVersion,
     arch: arch,
   });
 }

--- a/src/installer/download-url.ts
+++ b/src/installer/download-url.ts
@@ -1,8 +1,11 @@
 import { ensureLocalInstaller } from "./base";
+import * as types from "../types";
 
 /**
  * @param url A URL for a file with the CLI of a `constructor`-built artifact
  */
-export async function downloadCustomInstaller(url: string): Promise<string> {
-  return await ensureLocalInstaller({ url });
+export async function downloadCustomInstaller(
+  inputs: types.IActionInputs
+): Promise<string> {
+  return await ensureLocalInstaller({ url: inputs.installerUrl });
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,17 +1,21 @@
 import { condaCommand } from "./conda";
 
+import * as types from "./types";
+
 /**
  * Setup python test environment
  */
 export async function setupPython(
-  activateEnvironment: string,
-  pythonVersion: string,
-  useBundled: boolean,
-  useMamba: boolean
+  inputs: types.IActionInputs,
+  options: types.IDynamicOptions
 ): Promise<void> {
   return await condaCommand(
-    ["install", "--name", activateEnvironment, `python=${pythonVersion}`],
-    useBundled,
-    useMamba
+    [
+      "install",
+      "--name",
+      inputs.activateEnvironment,
+      `python=${inputs.pythonVersion}`,
+    ],
+    options
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,27 @@ export interface ILocalInstallerOpts {
 }
 
 /**
+ * Special case `dependencies` member for pip  in `environment.yml`
+ */
+export interface IPipSpec {
+  pip: string[];
+}
+
+/**
+ * Any valid member of `dependencies` in `environment.yml`.
+ */
+export type TYamlDependencies = (string | IPipSpec)[];
+
+/**
+ * A (partial) `environment.yml`
+ */
+export interface IEnvironment {
+  name?: string;
+  channels?: string[];
+  dependencies?: TYamlDependencies;
+}
+
+/**
  * A subset of the .condarc file options available as action inputs
  * https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html
  */
@@ -62,4 +83,22 @@ export interface IActionInputs {
   readonly minicondaVersion: string;
   readonly pythonVersion: string;
   readonly removeProfiles: string;
+}
+
+/**
+ * Options that may change during the course of discovery/installation/configuration
+ */
+export interface IDynamicOptions {
+  useBundled: boolean;
+  useMamba: boolean;
+  envSpec?: IEnvSpec;
+  condaConfig: TCondaConfig;
+}
+
+/**
+ * File contents describing an environment
+ */
+export interface IEnvSpec {
+  yaml?: IEnvironment;
+  explicit?: string;
 }

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -3,17 +3,20 @@ import * as path from "path";
 import * as core from "@actions/core";
 
 import { minicondaPath } from "./conda";
+import * as types from "./types";
 
 /**
  * Add Conda executable to PATH
  */
-export async function setVariables(useBundled: boolean): Promise<void> {
+export async function setVariables(
+  options: types.IDynamicOptions
+): Promise<void> {
   // Set environment variables
-  const condaBin: string = path.join(minicondaPath(useBundled), "condabin");
-  const conda: string = minicondaPath(useBundled);
+  const condaBin: string = path.join(minicondaPath(options), "condabin");
+  const conda: string = minicondaPath(options);
   core.info(`Add "${condaBin}" to PATH`);
   core.addPath(condaBin);
-  if (!useBundled) {
+  if (!options.useBundled) {
     core.info(`Set 'CONDA="${conda}"'`);
     core.exportVariable("CONDA", conda);
   }


### PR DESCRIPTION
This encapsulates the state that _does_ change, as highlighted in #124, in a single, relatively lenient object, and changes most function signatures to accept inputs, options or both.

- continues #107 

> @bollwyvl: I haven't tested this one out. :crossed_fingers: 

## On the next PR

> refactor the installer provider

One of the first "irregularities" is that `runInstaller` is allowed to calculate its own `outputPath`, which requires access to mutable state. If we split up that behavior, we can get a lot of reuse, where it will be more straightforward to add additional "well-known" installer providers.

The idea here is to break up the installer provisioning step even more. There should be a significant net negative line count in `setup.ts`, and encapsulate the logic more succinctly along with its effects.

This is where we want to leave enough breathing room to handle micromamba #75 without actually _building_ it right now.