### PR TITLE
chore: use Node.js 16 instead of deprecated Node.js 12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: Gonzalo Peña-Castellanos (@goanpeca)
 description: "Set up Conda package and environment manager with Miniconda."
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/setup/index.js"
   post: "dist/delete/index.js"
   post-if: "success()"


### PR DESCRIPTION
<img width="1406" alt="image" src="https://user-images.githubusercontent.com/17984549/199589428-f51b3cc0-322b-4bff-9498-024f7956f0ad.png">

Fixes https://github.com/conda-incubator/setup-miniconda/issues/248