### PR TITLE
Handle unset miniforge-version

### DIFF
--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -65,10 +65,10 @@ jobs:
             environment-file: etc/example-empty-channels-environment.yml
             miniforge-variant: Mambaforge-pypy3
             miniforge-version: latest
+          # should use mamabforge `latest`
           - os: windows
             environment-file: etc/example-explicit.Windows.conda.lock
             condarc-file: etc/example-condarc.yml
-            miniforge-version: 4.9.2-4
             miniforge-variant: Mambaforge
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ jobs:
 alternatives to Miniconda, built from the ground up with `conda-forge` packages
 and with only `conda-forge` in its default channels.
 
+If only `miniforge-version` is provided, `Miniforge3` will be used.
+
 ```yaml
 jobs:
   example-10-miniforge:
@@ -390,11 +392,11 @@ jobs:
           miniforge-version: latest
 ```
 
-In addition to `Miniforge3`, with `conda` and `CPython`, for each
+In addition to `Miniforge3` with `conda` and `CPython`, for each
 of its many supported platforms and architectures, additional variants including
 `Mambaforge` (which comes pre-installed `mamba` in addition to `conda` on all platforms)
 and `Miniforge-pypy3`/`Mamabaforge-pypy3` (which replace `CPython` with `pypy3`
-on Linux/MacOS) are available. A specific version can also be provided.
+on Linux/MacOS) are available.
 
 ```yaml
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,7 @@ inputs:
   miniforge-variant:
     description:
       "If provided, this variant of Miniforge will be downloaded and installed.
+      If `miniforge-version` is not provided, the `latest` version will be used.
       Currently-known values:
       - Miniforge3 (default)
       - Miniforge-pypy3
@@ -27,11 +28,11 @@ inputs:
       Visit https://github.com/conda-forge/miniforge/releases/ for more information
       on available variants"
     required: false
-    default: "Miniforge3"
+    default: ""
   miniforge-version:
     description:
       "If provided, this version of the given Miniforge variant will be downloaded
-      and installed.
+      and installed. If `miniforge-variant` is not provided, `Miniforge3` will be used.
       Visit https://github.com/conda-forge/miniforge/releases/ for more information
       on available versions"
     required: false

--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -1161,7 +1161,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_URL_PREFIX = exports.OS_NAMES = exports.MINIFORGE_ARCHITECTURES = exports.MINICONDA_ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
+exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_DEFAULT_VERSION = exports.MINIFORGE_DEFAULT_VARIANT = exports.MINIFORGE_URL_PREFIX = exports.OS_NAMES = exports.MINIFORGE_ARCHITECTURES = exports.MINICONDA_ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 //-----------------------------------------------------------------------
@@ -1195,6 +1195,10 @@ exports.OS_NAMES = {
 };
 /** Common download prefix */
 exports.MINIFORGE_URL_PREFIX = "https://github.com/conda-forge/miniforge/releases";
+/** Default miniforge if only miniforge-version is provided */
+exports.MINIFORGE_DEFAULT_VARIANT = "Miniforge3";
+/** Default miniforge if only miniforge-variant is provided */
+exports.MINIFORGE_DEFAULT_VERSION = "latest";
 /** Names for a conda `base` env */
 exports.BASE_ENV_NAMES = ["root", "base", ""];
 /**

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -9358,7 +9358,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_URL_PREFIX = exports.OS_NAMES = exports.MINIFORGE_ARCHITECTURES = exports.MINICONDA_ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
+exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_DEFAULT_VERSION = exports.MINIFORGE_DEFAULT_VARIANT = exports.MINIFORGE_URL_PREFIX = exports.OS_NAMES = exports.MINIFORGE_ARCHITECTURES = exports.MINICONDA_ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 //-----------------------------------------------------------------------
@@ -9392,6 +9392,10 @@ exports.OS_NAMES = {
 };
 /** Common download prefix */
 exports.MINIFORGE_URL_PREFIX = "https://github.com/conda-forge/miniforge/releases";
+/** Default miniforge if only miniforge-version is provided */
+exports.MINIFORGE_DEFAULT_VARIANT = "Miniforge3";
+/** Default miniforge if only miniforge-variant is provided */
+exports.MINIFORGE_DEFAULT_VERSION = "latest";
 /** Names for a conda `base` env */
 exports.BASE_ENV_NAMES = ["root", "base", ""];
 /**
@@ -19181,6 +19185,7 @@ exports.bundledMinicondaUser = {
     label: "use bundled Miniconda",
     provides: (inputs, options) => __awaiter(void 0, void 0, void 0, function* () {
         return (inputs.minicondaVersion === "" &&
+            inputs.miniforgeVariant === "" &&
             inputs.miniforgeVersion === "" &&
             inputs.architecture === "x64" &&
             inputs.installerUrl === "");
@@ -34174,13 +34179,13 @@ const base = __importStar(__webpack_require__(122));
  */
 function downloadMiniforge(inputs, options) {
     return __awaiter(this, void 0, void 0, function* () {
-        const version = inputs.miniforgeVersion.trim();
+        const tool = inputs.miniforgeVariant.trim() || constants.MINIFORGE_DEFAULT_VARIANT;
+        const version = inputs.miniforgeVersion.trim() || constants.MINIFORGE_DEFAULT_VERSION;
         const arch = constants.MINIFORGE_ARCHITECTURES[inputs.architecture];
         // Check valid arch
         if (!arch) {
             throw new Error(`Invalid 'architecture: ${inputs.architecture}'`);
         }
-        const tool = inputs.miniforgeVariant.trim();
         const extension = constants.IS_UNIX ? "sh" : "exe";
         const osName = constants.OS_NAMES[process.platform];
         let fileName;
@@ -34209,7 +34214,7 @@ exports.downloadMiniforge = downloadMiniforge;
  */
 exports.miniforgeDownloader = {
     label: "download Miniforge",
-    provides: (inputs, options) => __awaiter(void 0, void 0, void 0, function* () { return inputs.miniforgeVersion !== ""; }),
+    provides: (inputs, options) => __awaiter(void 0, void 0, void 0, function* () { return inputs.miniforgeVersion !== "" || inputs.miniforgeVariant !== ""; }),
     installerPath: (inputs, options) => __awaiter(void 0, void 0, void 0, function* () {
         return {
             localInstallerPath: yield downloadMiniforge(inputs, options),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,12 @@ export const OS_NAMES: types.IOperatingSystems = {
 export const MINIFORGE_URL_PREFIX =
   "https://github.com/conda-forge/miniforge/releases";
 
+/** Default miniforge if only miniforge-version is provided */
+export const MINIFORGE_DEFAULT_VARIANT = "Miniforge3";
+
+/** Default miniforge if only miniforge-variant is provided */
+export const MINIFORGE_DEFAULT_VERSION = "latest";
+
 /** Names for a conda `base` env */
 export const BASE_ENV_NAMES = ["root", "base", ""];
 

--- a/src/installer/bundled-miniconda.ts
+++ b/src/installer/bundled-miniconda.ts
@@ -12,6 +12,7 @@ export const bundledMinicondaUser: types.IInstallerProvider = {
   provides: async (inputs, options) => {
     return (
       inputs.minicondaVersion === "" &&
+      inputs.miniforgeVariant === "" &&
       inputs.miniforgeVersion === "" &&
       inputs.architecture === "x64" &&
       inputs.installerUrl === ""

--- a/src/installer/download-miniforge.ts
+++ b/src/installer/download-miniforge.ts
@@ -12,7 +12,10 @@ export async function downloadMiniforge(
   inputs: types.IActionInputs,
   options: types.IDynamicOptions
 ): Promise<string> {
-  const version = inputs.miniforgeVersion.trim();
+  const tool =
+    inputs.miniforgeVariant.trim() || constants.MINIFORGE_DEFAULT_VARIANT;
+  const version =
+    inputs.miniforgeVersion.trim() || constants.MINIFORGE_DEFAULT_VERSION;
   const arch = constants.MINIFORGE_ARCHITECTURES[inputs.architecture];
 
   // Check valid arch
@@ -20,7 +23,6 @@ export async function downloadMiniforge(
     throw new Error(`Invalid 'architecture: ${inputs.architecture}'`);
   }
 
-  const tool = inputs.miniforgeVariant.trim();
   const extension = constants.IS_UNIX ? "sh" : "exe";
   const osName = constants.OS_NAMES[process.platform];
 
@@ -54,7 +56,8 @@ export async function downloadMiniforge(
  */
 export const miniforgeDownloader: types.IInstallerProvider = {
   label: "download Miniforge",
-  provides: async (inputs, options) => inputs.miniforgeVersion !== "",
+  provides: async (inputs, options) =>
+    inputs.miniforgeVersion !== "" || inputs.miniforgeVariant !== "",
   installerPath: async (inputs, options) => {
     return {
       localInstallerPath: await downloadMiniforge(inputs, options),


### PR DESCRIPTION
Setting `miniforge-variant` but _not_ setting `miniforge-version` doesn't use that variant.

- fixes #145
- [x] test
  - [repro](https://github.com/conda-incubator/setup-miniconda/pull/146/checks?check_run_id=1839861005#step:4:10) on 3da7dcf:  `mamba: command not found`
- [x] fix
- [x] docs