### PR TITLE
[6 of #107] move installer detection logic to implementation

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -3,8 +3,8 @@ import * as path from "path";
 
 import * as core from "@actions/core";
 
-import { minicondaPath, condaCommand } from "./conda";
 import * as types from "./types";
+import * as conda from "./conda";
 
 /**
  * Check if a given conda environment exists
@@ -14,7 +14,7 @@ export function environmentExists(
   options: types.IDynamicOptions
 ): boolean {
   const condaMetaPath: string = path.join(
-    minicondaPath(options),
+    conda.condaBasePath(options),
     "envs",
     inputs.activateEnvironment,
     "conda-meta"
@@ -36,7 +36,7 @@ export async function createTestEnvironment(
   ) {
     if (!environmentExists(inputs, options)) {
       core.startGroup("Create test environment...");
-      await condaCommand(
+      await conda.condaCommand(
         ["create", "--name", inputs.activateEnvironment],
         options
       );

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -6,9 +6,9 @@ import * as core from "@actions/core";
 import * as io from "@actions/io";
 import * as tc from "@actions/tool-cache";
 
-import { minicondaPath } from "../conda";
-import { execute } from "../utils";
 import * as types from "../types";
+import * as utils from "../utils";
+import * as conda from "../conda";
 
 /** Get the path for a locally-executable installer from cache, or as downloaded
  *
@@ -90,7 +90,7 @@ export async function runInstaller(
   installerPath: string,
   options: types.IDynamicOptions
 ): Promise<void> {
-  const outputPath: string = minicondaPath(options);
+  const outputPath: string = conda.condaBasePath(options);
   const installerExtension = path.extname(installerPath);
   let command: string[];
 
@@ -116,5 +116,5 @@ export async function runInstaller(
 
   core.info(`Install Command:\n\t${command}`);
 
-  return await execute(command);
+  return await utils.execute(command);
 }

--- a/src/installer/bundled-miniconda.ts
+++ b/src/installer/bundled-miniconda.ts
@@ -1,0 +1,29 @@
+import * as types from "../types";
+
+/**
+ * Provide a path to the pre-bundled (but probably old) Miniconda base installation
+ *
+ * ### Note
+ * This is the "cheapest" provider: if miniconda is already on disk, it can be
+ * fastest to avoid the download/install and use what's already on the image.
+ */
+export const bundledMinicondaUser: types.IInstallerProvider = {
+  label: "use bundled Miniconda",
+  provides: async (inputs, options) => {
+    return (
+      inputs.minicondaVersion === "" &&
+      inputs.architecture === "x64" &&
+      inputs.installerUrl === ""
+    );
+  },
+  installerPath: async (inputs, options) => {
+    // no-op
+    return {
+      localInstallerPath: "",
+      options: {
+        ...options,
+        useBundled: true,
+      },
+    };
+  },
+};

--- a/src/installer/download-url.ts
+++ b/src/installer/download-url.ts
@@ -1,11 +1,26 @@
-import { ensureLocalInstaller } from "./base";
 import * as types from "../types";
 
+import * as base from "./base";
+
 /**
- * @param url A URL for a file with the CLI of a `constructor`-built artifact
+ * Provide a path to a `constructor`-compatible installer downloaded from
+ * any URL, including `file://` URLs.
+ *
+ * ### Note
+ * The entire local URL is used as the cache key.
  */
-export async function downloadCustomInstaller(
-  inputs: types.IActionInputs
-): Promise<string> {
-  return await ensureLocalInstaller({ url: inputs.installerUrl });
-}
+export const urlDownloader: types.IInstallerProvider = {
+  label: "download a custom installer by URL",
+  provides: async (inputs, options) => !!inputs.installerUrl,
+  installerPath: async (inputs, options) => {
+    return {
+      localInstallerPath: await base.ensureLocalInstaller({
+        url: inputs.installerUrl,
+      }),
+      options: {
+        ...options,
+        useBundled: false,
+      },
+    };
+  },
+};

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -1,3 +1,76 @@
-export * from "./base";
-export * from "./download-miniconda";
-export * from "./download-url";
+import * as path from "path";
+
+import * as core from "@actions/core";
+
+import * as types from "../types";
+import * as utils from "../utils";
+
+import { minicondaDownloader } from "./download-miniconda";
+import { urlDownloader } from "./download-url";
+import { bundledMinicondaUser } from "./bundled-miniconda";
+
+/**
+ * Providers of `constructor`-compatible installers, ordered roughly by "cost".
+ *
+ * ### Note
+ * To add a new installer,
+ * - implement IInstallerProvider and add it here
+ * - add to `../../action.yaml`
+ * - any any new RULEs in ../input.ts, for example if the installer is not
+ *   compatible with some architectures
+ */
+const providers: types.IInstallerProvider[] = [
+  bundledMinicondaUser,
+  urlDownloader,
+  minicondaDownloader,
+];
+
+/** See if any provider works with the given inputs and options */
+export async function getLocalInstallerPath(
+  inputs: types.IActionInputs,
+  options: types.IDynamicOptions
+) {
+  for (const provider of providers) {
+    core.info(`Can we ${provider.label}?`);
+    if (await provider.provides(inputs, options)) {
+      core.info(`... will ${provider.label}`);
+      return provider.installerPath(inputs, options);
+    }
+  }
+  throw Error(`No installer could be found for the given inputs`);
+}
+
+/**
+ * Run a `constructor`-generated installer, like Miniconda.
+ *
+ * @param installerPath must have an appropriate extension for this platform
+ */
+export async function runInstaller(
+  installerPath: string,
+  outputPath: string
+): Promise<void> {
+  const installerExtension = path.extname(installerPath);
+  let command: string[];
+
+  switch (installerExtension) {
+    case ".exe":
+      /* From https://docs.anaconda.com/anaconda/install/silent-mode/
+          /D=<installation path> - Destination installation path.
+                                  - Must be the last argument.
+                                  - Do not wrap in quotation marks.
+                                  - Required if you use /S.
+          For the above reasons, this is treated a monolithic arg
+        */
+      command = [
+        `"${installerPath}" /InstallationType=JustMe /RegisterPython=0 /S /D=${outputPath}`,
+      ];
+      break;
+    case ".sh":
+      command = ["bash", installerPath, "-f", "-b", "-p", outputPath];
+      break;
+    default:
+      throw Error(`Unknown installer extension: ${installerExtension}`);
+  }
+
+  await utils.execute(command);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,3 +102,26 @@ export interface IEnvSpec {
   yaml?: IEnvironment;
   explicit?: string;
 }
+
+/**
+ * The output of an installer: may update the dynamic options
+ */
+export interface IInstallerResult {
+  options: IDynamicOptions;
+  localInstallerPath: string;
+}
+
+/**
+ * A strategy for ensuring a locally-runnable provider (or no-op, if bundled)
+ */
+export interface IInstallerProvider {
+  label: string;
+  provides: (
+    inputs: IActionInputs,
+    options: IDynamicOptions
+  ) => Promise<boolean>;
+  installerPath: (
+    inputs: IActionInputs,
+    options: IDynamicOptions
+  ) => Promise<IInstallerResult>;
+}

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -2,8 +2,8 @@ import * as path from "path";
 
 import * as core from "@actions/core";
 
-import { minicondaPath } from "./conda";
 import * as types from "./types";
+import * as conda from "./conda";
 
 /**
  * Add Conda executable to PATH
@@ -12,12 +12,12 @@ export async function setVariables(
   options: types.IDynamicOptions
 ): Promise<void> {
   // Set environment variables
-  const condaBin: string = path.join(minicondaPath(options), "condabin");
-  const conda: string = minicondaPath(options);
+  const condaBin: string = path.join(conda.condaBasePath(options), "condabin");
+  const condaVar: string = conda.condaBasePath(options);
   core.info(`Add "${condaBin}" to PATH`);
   core.addPath(condaBin);
   if (!options.useBundled) {
-    core.info(`Set 'CONDA="${conda}"'`);
-    core.exportVariable("CONDA", conda);
+    core.info(`Set 'CONDA="${condaVar}"'`);
+    core.exportVariable("CONDA", condaVar);
   }
 }


### PR DESCRIPTION
This moves all of the boolean logic for each installer provider out of `setup` to its individual file. This 1) cuts down on the complexity in `setup`, and 2) makes it very tractable to add the next installer, e.g. MiniForge, etc.

- continues #107

## On the next PR

> refactor the env provider

Apply a similar treatment as this PR to the _running_ of an installer and creating the environment. Another large chunk of `setup` will drop, and the boolean switches will be closer to their specific implementations. This is where the hook would become relevant for whether `mamba` is already provided by the installer for, e.g. config operations.