### PR TITLE
support miniforge-version: latest, add more architectures

### DIFF
--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -28,7 +28,7 @@ jobs:
         os: ["ubuntu", "macos", "windows"]
         include:
           - os: windows
-            miniforge-version: 4.9.2-4
+            miniforge-version: latest
     steps:
       - uses: actions/checkout@v2
       - uses: ./
@@ -67,7 +67,7 @@ jobs:
           - os: macos
             environment-file: etc/example-empty-channels-environment.yml
             miniforge-variant: Mambaforge-pypy3
-            miniforge-version: 4.9.2-4
+            miniforge-version: latest
           - os: windows
             environment-file: etc/example-explicit.Windows.conda.lock
             condarc-file: etc/example-condarc.yml

--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -26,16 +26,13 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu", "macos", "windows"]
-        include:
-          - os: windows
-            miniforge-version: latest
     steps:
       - uses: actions/checkout@v2
       - uses: ./
         id: setup-miniconda
         with:
           environment-file: etc/example-environment.yml
-          miniforge-version: ${{ matrix.miniforge-version }}
+          miniforge-version: latest
       - run: |
           conda info
           conda list

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ jobs:
         os: ["ubuntu", "macos", "windows"]
         include:
         - os: windows
-          miniforge-version: 4.9.2-4
+          miniforge-version: latest
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
@@ -398,7 +398,7 @@ In addition to `Miniforge3`, with `conda` and `CPython`, for each
 of its many supported platforms and architectures, additional variants including
 `Mambaforge` (which comes pre-installed `mamba` in addition to `conda` on all platforms)
 and `Miniforge-pypy3`/`Mamabaforge-pypy3` (which replace `CPython` with `pypy3`
-on Linux/MacOs) are available. The specific version can also be overridden.
+on Linux/MacOS) are available. A specific version can also be provided.
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -382,16 +382,12 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu", "macos", "windows"]
-        include:
-        - os: windows
-          miniforge-version: latest
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
-        id: setup-miniconda
         with:
           environment-file: etc/example-environment.yml
-          miniforge-version: ${{ matrix.miniforge-version }}
+          miniforge-version: latest
 ```
 
 In addition to `Miniforge3`, with `conda` and `CPython`, for each
@@ -424,7 +420,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
-        id: setup-miniconda
         with:
           condarc-file: ${{ matrix.condarc-file }}
           environment-file: ${{ matrix.environment-file }}

--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -1182,6 +1182,7 @@ exports.MINICONDA_ARCHITECTURES = {
 };
 /** Processor architectures supported by Miniforge */
 exports.MINIFORGE_ARCHITECTURES = {
+    x64: "x86_64",
     x86_64: "x86_64",
     aarch64: "aarch64",
     ppc64le: "ppc64le",

--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -1161,7 +1161,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_URL_PREFIX = exports.OS_NAMES = exports.ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
+exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_URL_PREFIX = exports.OS_NAMES = exports.MINIFORGE_ARCHITECTURES = exports.MINICONDA_ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 //-----------------------------------------------------------------------
@@ -1173,11 +1173,19 @@ exports.IS_MAC = process.platform === "darwin";
 exports.IS_LINUX = process.platform === "linux";
 exports.IS_UNIX = exports.IS_MAC || exports.IS_LINUX;
 exports.MINICONDA_BASE_URL = "https://repo.anaconda.com/miniconda/";
-exports.ARCHITECTURES = {
+/** Processor architectures supported by Miniconda */
+exports.MINICONDA_ARCHITECTURES = {
     x64: "x86_64",
     x86: "x86",
     ARM64: "aarch64",
     ARM32: "armv7l",
+};
+/** Processor architectures supported by Miniforge */
+exports.MINIFORGE_ARCHITECTURES = {
+    x86_64: "x86_64",
+    aarch64: "aarch64",
+    ppc64le: "ppc64le",
+    arm64: "arm64",
 };
 exports.OS_NAMES = {
     win32: "Windows",
@@ -1185,7 +1193,7 @@ exports.OS_NAMES = {
     linux: "Linux",
 };
 /** Common download prefix */
-exports.MINIFORGE_URL_PREFIX = "https://github.com/conda-forge/miniforge/releases/download";
+exports.MINIFORGE_URL_PREFIX = "https://github.com/conda-forge/miniforge/releases";
 /** Names for a conda `base` env */
 exports.BASE_ENV_NAMES = ["root", "base", ""];
 /**

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -34188,13 +34188,7 @@ function downloadMiniforge(inputs, options) {
         if (version === "latest") {
             // e.g. https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
             fileName = [tool, osName, `${arch}.${extension}`].join("-");
-            url = [
-                constants.MINIFORGE_URL_PREFIX,
-                "latest",
-                "download",
-                version,
-                fileName,
-            ].join("/");
+            url = [constants.MINIFORGE_URL_PREFIX, version, "download", fileName].join("/");
         }
         else {
             // e.g. https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-Linux-x86_64.sh

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -9358,7 +9358,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_URL_PREFIX = exports.OS_NAMES = exports.ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
+exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_URL_PREFIX = exports.OS_NAMES = exports.MINIFORGE_ARCHITECTURES = exports.MINICONDA_ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 //-----------------------------------------------------------------------
@@ -9370,11 +9370,19 @@ exports.IS_MAC = process.platform === "darwin";
 exports.IS_LINUX = process.platform === "linux";
 exports.IS_UNIX = exports.IS_MAC || exports.IS_LINUX;
 exports.MINICONDA_BASE_URL = "https://repo.anaconda.com/miniconda/";
-exports.ARCHITECTURES = {
+/** Processor architectures supported by Miniconda */
+exports.MINICONDA_ARCHITECTURES = {
     x64: "x86_64",
     x86: "x86",
     ARM64: "aarch64",
     ARM32: "armv7l",
+};
+/** Processor architectures supported by Miniforge */
+exports.MINIFORGE_ARCHITECTURES = {
+    x86_64: "x86_64",
+    aarch64: "aarch64",
+    ppc64le: "ppc64le",
+    arm64: "arm64",
 };
 exports.OS_NAMES = {
     win32: "Windows",
@@ -9382,7 +9390,7 @@ exports.OS_NAMES = {
     linux: "Linux",
 };
 /** Common download prefix */
-exports.MINIFORGE_URL_PREFIX = "https://github.com/conda-forge/miniforge/releases/download";
+exports.MINIFORGE_URL_PREFIX = "https://github.com/conda-forge/miniforge/releases";
 /** Names for a conda `base` env */
 exports.BASE_ENV_NAMES = ["root", "base", ""];
 /**
@@ -28242,7 +28250,7 @@ function minicondaVersions(arch) {
 function downloadMiniconda(pythonMajorVersion, inputs) {
     return __awaiter(this, void 0, void 0, function* () {
         // Check valid arch
-        const arch = constants.ARCHITECTURES[inputs.architecture];
+        const arch = constants.MINICONDA_ARCHITECTURES[inputs.architecture];
         if (!arch) {
             throw new Error(`Invalid arch "${inputs.architecture}"!`);
         }
@@ -34166,7 +34174,7 @@ const base = __importStar(__webpack_require__(122));
 function downloadMiniforge(inputs, options) {
     return __awaiter(this, void 0, void 0, function* () {
         const version = inputs.miniforgeVersion.trim();
-        const arch = constants.ARCHITECTURES[inputs.architecture];
+        const arch = constants.MINIFORGE_ARCHITECTURES[inputs.architecture];
         // Check valid arch
         if (!arch) {
             throw new Error(`Invalid 'architecture: ${inputs.architecture}'`);
@@ -34174,8 +34182,24 @@ function downloadMiniforge(inputs, options) {
         const tool = inputs.miniforgeVariant.trim();
         const extension = constants.IS_UNIX ? "sh" : "exe";
         const osName = constants.OS_NAMES[process.platform];
-        const fileName = [tool, version, osName, `${arch}.${extension}`].join("-");
-        const url = [constants.MINIFORGE_URL_PREFIX, version, fileName].join("/");
+        let fileName;
+        let url;
+        if (version === "latest") {
+            // e.g. https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+            fileName = [tool, osName, `${arch}.${extension}`].join("-");
+            url = [
+                constants.MINIFORGE_URL_PREFIX,
+                "latest",
+                "download",
+                version,
+                fileName,
+            ].join("/");
+        }
+        else {
+            // e.g. https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-Linux-x86_64.sh
+            fileName = [tool, version, osName, `${arch}.${extension}`].join("-");
+            url = [constants.MINIFORGE_URL_PREFIX, "download", version, fileName].join("/");
+        }
         core.info(`Will fetch ${tool} ${version} from ${url}`);
         return yield base.ensureLocalInstaller({ url, tool, version, arch });
     });

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -9379,6 +9379,7 @@ exports.MINICONDA_ARCHITECTURES = {
 };
 /** Processor architectures supported by Miniforge */
 exports.MINIFORGE_ARCHITECTURES = {
+    x64: "x86_64",
     x86_64: "x86_64",
     aarch64: "aarch64",
     ppc64le: "ppc64le",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,11 +15,20 @@ export const IS_UNIX: boolean = IS_MAC || IS_LINUX;
 export const MINICONDA_BASE_URL: string =
   "https://repo.anaconda.com/miniconda/";
 
-export const ARCHITECTURES: types.IArchitectures = {
+/** Processor architectures supported by Miniconda */
+export const MINICONDA_ARCHITECTURES: types.IArchitectures = {
   x64: "x86_64",
   x86: "x86",
   ARM64: "aarch64", // To be supported by github runners
   ARM32: "armv7l", // To be supported by github runners
+};
+
+/** Processor architectures supported by Miniforge */
+export const MINIFORGE_ARCHITECTURES: types.IArchitectures = {
+  x86_64: "x86_64",
+  aarch64: "aarch64", // To be supported by github runners
+  ppc64le: "ppc64le", // To be supported by github runners
+  arm64: "arm64", // To be supported by github runners
 };
 
 export const OS_NAMES: types.IOperatingSystems = {
@@ -30,7 +39,7 @@ export const OS_NAMES: types.IOperatingSystems = {
 
 /** Common download prefix */
 export const MINIFORGE_URL_PREFIX =
-  "https://github.com/conda-forge/miniforge/releases/download";
+  "https://github.com/conda-forge/miniforge/releases";
 
 /** Names for a conda `base` env */
 export const BASE_ENV_NAMES = ["root", "base", ""];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,7 @@ export const MINICONDA_ARCHITECTURES: types.IArchitectures = {
 
 /** Processor architectures supported by Miniforge */
 export const MINIFORGE_ARCHITECTURES: types.IArchitectures = {
+  x64: "x86_64",
   x86_64: "x86_64",
   aarch64: "aarch64", // To be supported by github runners
   ppc64le: "ppc64le", // To be supported by github runners

--- a/src/installer/download-miniconda.ts
+++ b/src/installer/download-miniconda.ts
@@ -47,7 +47,7 @@ export async function downloadMiniconda(
   inputs: types.IActionInputs
 ): Promise<string> {
   // Check valid arch
-  const arch: string = constants.ARCHITECTURES[inputs.architecture];
+  const arch: string = constants.MINICONDA_ARCHITECTURES[inputs.architecture];
   if (!arch) {
     throw new Error(`Invalid arch "${inputs.architecture}"!`);
   }

--- a/src/installer/download-miniforge.ts
+++ b/src/installer/download-miniforge.ts
@@ -29,13 +29,9 @@ export async function downloadMiniforge(
   if (version === "latest") {
     // e.g. https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
     fileName = [tool, osName, `${arch}.${extension}`].join("-");
-    url = [
-      constants.MINIFORGE_URL_PREFIX,
-      "latest",
-      "download",
-      version,
-      fileName,
-    ].join("/");
+    url = [constants.MINIFORGE_URL_PREFIX, version, "download", fileName].join(
+      "/"
+    );
   } else {
     // e.g. https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-Linux-x86_64.sh
     fileName = [tool, version, osName, `${arch}.${extension}`].join("-");

--- a/src/installer/download-miniforge.ts
+++ b/src/installer/download-miniforge.ts
@@ -13,7 +13,7 @@ export async function downloadMiniforge(
   options: types.IDynamicOptions
 ): Promise<string> {
   const version = inputs.miniforgeVersion.trim();
-  const arch = constants.ARCHITECTURES[inputs.architecture];
+  const arch = constants.MINIFORGE_ARCHITECTURES[inputs.architecture];
 
   // Check valid arch
   if (!arch) {
@@ -23,8 +23,26 @@ export async function downloadMiniforge(
   const tool = inputs.miniforgeVariant.trim();
   const extension = constants.IS_UNIX ? "sh" : "exe";
   const osName = constants.OS_NAMES[process.platform];
-  const fileName = [tool, version, osName, `${arch}.${extension}`].join("-");
-  const url = [constants.MINIFORGE_URL_PREFIX, version, fileName].join("/");
+
+  let fileName: string;
+  let url: string;
+  if (version === "latest") {
+    // e.g. https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+    fileName = [tool, osName, `${arch}.${extension}`].join("-");
+    url = [
+      constants.MINIFORGE_URL_PREFIX,
+      "latest",
+      "download",
+      version,
+      fileName,
+    ].join("/");
+  } else {
+    // e.g. https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Miniforge3-4.9.2-5-Linux-x86_64.sh
+    fileName = [tool, version, osName, `${arch}.${extension}`].join("-");
+    url = [constants.MINIFORGE_URL_PREFIX, "download", version, fileName].join(
+      "/"
+    );
+  }
 
   core.info(`Will fetch ${tool} ${version} from ${url}`);
 


### PR DESCRIPTION
Happy New Miniforge :tada: ! Turns out we _can_ get `miniforge-version: latest` at a predictable (though _slightly_ different) URL.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/linking-to-releases

## Questions
- @goanpeca what's the motivation for the specific `arch` inputs on the miniconda architectures? On the miniforge ones, not knowing what to put, i just made it a pass-through, but renamed the constant so we don't get them mixed up...

## Code changes
- [x] supports the `latest` URL scheme
- [x] fills out rest of architectures supported by miniforge (I guess for self-hosted runners) 
- [x] docs
- [x] test