### PR TITLE
Add (Mini/Mamba)forge

### DIFF
--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -55,7 +55,7 @@ jobs:
           - os: ubuntu
             environment-file: etc/example-environment-no-name.yml
             miniforge-variant: Mambaforge
-            miniforge-version: 4.9.2-1
+            miniforge-version: 4.9.2-2
             mamba-version: "*"
           - os: macos
             environment-file: etc/example-empty-channels-environment.yml

--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -58,12 +58,12 @@ jobs:
       matrix:
         os: ["ubuntu", "macos", "windows"]
         include:
-          # should use mamba to upgrade mamba
+          # should use mamba 0.7.4 to upgrade to mamba 0.7.6
           - os: ubuntu
             environment-file: etc/example-environment-no-name.yml
             miniforge-variant: Mambaforge
             miniforge-version: 4.9.2-2
-            mamba-version: 0.7.7
+            mamba-version: 0.7.6
             python-version: 3.6
           - os: macos
             environment-file: etc/example-empty-channels-environment.yml

--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -1,0 +1,78 @@
+name: "Example 10: Miniforge, etc"
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "master"
+  schedule:
+    # Note that cronjobs run on master/main by default
+    - cron: "0 0 * * *"
+
+jobs:
+  example-10-miniforge:
+    # prevent cronjobs from running on forks
+    if:
+      (github.event_name == 'schedule' && github.repository ==
+      'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
+    name: Ex10 (${{ matrix.os }}, Miniforge)
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu", "macos", "windows"]
+        include:
+          - os: windows
+            miniforge-version: 4.9.2-4
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        id: setup-miniconda
+        with:
+          environment-file: etc/example-environment.yml
+          miniforge-variant: Miniforge3
+          miniforge-version: ${{ matrix.miniforge-version }}
+      - run: |
+          conda info
+          conda list
+          printenv | sort
+
+  example-10-mambaforge:
+    # prevent cronjobs from running on forks
+    if:
+      (github.event_name == 'schedule' && github.repository ==
+      'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
+    name: Ex10 (${{ matrix.os }}, Mambaforge)
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu", "macos", "windows"]
+        include:
+          - os: ubuntu
+            environment-file: etc/example-environment-no-name.yml
+            miniforge-variant: Mambaforge
+            miniforge-version: 4.9.2-4
+          - os: macos
+            environment-file: etc/example-empty-channels-environment.yml
+            miniforge-variant: Mambaforge-pypy3
+          - os: windows
+            environment-file: etc/example-explicit.Windows.conda.lock
+            condarc-file: etc/example-condarc.yml
+            miniforge-variant: Mambaforge
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        id: setup-miniconda
+        with:
+          condarc-file: ${{ matrix.condarc-file }}
+          environment-file: ${{ matrix.environment-file }}
+          miniforge-variant: ${{ matrix.miniforge-variant }}
+          miniforge-version: ${{ matrix.miniforge-version }}
+          use-mamba: true
+      - run: |
+          mamba info
+          mamba list
+          printenv | sort

--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -51,10 +51,12 @@ jobs:
       matrix:
         os: ["ubuntu", "macos", "windows"]
         include:
+          # should use mamba to upgrade mamba
           - os: ubuntu
             environment-file: etc/example-environment-no-name.yml
             miniforge-variant: Mambaforge
-            miniforge-version: 4.9.2-4
+            miniforge-version: 4.9.2-1
+            mamba-version: "*"
           - os: macos
             environment-file: etc/example-empty-channels-environment.yml
             miniforge-variant: Mambaforge-pypy3

--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -19,6 +19,9 @@ jobs:
       'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
     name: Ex10 (${{ matrix.os }}, Miniforge)
     runs-on: ${{ matrix.os }}-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:
@@ -47,6 +50,9 @@ jobs:
       'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
     name: Ex10 (${{ matrix.os }}, Mambaforge)
     runs-on: ${{ matrix.os }}-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -63,7 +63,7 @@ jobs:
             environment-file: etc/example-environment-no-name.yml
             miniforge-variant: Mambaforge
             miniforge-version: 4.9.2-2
-            mamba-version: "*"
+            mamba-version: 0.7.7
             python-version: 3.6
           - os: macos
             environment-file: etc/example-empty-channels-environment.yml

--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -66,7 +66,6 @@ jobs:
             environment-file: etc/example-explicit.Windows.conda.lock
             condarc-file: etc/example-condarc.yml
             miniforge-variant: Mambaforge
-            python-version: 3.7
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -73,6 +73,7 @@ jobs:
           environment-file: ${{ matrix.environment-file }}
           miniforge-variant: ${{ matrix.miniforge-variant }}
           miniforge-version: ${{ matrix.miniforge-version }}
+          mamba-version: ${{ matrix.mamba-version }}
           use-mamba: true
       - run: |
           mamba info

--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -37,6 +37,7 @@ jobs:
       - run: |
           conda info
           conda list
+          python -VV
           printenv | sort
 
   example-10-mambaforge:
@@ -57,6 +58,7 @@ jobs:
             miniforge-variant: Mambaforge
             miniforge-version: 4.9.2-2
             mamba-version: "*"
+            python-version: 3.6
           - os: macos
             environment-file: etc/example-empty-channels-environment.yml
             miniforge-variant: Mambaforge-pypy3
@@ -64,6 +66,7 @@ jobs:
             environment-file: etc/example-explicit.Windows.conda.lock
             condarc-file: etc/example-condarc.yml
             miniforge-variant: Mambaforge
+            python-version: 3.7
     steps:
       - uses: actions/checkout@v2
       - uses: ./
@@ -75,7 +78,9 @@ jobs:
           miniforge-version: ${{ matrix.miniforge-version }}
           mamba-version: ${{ matrix.mamba-version }}
           use-mamba: true
+          python-version: ${{ matrix.python-version }}
       - run: |
           mamba info
           mamba list
+          python -VV
           printenv | sort

--- a/README.md
+++ b/README.md
@@ -282,11 +282,8 @@ priority.
 
 > Notes:
 >  - If a [custom installer](#example-5-custom-installer) provides `mamba`, it
->    can prioritized wherever possible with the following settings.
->    - `mamba-in-installer: true`
->      - this is _always_ `true` for [Mambaforge](#example-10-miniforge)
->    - `use-mamba: true`
-
+>    can be prioritized wherever possible (including installing `mamba-version`)
+>    with `use-mamba: true`.
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -243,10 +243,12 @@ Any installer created with [constructor](https://github.com/conda/constructor)
 which includes `conda` can be used in place of Miniconda. For example,
 [conda-forge](https://conda-forge.org/) maintains additional builds of
 [miniforge](https://github.com/conda-forge/miniforge/releases) for platforms not
-yet supported by Miniconda.
+yet supported by Miniconda. For more, see [Example 10](#example-10-miniforge).
 
-> Note: Installer downloads are cached based on their full URL: adding some
-  non-functional salt to the URL will prevent this behavior, e.g. `#${{ github.run_number }}`
+> Notes:
+>  - Installer downloads are cached based on their full URL: adding some
+>    non-functional salt to the URL will prevent this behavior, e.g.
+>    `#${{ github.run_number }}`
 
 ```yaml
 jobs:
@@ -277,6 +279,14 @@ Experimental! Use `mamba` to handle conda installs in a faster way.
 `mamba-version` accepts a version string `x.y` (including `"*"`). It requires
 you specify `conda-forge` as part of the channels, ideally with the highest
 priority.
+
+> Notes:
+>  - If a [custom installer](#example-5-custom-installer) provides `mamba`, it
+>    can prioritized wherever possible with the following settings.
+>    - `mamba-in-installer: true`
+>      - this is _always_ `true` for [Mambaforge](#example-10-miniforge)
+>    - `use-mamba: true`
+
 
 ```yaml
 jobs:
@@ -348,6 +358,72 @@ jobs:
           conda config --show-sources
           conda config --show
           printenv | sort
+```
+
+### Example 10: Miniforge
+
+[Miniforge](https://github.com/conda-forge/miniforge) provides a number of
+alternatives to Miniconda, built from the ground up with `conda-forge` packages
+and with only `conda-forge` in its default channels.
+
+```yaml
+jobs:
+  example-10-miniforge:
+    name: Ex10 (${{ matrix.os }}, Miniforge)
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: ["ubuntu", "macos", "windows"]
+        include:
+        - os: windows
+          miniforge-version: 4.9.2-4
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        id: setup-miniconda
+        with:
+          environment-file: etc/example-environment.yml
+          miniforge-variant: Miniforge3
+          miniforge-version: ${{ matrix.miniforge-version }}
+```
+
+In addition to `Miniforge3` with `conda` and `CPython` for each
+of its many supported platforms and architectures, additional variants including
+`Mambaforge` (which comes pre-installed `mamba` in addition to `conda` on all platforms)
+and `Miniforge-pypy3`/`Mamabaforge-pypy3` (which replace `CPython` with `pypy3`
+on Linux/MacOs) are available. The specific version can also be overridden.
+
+```yaml
+jobs:
+  example-10-mambaforge:
+    name: Ex10 (${{ matrix.os }}, Mambaforge)
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu", "macos", "windows"]
+        include:
+          - os: ubuntu
+            environment-file: etc/example-environment-no-name.yml
+            miniforge-variant: Mambaforge
+            miniforge-version: 4.9.2-4
+          - os: macos
+            environment-file: etc/example-empty-channels-environment.yml
+            miniforge-variant: Mambaforge-pypy3
+          - os: windows
+            environment-file: etc/example-explicit.Windows.conda.lock
+            condarc-file: etc/example-condarc.yml
+            miniforge-variant: Mambaforge
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        id: setup-miniconda
+        with:
+          condarc-file: ${{ matrix.condarc-file }}
+          environment-file: ${{ matrix.environment-file }}
+          miniforge-variant: ${{ matrix.miniforge-variant }}
+          miniforge-version: ${{ matrix.miniforge-version }}
+          use-mamba: true
 ```
 
 ## Caching

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,29 @@ inputs:
     default: ""
   miniconda-version:
     description:
-      "If provided, this version of miniconda will be downloaded and installed.
+      "If provided, this version of Miniconda3 will be downloaded and installed.
       Visit https://repo.continuum.io/miniconda/ for more information on
       available versions."
+    required: false
+    default: ""
+  miniforge-variant:
+    description:
+      "If provided, this variant of Miniforge will be downloaded and installed.
+      Currently-known values:
+      - Miniforge3
+      - Miniforge-pypy3
+      - Mambaforge
+      - Mambaforge-pypy3
+      Visit https://github.com/conda-forge/miniforge/releases/ for more information
+      on available variants"
+    required: false
+    default: ""
+  miniforge-version:
+    description:
+      "If provided, this version of the given Miniforge variant will be downloaded
+      and installed instead of the latest.
+      Visit https://github.com/conda-forge/miniforge/releases/ for more information
+      on available versions"
     required: false
     default: ""
   conda-version:
@@ -180,11 +200,24 @@ inputs:
       removed from the runner. Default is "true".'
     required: false
     default: "true"
+  mamba-in-installer:
+    description:
+      'Experimental. If `true`, assume `mamba` is already available after running
+      the installer. Always `true` for `miniforge-variant: Mambaforge` or
+      `miniforge-variant: Mambaforge-pypy3`'
+    required: false
+    default: ""
   mamba-version:
     description:
       'Experimental. Use mamba (https://github.com/QuantStack/mamba) as a faster
       drop-in replacement for conda installs. Disabled by default. To enable,
       use "*" or a "x.y" version string.'
+    required: false
+    default: ""
+  use-mamba:
+    description:
+      'Experimental. Use mamba as soon as available (either as provided by
+      `mamba-in-installer` or installation by `mamba-version`)'
     required: false
     default: ""
   architecture:

--- a/action.yml
+++ b/action.yml
@@ -200,13 +200,6 @@ inputs:
       removed from the runner. Default is "true".'
     required: false
     default: "true"
-  mamba-in-installer:
-    description:
-      'Experimental. If `true`, assume `mamba` is already available after running
-      the installer. Always `true` for `miniforge-variant: Mambaforge` or
-      `miniforge-variant: Mambaforge-pypy3`'
-    required: false
-    default: ""
   mamba-version:
     description:
       'Experimental. Use mamba (https://github.com/QuantStack/mamba) as a faster

--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -1161,7 +1161,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.OS_NAMES = exports.ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
+exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_URL_PREFIX = exports.MINIFORGE_INDEX_URL = exports.OS_NAMES = exports.ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 //-----------------------------------------------------------------------
@@ -1184,12 +1184,27 @@ exports.OS_NAMES = {
     darwin: "MacOSX",
     linux: "Linux",
 };
+/** API endpoint for Miniforge releases */
+exports.MINIFORGE_INDEX_URL = `https://api.github.com/repos/conda-forge/miniforge/releases`;
+/** Common download prefix */
+exports.MINIFORGE_URL_PREFIX = "https://github.com/conda-forge/miniforge/releases/download";
 /** Names for a conda `base` env */
 exports.BASE_ENV_NAMES = ["root", "base", ""];
 /**
  * Known extensions for `constructor`-generated installers supported
  */
 exports.KNOWN_EXTENSIONS = [".exe", ".sh"];
+/** As of mamba 0.7.6, only these top-level commands are supported */
+exports.MAMBA_SUBCOMMANDS = [
+    "clean",
+    "create",
+    "env",
+    "info",
+    "install",
+    "list",
+    "run",
+    "search",
+];
 /**
  * Errors that are always probably spurious
  */

--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -1161,7 +1161,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_URL_PREFIX = exports.MINIFORGE_INDEX_URL = exports.OS_NAMES = exports.ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
+exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_URL_PREFIX = exports.MINIFORGE_RELEASE_JSON = exports.MINIFORGE_INDEX_URL = exports.OS_NAMES = exports.ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 //-----------------------------------------------------------------------
@@ -1185,7 +1185,9 @@ exports.OS_NAMES = {
     linux: "Linux",
 };
 /** API endpoint for Miniforge releases */
-exports.MINIFORGE_INDEX_URL = `https://api.github.com/repos/conda-forge/miniforge/releases`;
+exports.MINIFORGE_INDEX_URL = `https://api.github.com/repos/conda-forge/miniforge/releases?per_page=100`;
+/**  */
+exports.MINIFORGE_RELEASE_JSON = "miniforge-releases.json";
 /** Common download prefix */
 exports.MINIFORGE_URL_PREFIX = "https://github.com/conda-forge/miniforge/releases/download";
 /** Names for a conda `base` env */

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -13705,11 +13705,13 @@ const conda = __importStar(__webpack_require__(259));
 /** Install `mamba` in the `base` env at a specified version */
 exports.updateMamba = {
     label: "update mamba",
-    provides: (inputs, options) => __awaiter(void 0, void 0, void 0, function* () { return inputs.mambaVersion !== ""; }),
+    provides: (inputs, options) => __awaiter(void 0, void 0, void 0, function* () { return inputs.mambaVersion !== "" || options.mambaInInstaller; }),
     toolPackages: (inputs, options) => __awaiter(void 0, void 0, void 0, function* () {
         core.warning(`Mamba support is still experimental and can result in differently solved environments!`);
         return {
-            tools: [utils.makeSpec("mamba", inputs.mambaVersion)],
+            tools: inputs.mambaVersion !== ""
+                ? [utils.makeSpec("mamba", inputs.mambaVersion)]
+                : [],
             options: Object.assign(Object.assign({}, options), { useMamba: true }),
         };
     }),

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -2132,7 +2132,7 @@ function installBaseTools(inputs, options) {
             }
         }
         if (tools.length) {
-            yield conda.condaCommand(["install", "--name", "base", ...tools], 
+            yield conda.condaCommand(["install", "--name", "base", ...tools],
             // Use the original `options`, as we can't guarantee `mamba` is available
             // TODO: allow declaring that the installer already has `mamba`
             options);
@@ -7086,7 +7086,7 @@ var attributeRules = {
 		if(len === 0){
 			return falseFunc;
 		}
-		
+
 		if(data.ignoreCase){
 			value = value.toLowerCase();
 
@@ -7254,7 +7254,7 @@ exports.prepend = function(elem, prev){
 	if(elem.prev){
 		elem.prev.next = prev;
 	}
-	
+
 	prev.parent = parent;
 	prev.prev = elem.prev;
 	prev.next = elem;
@@ -8525,7 +8525,7 @@ Parser.prototype.onclosetag = function(name) {
     if (this._lowerCaseTagNames) {
         name = name.toLowerCase();
     }
-    
+
     if (name in foreignContextElements || name in htmlIntegrationElements) {
         this._foreignContext.pop();
     }
@@ -8574,7 +8574,7 @@ Parser.prototype._closeCurrentTag = function() {
             this._cbs.onclosetag(name);
         }
         this._stack.pop();
-        
+
     }
 };
 
@@ -15654,7 +15654,7 @@ DomHandler.prototype.onerror = function(error){
 
 DomHandler.prototype.onclosetag = function(){
 	//if(this._tagStack.pop().name !== name) this._handleCallback(Error("Tagname didn't match!"));
-	
+
 	var elem = this._tagStack.pop();
 
 	if(this._options.withEndIndices && elem){
@@ -20653,9 +20653,12 @@ exports.ensureYaml = {
         if (patchesApplied.length) {
             const patchedYaml = yaml.safeDump(Object.assign(Object.assign({}, yamlData), { dependencies }));
             envFile = path.join(os.tmpdir(), "environment-patched.yml");
-            core.info(`Making patched copy of 'environment-file: ${inputs.environmentFile}'
-        ${patchedYaml}`);
+            core.info(`Making patched copy of 'environment-file: ${inputs.environmentFile}'`);
+            core.info(patchedYaml);
             fs.writeFileSync(envFile, patchedYaml, "utf8");
+        }
+        else {
+            core.info(`Using 'environment-file: ${inputs.environmentFile}' as-is`);
         }
         return [
             "env",
@@ -38318,7 +38321,7 @@ LocationInfoTokenizerMixin.prototype._getOverriddenMethods = function (mxn, orig
 /******/ ],
 /******/ function(__webpack_require__) { // webpackRuntimeModules
 /******/ 	"use strict";
-/******/ 
+/******/
 /******/ 	/* webpack/runtime/node module decorator */
 /******/ 	!function() {
 /******/ 		__webpack_require__.nmd = function(module) {
@@ -38335,6 +38338,6 @@ LocationInfoTokenizerMixin.prototype._getOverriddenMethods = function (mxn, orig
 /******/ 			return module;
 /******/ 		};
 /******/ 	}();
-/******/ 	
+/******/
 /******/ }
 );

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -6666,15 +6666,17 @@ function ensureLocalInstaller(options) {
         }
         if (executablePath === "") {
             core.info(`Checking for cached ${tool}@${version}...`);
-            executablePath = tc.find(installerName, version);
+            executablePath = tc.find(installerName, version, ...(options.arch ? [options.arch] : []));
             if (executablePath !== "") {
                 core.info(`Found ${installerName} cache at ${executablePath}!`);
             }
+            else {
+                core.info(`Did not find ${installerName} ${version} in cache`);
+            }
         }
         if (executablePath === "") {
-            core.info(`Did not find ${installerName} in cache, downloading...`);
             const rawDownloadPath = yield tc.downloadTool(options.url);
-            core.info(`Downloaded ${installerName}, appending ${installerExtension}`);
+            core.info(`Downloaded ${installerName}, ensuring extension ${installerExtension}`);
             // Always ensure the installer ends with a known path
             executablePath = rawDownloadPath + installerExtension;
             yield io.mv(rawDownloadPath, executablePath);
@@ -9351,7 +9353,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_URL_PREFIX = exports.MINIFORGE_INDEX_URL = exports.OS_NAMES = exports.ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
+exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_URL_PREFIX = exports.MINIFORGE_RELEASE_JSON = exports.MINIFORGE_INDEX_URL = exports.OS_NAMES = exports.ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 //-----------------------------------------------------------------------
@@ -9375,7 +9377,9 @@ exports.OS_NAMES = {
     linux: "Linux",
 };
 /** API endpoint for Miniforge releases */
-exports.MINIFORGE_INDEX_URL = `https://api.github.com/repos/conda-forge/miniforge/releases`;
+exports.MINIFORGE_INDEX_URL = `https://api.github.com/repos/conda-forge/miniforge/releases?per_page=100`;
+/**  */
+exports.MINIFORGE_RELEASE_JSON = "miniforge-releases.json";
 /** Common download prefix */
 exports.MINIFORGE_URL_PREFIX = "https://github.com/conda-forge/miniforge/releases/download";
 /** Names for a conda `base` env */
@@ -34127,8 +34131,19 @@ function miniforgeVersions(variant, osName, arch) {
         const assets = [];
         let extension = constants.IS_UNIX ? "sh" : "exe";
         const suffix = `${osName}-${arch}.${extension}`;
-        core.info(`Downloading ${constants.MINIFORGE_INDEX_URL}`);
-        const downloadPath = yield tc.downloadTool(constants.MINIFORGE_INDEX_URL);
+        core.info(`Checking for cached Miniforge releases...`);
+        // Try to pull cached releases with an hour epoch: YYYY-MM-DDTHH
+        const cacheEpoch = new Date().toISOString().split(":")[0];
+        let downloadPath = tc.find(constants.MINIFORGE_RELEASE_JSON, cacheEpoch);
+        if (downloadPath !== "") {
+            core.info(`Found Miniforge releases in cache`);
+        }
+        else {
+            core.info(`Downloading Miniforge releases from ${constants.MINIFORGE_INDEX_URL}`);
+            downloadPath = yield tc.downloadTool(constants.MINIFORGE_INDEX_URL);
+            const cacheResult = yield tc.cacheFile(downloadPath, constants.MINIFORGE_RELEASE_JSON, constants.MINIFORGE_RELEASE_JSON, cacheEpoch);
+            core.info(`Cached Miniforge releases: ${cacheResult}!`);
+        }
         const data = JSON.parse(fs.readFileSync(downloadPath, "utf8"));
         for (const release of data) {
             if (release.prerelease || release.draft) {
@@ -34170,6 +34185,7 @@ function downloadMiniforge(inputs, options) {
             version = assets[0].tag_name;
             url = assets[0].browser_download_url;
         }
+        core.info(`Will fetch ${tool} ${version} from ${url}`);
         return yield base.ensureLocalInstaller({ url, tool, version, arch });
     });
 }

--- a/src/base-tools/index.ts
+++ b/src/base-tools/index.ts
@@ -41,11 +41,14 @@ export async function installBaseTools(
   for (const provider of TOOL_PROVIDERS) {
     core.info(`Do we need to ${provider.label}?`);
     if (await provider.provides(inputs, options)) {
-      core.info(`... will ${provider.label}.`);
+      core.info(`... we will ${provider.label}.`);
       const toolUpdates = await provider.toolPackages(inputs, options);
       tools.push(...toolUpdates.tools);
       postInstallOptions = { ...postInstallOptions, ...toolUpdates.options };
       if (provider.postInstall) {
+        core.info(
+          `... we will perform post-intall steps after we ${provider.label}.`
+        );
         postInstallActions.push(provider.postInstall);
       }
     }
@@ -62,12 +65,16 @@ export async function installBaseTools(
     // *Now* use the new options, as we may have a new conda/mamba with more supported
     // options that previously failed
     await conda.applyCondaConfiguration(inputs, postInstallOptions);
+  } else {
+    core.info("No tools were installed in 'base' env.");
+  }
 
-    if (postInstallActions.length) {
-      for (const action of postInstallActions) {
-        await action(inputs, postInstallOptions);
-      }
+  if (postInstallActions.length) {
+    for (const action of postInstallActions) {
+      await action(inputs, postInstallOptions);
     }
+  } else {
+    core.info("No post-install actions were taken on 'base' env.");
   }
 
   return postInstallOptions;

--- a/src/base-tools/update-mamba.ts
+++ b/src/base-tools/update-mamba.ts
@@ -11,13 +11,17 @@ import * as conda from "../conda";
 /** Install `mamba` in the `base` env at a specified version */
 export const updateMamba: types.IToolProvider = {
   label: "update mamba",
-  provides: async (inputs, options) => inputs.mambaVersion !== "",
+  provides: async (inputs, options) =>
+    inputs.mambaVersion !== "" || options.mambaInInstaller,
   toolPackages: async (inputs, options) => {
     core.warning(
       `Mamba support is still experimental and can result in differently solved environments!`
     );
     return {
-      tools: [utils.makeSpec("mamba", inputs.mambaVersion)],
+      tools:
+        inputs.mambaVersion !== ""
+          ? [utils.makeSpec("mamba", inputs.mambaVersion)]
+          : [],
       options: { ...options, useMamba: true },
     };
   },

--- a/src/base-tools/update-mamba.ts
+++ b/src/base-tools/update-mamba.ts
@@ -27,6 +27,7 @@ export const updateMamba: types.IToolProvider = {
   },
   postInstall: async (inputs, options) => {
     if (!constants.IS_WINDOWS) {
+      core.info("`mamba` is already executable");
       return;
     }
     core.info("Creating bash wrapper for `mamba`...");

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -31,11 +31,19 @@ export function condaBasePath(options: types.IDynamicOptions): string {
 /**
  * Provide cross platform location of conda/mamba executable
  */
-export function condaExecutable(options: types.IDynamicOptions): string {
+export function condaExecutable(
+  options: types.IDynamicOptions,
+  subcommand?: string
+): string {
   const dir: string = condaBasePath(options);
   let condaExe: string;
-  let commandName: string;
-  commandName = options.useMamba ? "mamba" : "conda";
+  let commandName = "conda";
+  if (
+    options.useMamba &&
+    (subcommand == null || constants.MAMBA_SUBCOMMANDS.includes(subcommand))
+  ) {
+    commandName = "mamba";
+  }
   commandName = constants.IS_WINDOWS ? commandName + ".bat" : commandName;
   condaExe = path.join(dir, "condabin", commandName);
   return condaExe;
@@ -48,7 +56,7 @@ export async function condaCommand(
   cmd: string[],
   options: types.IDynamicOptions
 ): Promise<void> {
-  const command = [condaExecutable(options), ...cmd];
+  const command = [condaExecutable(options, cmd[0]), ...cmd];
   return await utils.execute(command);
 }
 
@@ -177,12 +185,7 @@ export async function condaInit(
 
   // Run conda init
   for (let cmd of ["--all"]) {
-    // TODO: determine when it's safe to use mamba
-    await utils.execute([
-      condaExecutable({ ...options, useMamba: false }),
-      "init",
-      cmd,
-    ]);
+    await condaCommand(["init", cmd], options);
   }
 
   // Rename files

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -49,6 +49,12 @@ export function condaExecutable(
   return condaExe;
 }
 
+/** Detect the presence of mamba */
+export function isMambaInstalled(options: types.IDynamicOptions) {
+  const mamba = condaExecutable({ ...options, useMamba: true });
+  return fs.existsSync(mamba);
+}
+
 /**
  * Run Conda command
  */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,7 +29,10 @@ export const OS_NAMES: types.IOperatingSystems = {
 };
 
 /** API endpoint for Miniforge releases */
-export const MINIFORGE_INDEX_URL = `https://api.github.com/repos/conda-forge/miniforge/releases`;
+export const MINIFORGE_INDEX_URL = `https://api.github.com/repos/conda-forge/miniforge/releases?per_page=100`;
+
+/**  */
+export const MINIFORGE_RELEASE_JSON = "miniforge-releases.json";
 
 /** Common download prefix */
 export const MINIFORGE_URL_PREFIX =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,7 @@ export const IS_WINDOWS: boolean = process.platform === "win32";
 export const IS_MAC: boolean = process.platform === "darwin";
 export const IS_LINUX: boolean = process.platform === "linux";
 export const IS_UNIX: boolean = IS_MAC || IS_LINUX;
+
 export const MINICONDA_BASE_URL: string =
   "https://repo.anaconda.com/miniconda/";
 
@@ -27,6 +28,13 @@ export const OS_NAMES: types.IOperatingSystems = {
   linux: "Linux",
 };
 
+/** API endpoint for Miniforge releases */
+export const MINIFORGE_INDEX_URL = `https://api.github.com/repos/conda-forge/miniforge/releases`;
+
+/** Common download prefix */
+export const MINIFORGE_URL_PREFIX =
+  "https://github.com/conda-forge/miniforge/releases/download";
+
 /** Names for a conda `base` env */
 export const BASE_ENV_NAMES = ["root", "base", ""];
 
@@ -34,6 +42,18 @@ export const BASE_ENV_NAMES = ["root", "base", ""];
  * Known extensions for `constructor`-generated installers supported
  */
 export const KNOWN_EXTENSIONS = [".exe", ".sh"];
+
+/** As of mamba 0.7.6, only these top-level commands are supported */
+export const MAMBA_SUBCOMMANDS = [
+  "clean",
+  "create",
+  "env",
+  "info",
+  "install",
+  "list",
+  "run",
+  "search",
+];
 
 /**
  * Errors that are always probably spurious

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -36,9 +36,9 @@ export async function ensureEnvironment(
   options: types.IDynamicOptions
 ): Promise<void> {
   for (const provider of ENV_PROVIDERS) {
-    core.info(`Can we use ${provider.label}?`);
+    core.info(`Can we ${provider.label}?`);
     if (await provider.provides(inputs, options)) {
-      core.info(`... will use ${provider.label}.`);
+      core.info(`... will ${provider.label}.`);
       const args = await provider.condaArgs(inputs, options);
       return await core.group(
         `Updating '${inputs.activateEnvironment}' env from ${provider.label}...`,

--- a/src/env/yaml.ts
+++ b/src/env/yaml.ts
@@ -110,10 +110,12 @@ export const ensureYaml: types.IEnvProvider = {
       const patchedYaml = yaml.safeDump({ ...yamlData, dependencies });
       envFile = path.join(os.tmpdir(), "environment-patched.yml");
       core.info(
-        `Making patched copy of 'environment-file: ${inputs.environmentFile}'
-        ${patchedYaml}`
+        `Making patched copy of 'environment-file: ${inputs.environmentFile}'`
       );
+      core.info(patchedYaml);
       fs.writeFileSync(envFile, patchedYaml, "utf8");
+    } else {
+      core.info(`Using 'environment-file: ${inputs.environmentFile}' as-is`);
     }
 
     return [

--- a/src/input.ts
+++ b/src/input.ts
@@ -41,12 +41,15 @@ const RULES: IRule[] = [
   (i) =>
     !!(i.pythonVersion && !i.activateEnvironment) &&
     `'python-version: ${i.pythonVersion}' requires 'activate-environment: true'`,
-  (i, c) =>
-    !!(i.mambaVersion && !c.channels.includes("conda-forge")) &&
-    `'mamba-version: ${i.mambaVersion}' requires 'conda-forge' to be included in 'channels'`,
+  (i) =>
+    !!(i.minicondaVersion && i.miniforgeVariant) &&
+    `only one of 'miniconda-version: ${i.minicondaVersion}' or 'miniforge-variant: ${i.miniforgeVariant}' may be provided`,
   (i) =>
     !!(i.installerUrl && i.minicondaVersion) &&
-    `only one of 'installer-url' and 'miniconda-version' may be provided`,
+    `only one of 'installer-url: ${i.installerUrl}' or 'miniconda-version: ${i.minicondaVersion}' may be provided`,
+  (i) =>
+    !!(i.installerUrl && i.miniforgeVariant) &&
+    `only one of 'installer-url: ${i.installerUrl}' or 'miniforge-variant: ${i.miniforgeVariant}' may be provided`,
   (i) =>
     !!(
       i.installerUrl &&
@@ -75,8 +78,12 @@ export async function parseInputs(): Promise<types.IActionInputs> {
     condaVersion: core.getInput("conda-version"),
     environmentFile: core.getInput("environment-file"),
     installerUrl: core.getInput("installer-url"),
+    mambaInInstaller: core.getInput("mamba-in-installer"),
     mambaVersion: core.getInput("mamba-version"),
+    useMamba: core.getInput("use-mamba"),
     minicondaVersion: core.getInput("miniconda-version"),
+    miniforgeVariant: core.getInput("miniforge-variant"),
+    miniforgeVersion: core.getInput("miniforge-version"),
     pythonVersion: core.getInput("python-version"),
     removeProfiles: core.getInput("remove-profiles"),
     condaConfig: Object.freeze({

--- a/src/input.ts
+++ b/src/input.ts
@@ -70,7 +70,7 @@ const RULES: IRule[] = [
  * Parse, validate, and normalize string-ish inputs from a workflow action's `with`
  */
 export async function parseInputs(): Promise<types.IActionInputs> {
-  const inputs = Object.freeze({
+  const inputs: types.IActionInputs = Object.freeze({
     activateEnvironment: core.getInput("activate-environment"),
     architecture: core.getInput("architecture"),
     condaBuildVersion: core.getInput("conda-build-version"),
@@ -78,7 +78,6 @@ export async function parseInputs(): Promise<types.IActionInputs> {
     condaVersion: core.getInput("conda-version"),
     environmentFile: core.getInput("environment-file"),
     installerUrl: core.getInput("installer-url"),
-    mambaInInstaller: core.getInput("mamba-in-installer"),
     mambaVersion: core.getInput("mamba-version"),
     useMamba: core.getInput("use-mamba"),
     minicondaVersion: core.getInput("miniconda-version"),
@@ -118,5 +117,5 @@ export async function parseInputs(): Promise<types.IActionInputs> {
     throw Error(`${errors.length} errors found in action inputs`);
   }
 
-  return Object.freeze(inputs);
+  return inputs;
 }

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -7,8 +7,6 @@ import * as io from "@actions/io";
 import * as tc from "@actions/tool-cache";
 
 import * as types from "../types";
-import * as utils from "../utils";
-import * as conda from "../conda";
 
 /** Get the path for a locally-executable installer from cache, or as downloaded
  *
@@ -77,42 +75,4 @@ export async function ensureLocalInstaller(
   }
 
   return executablePath;
-}
-
-/**
- * Create a conda base (ne root) env from a `constructor`-compatible CLI executable
- *
- * @param installerPath must have an appropriate extension for this platform
- */
-export async function runInstaller(
-  installerPath: string,
-  options: types.IDynamicOptions
-): Promise<void> {
-  const outputPath: string = conda.condaBasePath(options);
-  const installerExtension = path.extname(installerPath);
-  let command: string[];
-
-  switch (installerExtension) {
-    case ".exe":
-      /* From https://docs.anaconda.com/anaconda/install/silent-mode/
-          /D=<installation path> - Destination installation path.
-                                  - Must be the last argument.
-                                  - Do not wrap in quotation marks.
-                                  - Required if you use /S.
-          For the above reasons, this is treated a monolithic arg
-        */
-      command = [
-        `"${installerPath}" /InstallationType=JustMe /RegisterPython=0 /S /D=${outputPath}`,
-      ];
-      break;
-    case ".sh":
-      command = ["bash", installerPath, "-f", "-b", "-p", outputPath];
-      break;
-    default:
-      throw new Error(`Unknown installer extension: ${installerExtension}`);
-  }
-
-  core.info(`Install Command:\n\t${command}`);
-
-  return await utils.execute(command);
 }

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -46,16 +46,23 @@ export async function ensureLocalInstaller(
 
   if (executablePath === "") {
     core.info(`Checking for cached ${tool}@${version}...`);
-    executablePath = tc.find(installerName, version);
+    executablePath = tc.find(
+      installerName,
+      version,
+      ...(options.arch ? [options.arch] : [])
+    );
     if (executablePath !== "") {
       core.info(`Found ${installerName} cache at ${executablePath}!`);
+    } else {
+      core.info(`Did not find ${installerName} ${version} in cache`);
     }
   }
 
   if (executablePath === "") {
-    core.info(`Did not find ${installerName} in cache, downloading...`);
     const rawDownloadPath = await tc.downloadTool(options.url);
-    core.info(`Downloaded ${installerName}, appending ${installerExtension}`);
+    core.info(
+      `Downloaded ${installerName}, ensuring extension ${installerExtension}`
+    );
     // Always ensure the installer ends with a known path
     executablePath = rawDownloadPath + installerExtension;
     await io.mv(rawDownloadPath, executablePath);

--- a/src/installer/bundled-miniconda.ts
+++ b/src/installer/bundled-miniconda.ts
@@ -12,6 +12,7 @@ export const bundledMinicondaUser: types.IInstallerProvider = {
   provides: async (inputs, options) => {
     return (
       inputs.minicondaVersion === "" &&
+      inputs.miniforgeVariant === "" &&
       inputs.architecture === "x64" &&
       inputs.installerUrl === ""
     );

--- a/src/installer/download-miniforge.ts
+++ b/src/installer/download-miniforge.ts
@@ -105,9 +105,6 @@ export const miniforgeDownloader: types.IInstallerProvider = {
       options: {
         ...options,
         useBundled: false,
-        mambaInInstaller: inputs.miniforgeVariant
-          .toLowerCase()
-          .includes("mamba"),
       },
     };
   },

--- a/src/installer/download-miniforge.ts
+++ b/src/installer/download-miniforge.ts
@@ -1,0 +1,114 @@
+import * as fs from "fs";
+
+import * as core from "@actions/core";
+import * as tc from "@actions/tool-cache";
+
+import * as types from "../types";
+import * as constants from "../constants";
+
+import * as base from "./base";
+
+/**
+ * List available Miniforge versions
+ *
+ * @param arch
+ */
+async function miniforgeVersions(
+  variant: string,
+  osName: string,
+  arch: string
+): Promise<types.IGithubAssetWithRelease[]> {
+  const assets: types.IGithubAssetWithRelease[] = [];
+  let extension: string = constants.IS_UNIX ? "sh" : "exe";
+  const suffix = `${osName}-${arch}.${extension}`;
+
+  core.info(`Downloading ${constants.MINIFORGE_INDEX_URL}`);
+  const downloadPath: string = await tc.downloadTool(
+    constants.MINIFORGE_INDEX_URL
+  );
+
+  const data: types.IGithubRelease[] = JSON.parse(
+    fs.readFileSync(downloadPath, "utf8")
+  );
+
+  for (const release of data) {
+    if (release.prerelease || release.draft) {
+      continue;
+    }
+    for (const asset of release.assets) {
+      if (asset.name.match(`${variant}-\\d`) && asset.name.endsWith(suffix)) {
+        assets.push({ ...asset, tag_name: release.tag_name });
+      }
+    }
+  }
+
+  return assets;
+}
+
+/**
+ * Download specific Miniforge defined by variant, version and architecture
+ */
+export async function downloadMiniforge(
+  inputs: types.IActionInputs,
+  options: types.IDynamicOptions
+): Promise<string> {
+  let tool = inputs.miniforgeVariant.trim();
+  let version = inputs.miniforgeVersion.trim();
+  const arch = constants.ARCHITECTURES[inputs.architecture];
+
+  // Check valid arch
+  if (!arch) {
+    throw new Error(`Invalid 'architecture: ${inputs.architecture}'`);
+  }
+
+  let url: string;
+
+  const extension: string = constants.IS_UNIX ? "sh" : "exe";
+  const osName: string = constants.OS_NAMES[process.platform];
+
+  if (version) {
+    const fileName = [tool, version, osName, `${arch}.${extension}`].join("-");
+    url = [constants.MINIFORGE_URL_PREFIX, version, fileName].join("/");
+  } else {
+    const assets = await miniforgeVersions(
+      inputs.miniforgeVariant,
+      osName,
+      arch
+    );
+    if (!assets.length) {
+      throw new Error(
+        `Couldn't fetch Miniforge versions and 'miniforge-version' not provided`
+      );
+    }
+    version = assets[0].tag_name;
+    url = assets[0].browser_download_url;
+  }
+
+  return await base.ensureLocalInstaller({ url, tool, version, arch });
+}
+
+/**
+ * Provide a path to a Miniforge downloaded from github.com.
+ *
+ * ### Note
+ * Uses the well-known structure of GitHub releases to resolve and download
+ * a particular Miniforge installer.
+ */
+export const miniforgeDownloader: types.IInstallerProvider = {
+  label: "download Minforge",
+  provides: async (inputs, options) => {
+    return inputs.miniforgeVariant !== "" && inputs.installerUrl === "";
+  },
+  installerPath: async (inputs, options) => {
+    return {
+      localInstallerPath: await downloadMiniforge(inputs, options),
+      options: {
+        ...options,
+        useBundled: false,
+        mambaInInstaller: inputs.miniforgeVariant
+          .toLowerCase()
+          .includes("mamba"),
+      },
+    };
+  },
+};

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -5,6 +5,7 @@ import * as core from "@actions/core";
 import * as types from "../types";
 import * as utils from "../utils";
 
+import { miniforgeDownloader } from "./download-miniforge";
 import { minicondaDownloader } from "./download-miniconda";
 import { urlDownloader } from "./download-url";
 import { bundledMinicondaUser } from "./bundled-miniconda";
@@ -24,6 +25,7 @@ const INSTALLER_PROVIDERS: types.IInstallerProvider[] = [
   bundledMinicondaUser,
   urlDownloader,
   minicondaDownloader,
+  miniforgeDownloader,
 ];
 
 /** See if any provider works with the given inputs and options */
@@ -32,9 +34,9 @@ export async function getLocalInstallerPath(
   options: types.IDynamicOptions
 ) {
   for (const provider of INSTALLER_PROVIDERS) {
-    core.info(`Can we use ${provider.label}?`);
+    core.info(`Can we ${provider.label}?`);
     if (await provider.provides(inputs, options)) {
-      core.info(`... will use ${provider.label}.`);
+      core.info(`... will ${provider.label}.`);
       return provider.installerPath(inputs, options);
     }
   }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -18,7 +18,7 @@ async function setupMiniconda(inputs: types.IActionInputs): Promise<void> {
   let options: types.IDynamicOptions = {
     useBundled: true,
     useMamba: false,
-    mambaInInstaller: inputs.mambaInInstaller === "true",
+    mambaInInstaller: false,
     condaConfig: { ...inputs.condaConfig },
   };
 
@@ -42,8 +42,9 @@ async function setupMiniconda(inputs: types.IActionInputs): Promise<void> {
     );
   }
 
-  // The installer may have provisioned mamba: use if requested
-  options.useMamba = options.mambaInInstaller && inputs.useMamba === "true";
+  // The installer may have provisioned `mamba` in `base`: use if requested
+  options.useMamba =
+    conda.isMambaInstalled(options) && inputs.useMamba === "true";
 
   if (!fs.existsSync(basePath)) {
     throw Error(`No installed conda 'base' enviroment found at ${basePath}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,10 +79,14 @@ export interface IActionInputs {
   readonly condaVersion: string;
   readonly environmentFile: string;
   readonly installerUrl: string;
+  readonly mambaInInstaller: string;
   readonly mambaVersion: string;
   readonly minicondaVersion: string;
+  readonly miniforgeVariant: string;
+  readonly miniforgeVersion: string;
   readonly pythonVersion: string;
   readonly removeProfiles: string;
+  readonly useMamba: string;
 }
 
 /**
@@ -91,6 +95,7 @@ export interface IActionInputs {
 export interface IDynamicOptions {
   useBundled: boolean;
   useMamba: boolean;
+  mambaInInstaller: boolean;
   envSpec?: IEnvSpec;
   condaConfig: TCondaConfig;
 }
@@ -186,4 +191,24 @@ export interface IToolProvider {
     inputs: IActionInputs,
     options: IDynamicOptions
   ) => Promise<void>;
+}
+
+/** A release asset from the GitHub API */
+export interface IGithubAsset {
+  browser_download_url: string;
+  created_at: string;
+  name: string;
+}
+
+/** An asset with some extra metadata from the release */
+export interface IGithubAssetWithRelease extends IGithubAsset {
+  tag_name: string;
+}
+
+/** The body of the API request */
+export interface IGithubRelease {
+  assets: IGithubAsset[];
+  tag_name: string;
+  prerelease: boolean;
+  draft: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,6 @@ export interface IActionInputs {
   readonly condaVersion: string;
   readonly environmentFile: string;
   readonly installerUrl: string;
-  readonly mambaInInstaller: string;
   readonly mambaVersion: string;
   readonly minicondaVersion: string;
   readonly miniforgeVariant: string;


### PR DESCRIPTION
## Related
- one approach to #76

## Code Changes
- `download-miniforge.ts`
  - uses GitHub API to fetch releases (if version is not specified)... am trying to properly cache these, but i think there's some cache locality stuff
 - removes some dead code
 - tweaks provider logging to avoid constructions like `Can we use use conda create?`
- `conda.ts`
 - if `use-mamba` ~~and `mamba-in-installer`~~ is specified, will try to use `mamba` earlier in the process, but also catches things like `conda init` which _aren't_ supported by the `mamba` CLI yet
- `installer/index.ts`
  - now accepts (and can update) dynamic options, so that it can detect an installed `mamba`  
- `base-tools/index.ts`
  - splits up tool specs and post-install
- `upgrade-mamba.ts`
  - can no-up the upgrading, but we will _still_ want the mamba bash wrapper on windows without starting the solver)
- tests
  - adds workflow with a shotgun of different options to test out versions, interplay with other stuff 

## User-facing changes
- adds `miniforge-variant`, `miniforge-version`, to specify a Miniforge product
- adds ~~`mamba-in-installer`~~ and `use-mamba` to fine-tune use of Mambaforge
- updates the README, with some cross-links between mamba, custom installer, and this new provider

## Backwards-incompatible changes
N/A

## Follow-on

- with these changes, we're ready for `micromamba` (#75), but: 
  - the `mamba` CLI doesn't yet appear to support `init` for shell integration... 
    - perhaps we can hot-install `micromamba` into the bundled miniconda `bin` or `Scripts` or `condabin` or something?
- while our list of inputs (and therefore our README) is getting rather long, I think from a maintenance perspective, keeping _one_ action running that can do all the things is probably useful vs splitting effort (especially now that we've #107-ed ourselves to where we are now)
  - perhaps we should consider doing a real docs site, potentially with a little "wizard" for building up a workflow
  - or, start using the GitHub wiki or discussions