### PR TITLE
Remove line preventing the use of 32 bit version on Linux

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -61,9 +61,6 @@ const RULES: IRule[] = [
   (i) =>
     !!(i.minicondaVersion && i.architecture !== "x64") &&
     `'architecture: ${i.architecture}' requires "miniconda-version"`,
-  (i) =>
-    !!(i.architecture === "x86" && constants.IS_LINUX) &&
-    `'architecture: ${i.architecture}' is not supported by recent versions of Miniconda`,
 ];
 
 /*


### PR DESCRIPTION
Line prevented all use of `architecture: x86` and Linux distributions outright, which is not reasonable. While it is true that 32-bit version of Miniconda have not been produce in a while: 1) This isn't the right way to implement that check, it should be a warning at worst. 2) It shouldn't apply to specific version, only when 'latest' is specified; but it currently applies to *all* versions. ~~3) 'latest' is still the only way to refer to the latest release of Miniconda. There is no version alias for that release (AFAICT, based on dates).~~

Closes #147.