### PR TITLE
Fix path handling inconsistency in installer caching

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -6948,9 +6948,11 @@ function ensureLocalInstaller(options) {
         }
         if (executablePath === "") {
             core.info(`Checking for cached ${tool}@${version}...`);
-            executablePath = tc.find(installerName, version, ...(options.arch ? [options.arch] : []));
-            if (executablePath !== "") {
-                core.info(`Found ${installerName} cache at ${executablePath}!`);
+            let cacheDirectoryPath = tc.find(installerName, version, ...(options.arch ? [options.arch] : []));
+            if (cacheDirectoryPath !== "") {
+                core.info(`Found ${installerName} cache at ${cacheDirectoryPath}!`);
+                executablePath = cacheDirectoryPath + "/" + installerName;
+                core.info(`executablePath is ${executablePath}`);
             }
             else {
                 core.info(`Did not find ${installerName} ${version} in cache`);
@@ -24281,7 +24283,31 @@ module.exports = YAMLException;
 /* 559 */,
 /* 560 */,
 /* 561 */,
-/* 562 */,
+/* 562 */
+/***/ (function(module) {
+
+/** Used to match a single whitespace character. */
+var reWhitespace = /\s/;
+
+/**
+ * Used by `_.trim` and `_.trimEnd` to get the index of the last non-whitespace
+ * character of `string`.
+ *
+ * @private
+ * @param {string} string The string to inspect.
+ * @returns {number} Returns the index of the last non-whitespace character.
+ */
+function trimmedEndIndex(string) {
+  var index = string.length;
+
+  while (index-- && reWhitespace.test(string.charAt(index))) {}
+  return index;
+}
+
+module.exports = trimmedEndIndex;
+
+
+/***/ }),
 /* 563 */
 /***/ (function(module) {
 
@@ -32031,7 +32057,7 @@ module.exports.safeLoad    = safeLoad;
 /* 771 */
 /***/ (function(module) {
 
-module.exports = {"_args":[["cheerio@1.0.0-rc.3","/Users/jrodriguez/devel/setup-miniconda"]],"_from":"cheerio@1.0.0-rc.3","_id":"cheerio@1.0.0-rc.3","_inBundle":false,"_integrity":"sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==","_location":"/cheerio","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"cheerio@1.0.0-rc.3","name":"cheerio","escapedName":"cheerio","rawSpec":"1.0.0-rc.3","saveSpec":null,"fetchSpec":"1.0.0-rc.3"},"_requiredBy":["/get-hrefs"],"_resolved":"https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz","_spec":"1.0.0-rc.3","_where":"/Users/jrodriguez/devel/setup-miniconda","author":{"name":"Matt Mueller","email":"mattmuelle@gmail.com","url":"mat.io"},"bugs":{"url":"https://github.com/cheeriojs/cheerio/issues"},"dependencies":{"css-select":"~1.2.0","dom-serializer":"~0.1.1","entities":"~1.1.1","htmlparser2":"^3.9.1","lodash":"^4.15.0","parse5":"^3.0.1"},"description":"Tiny, fast, and elegant implementation of core jQuery designed specifically for the server","devDependencies":{"benchmark":"^2.1.0","coveralls":"^2.11.9","expect.js":"~0.3.1","istanbul":"^0.4.3","jquery":"^3.0.0","jsdom":"^9.2.1","jshint":"^2.9.2","mocha":"^3.1.2","xyz":"~1.1.0"},"engines":{"node":">= 0.6"},"files":["index.js","lib"],"homepage":"https://github.com/cheeriojs/cheerio#readme","keywords":["htmlparser","jquery","selector","scraper","parser","html"],"license":"MIT","main":"./index.js","name":"cheerio","repository":{"type":"git","url":"git://github.com/cheeriojs/cheerio.git"},"scripts":{"test":"make test"},"version":"1.0.0-rc.3"};
+module.exports = {"_args":[["cheerio@1.0.0-rc.3","/work"]],"_from":"cheerio@1.0.0-rc.3","_id":"cheerio@1.0.0-rc.3","_inBundle":false,"_integrity":"sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==","_location":"/cheerio","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"cheerio@1.0.0-rc.3","name":"cheerio","escapedName":"cheerio","rawSpec":"1.0.0-rc.3","saveSpec":null,"fetchSpec":"1.0.0-rc.3"},"_requiredBy":["/get-hrefs"],"_resolved":"https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz","_spec":"1.0.0-rc.3","_where":"/work","author":{"name":"Matt Mueller","email":"mattmuelle@gmail.com","url":"mat.io"},"bugs":{"url":"https://github.com/cheeriojs/cheerio/issues"},"dependencies":{"css-select":"~1.2.0","dom-serializer":"~0.1.1","entities":"~1.1.1","htmlparser2":"^3.9.1","lodash":"^4.15.0","parse5":"^3.0.1"},"description":"Tiny, fast, and elegant implementation of core jQuery designed specifically for the server","devDependencies":{"benchmark":"^2.1.0","coveralls":"^2.11.9","expect.js":"~0.3.1","istanbul":"^0.4.3","jquery":"^3.0.0","jsdom":"^9.2.1","jshint":"^2.9.2","mocha":"^3.1.2","xyz":"~1.1.0"},"engines":{"node":">= 0.6"},"files":["index.js","lib"],"homepage":"https://github.com/cheeriojs/cheerio#readme","keywords":["htmlparser","jquery","selector","scraper","parser","html"],"license":"MIT","main":"./index.js","name":"cheerio","repository":{"type":"git","url":"git://github.com/cheeriojs/cheerio.git"},"scripts":{"test":"make test"},"version":"1.0.0-rc.3"};
 
 /***/ }),
 /* 772 */
@@ -32263,14 +32289,12 @@ module.exports = getWrapDetails;
 /* 790 */
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
-var isObject = __webpack_require__(988),
+var baseTrim = __webpack_require__(984),
+    isObject = __webpack_require__(988),
     isSymbol = __webpack_require__(186);
 
 /** Used as references for various `Number` constants. */
 var NAN = 0 / 0;
-
-/** Used to match leading and trailing whitespace. */
-var reTrim = /^\s+|\s+$/g;
 
 /** Used to detect bad signed hexadecimal string values. */
 var reIsBadHex = /^[-+]0x[0-9a-f]+$/i;
@@ -32321,7 +32345,7 @@ function toNumber(value) {
   if (typeof value != 'string') {
     return value === 0 ? value : +value;
   }
-  value = value.replace(reTrim, '');
+  value = baseTrim(value);
   var isBinary = reIsBinary.test(value);
   return (isBinary || reIsOctal.test(value))
     ? freeParseInt(value.slice(2), isBinary ? 2 : 8)
@@ -38413,7 +38437,31 @@ module.exports = cacheHas;
 
 
 /***/ }),
-/* 984 */,
+/* 984 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+var trimmedEndIndex = __webpack_require__(562);
+
+/** Used to match leading whitespace. */
+var reTrimStart = /^\s+/;
+
+/**
+ * The base implementation of `_.trim`.
+ *
+ * @private
+ * @param {string} string The string to trim.
+ * @returns {string} Returns the trimmed string.
+ */
+function baseTrim(string) {
+  return string
+    ? string.slice(0, trimmedEndIndex(string) + 1).replace(reTrimStart, '')
+    : string;
+}
+
+module.exports = baseTrim;
+
+
+/***/ }),
 /* 985 */
 /***/ (function(module, __unusedexports, __webpack_require__) {
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -6951,7 +6951,7 @@ function ensureLocalInstaller(options) {
             let cacheDirectoryPath = tc.find(installerName, version, ...(options.arch ? [options.arch] : []));
             if (cacheDirectoryPath !== "") {
                 core.info(`Found ${installerName} cache at ${cacheDirectoryPath}!`);
-                executablePath = cacheDirectoryPath + "/" + installerName;
+                executablePath = path.join(cacheDirectoryPath, installerName);
                 core.info(`executablePath is ${executablePath}`);
             }
             else {
@@ -24283,31 +24283,7 @@ module.exports = YAMLException;
 /* 559 */,
 /* 560 */,
 /* 561 */,
-/* 562 */
-/***/ (function(module) {
-
-/** Used to match a single whitespace character. */
-var reWhitespace = /\s/;
-
-/**
- * Used by `_.trim` and `_.trimEnd` to get the index of the last non-whitespace
- * character of `string`.
- *
- * @private
- * @param {string} string The string to inspect.
- * @returns {number} Returns the index of the last non-whitespace character.
- */
-function trimmedEndIndex(string) {
-  var index = string.length;
-
-  while (index-- && reWhitespace.test(string.charAt(index))) {}
-  return index;
-}
-
-module.exports = trimmedEndIndex;
-
-
-/***/ }),
+/* 562 */,
 /* 563 */
 /***/ (function(module) {
 
@@ -32289,12 +32265,14 @@ module.exports = getWrapDetails;
 /* 790 */
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
-var baseTrim = __webpack_require__(984),
-    isObject = __webpack_require__(988),
+var isObject = __webpack_require__(988),
     isSymbol = __webpack_require__(186);
 
 /** Used as references for various `Number` constants. */
 var NAN = 0 / 0;
+
+/** Used to match leading and trailing whitespace. */
+var reTrim = /^\s+|\s+$/g;
 
 /** Used to detect bad signed hexadecimal string values. */
 var reIsBadHex = /^[-+]0x[0-9a-f]+$/i;
@@ -32345,7 +32323,7 @@ function toNumber(value) {
   if (typeof value != 'string') {
     return value === 0 ? value : +value;
   }
-  value = baseTrim(value);
+  value = value.replace(reTrim, '');
   var isBinary = reIsBinary.test(value);
   return (isBinary || reIsOctal.test(value))
     ? freeParseInt(value.slice(2), isBinary ? 2 : 8)
@@ -38437,31 +38415,7 @@ module.exports = cacheHas;
 
 
 /***/ }),
-/* 984 */
-/***/ (function(module, __unusedexports, __webpack_require__) {
-
-var trimmedEndIndex = __webpack_require__(562);
-
-/** Used to match leading whitespace. */
-var reTrimStart = /^\s+/;
-
-/**
- * The base implementation of `_.trim`.
- *
- * @private
- * @param {string} string The string to trim.
- * @returns {string} Returns the trimmed string.
- */
-function baseTrim(string) {
-  return string
-    ? string.slice(0, trimmedEndIndex(string) + 1).replace(reTrimStart, '')
-    : string;
-}
-
-module.exports = baseTrim;
-
-
-/***/ }),
+/* 984 */,
 /* 985 */
 /***/ (function(module, __unusedexports, __webpack_require__) {
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -6948,9 +6948,13 @@ function ensureLocalInstaller(options) {
         }
         if (executablePath === "") {
             core.info(`Checking for cached ${tool}@${version}...`);
+            // tc.find returns the name of the directory in which
+            // the cached file is located.
             let cacheDirectoryPath = tc.find(installerName, version, ...(options.arch ? [options.arch] : []));
             if (cacheDirectoryPath !== "") {
                 core.info(`Found ${installerName} cache at ${cacheDirectoryPath}!`);
+                // Append the basename of the cached file to the directory
+                // returned by tc.find
                 executablePath = path.join(cacheDirectoryPath, installerName);
                 core.info(`executablePath is ${executablePath}`);
             }

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -46,13 +46,15 @@ export async function ensureLocalInstaller(
 
   if (executablePath === "") {
     core.info(`Checking for cached ${tool}@${version}...`);
-    executablePath = tc.find(
+    let cacheDirectoryPath = tc.find(
       installerName,
       version,
       ...(options.arch ? [options.arch] : [])
     );
-    if (executablePath !== "") {
-      core.info(`Found ${installerName} cache at ${executablePath}!`);
+    if (cacheDirectoryPath !== "") {
+      core.info(`Found ${installerName} cache at ${cacheDirectoryPath}!`);
+      executablePath = cacheDirectoryPath + "/" + installerName;
+      core.info(`executablePath is ${executablePath}`);
     } else {
       core.info(`Did not find ${installerName} ${version} in cache`);
     }

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -46,6 +46,8 @@ export async function ensureLocalInstaller(
 
   if (executablePath === "") {
     core.info(`Checking for cached ${tool}@${version}...`);
+    // tc.find returns the name of the directory in which
+    // the cached file is located.
     let cacheDirectoryPath = tc.find(
       installerName,
       version,
@@ -53,6 +55,9 @@ export async function ensureLocalInstaller(
     );
     if (cacheDirectoryPath !== "") {
       core.info(`Found ${installerName} cache at ${cacheDirectoryPath}!`);
+
+      // Append the basename of the cached file to the directory
+      // returned by tc.find
       executablePath = path.join(cacheDirectoryPath, installerName);
       core.info(`executablePath is ${executablePath}`);
     } else {

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -53,7 +53,7 @@ export async function ensureLocalInstaller(
     );
     if (cacheDirectoryPath !== "") {
       core.info(`Found ${installerName} cache at ${cacheDirectoryPath}!`);
-      executablePath = cacheDirectoryPath + "/" + installerName;
+      executablePath = path.join([cacheDirectoryPath, installerName]);
       core.info(`executablePath is ${executablePath}`);
     } else {
       core.info(`Did not find ${installerName} ${version} in cache`);

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -53,7 +53,7 @@ export async function ensureLocalInstaller(
     );
     if (cacheDirectoryPath !== "") {
       core.info(`Found ${installerName} cache at ${cacheDirectoryPath}!`);
-      executablePath = path.join([cacheDirectoryPath, installerName]);
+      executablePath = path.join(cacheDirectoryPath, installerName);
       core.info(`executablePath is ${executablePath}`);
     } else {
       core.info(`Did not find ${installerName} ${version} in cache`);


### PR DESCRIPTION
**Problem**: The current implementation of installer executable caching is located [here](https://github.com/conda-incubator/setup-miniconda/blob/develop/src/installer/base.ts#L47-L59). The code aims to determine `executablePath`, which is supposed to be the full local path (e.g. `/path/to/script.extension`) to the installer script. However, in the case where the installer script is found in the cache, `executablePath` is set to the return value of `tc.find`. This is inconsistent with the goal since `tc.find` returns a directory name (e.g. `/path/to/`) without the basename of the actual script. This inconsistency subsequently leads to failures because the `executablePath` does not end in a known executable extension, which is explicitly checked. 

**Proposed fix**: Manually append the basename of the installer to the executable path in the case where `tc.find` is used.

**Testing / Demonstration**: The broken behavior as well as the fixed one can be seen in [this test repo](https://github.com/AndreasAlbertQC/setup-miniconda-cache-test/actions/runs/2357337092), where example 5 from the setup-miniconda readme is run three times with identical job definitions. The only difference between the jobs is the version of setup-miniconda that is used: the tagged v2 version, the HEAD of the develop branch, or my proposed fixed version from this PR. The first two fail with the error described above, the PR version runs without error.

**Note**: It seems to me that one only encounters this problem with self-hosted github actions runners. When I tried to reproduce the problem with GitHub-hosted runners, I find that the problematic piece of code is never executed because the installer script is never found in the cache, even if a previous job in the same workflow logs a message saying it was cached. It therefore appears that the cache directory is not persistent between jobs in the case of GitHub-hosted runners, and no caching is ever done successfully. While this does not lead to errors, it still seems to be an independent issue of its own.
