### PR TITLE
ENH: capability to trust bundled conda

### DIFF
--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -3984,13 +3984,14 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.OUTPUT_ENV_FILE_WAS_PATCHED = exports.OUTPUT_ENV_FILE_CONTENT = exports.OUTPUT_ENV_FILE_PATH = exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_DEFAULT_VERSION = exports.MINIFORGE_DEFAULT_VARIANT = exports.MINIFORGE_URL_PREFIX = exports.OS_NAMES = exports.MINIFORGE_ARCHITECTURES = exports.MINICONDA_ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
+exports.OUTPUT_ENV_FILE_WAS_PATCHED = exports.OUTPUT_ENV_FILE_CONTENT = exports.OUTPUT_ENV_FILE_PATH = exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_DEFAULT_VERSION = exports.MINIFORGE_DEFAULT_VARIANT = exports.MINIFORGE_URL_PREFIX = exports.OS_NAMES = exports.MINIFORGE_ARCHITECTURES = exports.MINICONDA_ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.TRUST_BUNDLED = exports.MINICONDA_DIR_PATH = void 0;
 const os = __importStar(__nccwpck_require__(37));
 const path = __importStar(__nccwpck_require__(17));
 //-----------------------------------------------------------------------
 // Constants
 //-----------------------------------------------------------------------
 exports.MINICONDA_DIR_PATH = process.env["CONDA"] || "";
+exports.TRUST_BUNDLED = process.env["TRUST_CONDA"] === "true" || false;
 exports.IS_WINDOWS = process.platform === "win32";
 exports.IS_MAC = process.platform === "darwin";
 exports.IS_LINUX = process.platform === "linux";

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -25094,7 +25094,7 @@ const utils = __importStar(__nccwpck_require__(1314));
  */
 function condaBasePath(options) {
     let condaPath = constants.MINICONDA_DIR_PATH;
-    if (!options.useBundled) {
+    if (!options.useBundled && !constants.TRUST_BUNDLED) {
         if (constants.IS_MAC) {
             condaPath = "/Users/runner/miniconda3";
         }
@@ -25137,6 +25137,7 @@ exports.condaExecutable = condaExecutable;
 /** Detect the presence of mamba */
 function isMambaInstalled(options) {
     const mamba = condaExecutable(Object.assign(Object.assign({}, options), { useMamba: true }));
+    core.info("testing existence: ${mamba}, trust: ${constants.TRUST_BUNDLED}");
     return fs.existsSync(mamba);
 }
 exports.isMambaInstalled = isMambaInstalled;
@@ -25392,13 +25393,14 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.OUTPUT_ENV_FILE_WAS_PATCHED = exports.OUTPUT_ENV_FILE_CONTENT = exports.OUTPUT_ENV_FILE_PATH = exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_DEFAULT_VERSION = exports.MINIFORGE_DEFAULT_VARIANT = exports.MINIFORGE_URL_PREFIX = exports.OS_NAMES = exports.MINIFORGE_ARCHITECTURES = exports.MINICONDA_ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.MINICONDA_DIR_PATH = void 0;
+exports.OUTPUT_ENV_FILE_WAS_PATCHED = exports.OUTPUT_ENV_FILE_CONTENT = exports.OUTPUT_ENV_FILE_PATH = exports.PYTHON_SPEC = exports.WIN_PERMS_FOLDERS = exports.PROFILES = exports.ENV_VAR_CONDA_PKGS = exports.CONDA_CACHE_FOLDER = exports.CONDARC_PATH = exports.BOOTSTRAP_CONDARC = exports.FORCED_ERRORS = exports.IGNORED_WARNINGS = exports.MAMBA_SUBCOMMANDS = exports.KNOWN_EXTENSIONS = exports.BASE_ENV_NAMES = exports.MINIFORGE_DEFAULT_VERSION = exports.MINIFORGE_DEFAULT_VARIANT = exports.MINIFORGE_URL_PREFIX = exports.OS_NAMES = exports.MINIFORGE_ARCHITECTURES = exports.MINICONDA_ARCHITECTURES = exports.MINICONDA_BASE_URL = exports.IS_UNIX = exports.IS_LINUX = exports.IS_MAC = exports.IS_WINDOWS = exports.TRUST_BUNDLED = exports.MINICONDA_DIR_PATH = void 0;
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
 //-----------------------------------------------------------------------
 // Constants
 //-----------------------------------------------------------------------
 exports.MINICONDA_DIR_PATH = process.env["CONDA"] || "";
+exports.TRUST_BUNDLED = process.env["TRUST_CONDA"] === "true" || false;
 exports.IS_WINDOWS = process.platform === "win32";
 exports.IS_MAC = process.platform === "darwin";
 exports.IS_LINUX = process.platform === "linux";

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -26765,7 +26765,7 @@ function setupMiniconda(inputs) {
     return __awaiter(this, void 0, void 0, function* () {
         let options = {
             useBundled: true,
-            useMamba: false,
+            useMamba: constants.TRUST_BUNDLED ? inputs.useMamba === "true" : false,
             mambaInInstaller: false,
             condaConfig: Object.assign({}, inputs.condaConfig),
         };

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -25137,7 +25137,6 @@ exports.condaExecutable = condaExecutable;
 /** Detect the presence of mamba */
 function isMambaInstalled(options) {
     const mamba = condaExecutable(Object.assign(Object.assign({}, options), { useMamba: true }));
-    core.info("testing existence: ${mamba}, trust: ${constants.TRUST_BUNDLED}");
     return fs.existsSync(mamba);
 }
 exports.isMambaInstalled = isMambaInstalled;

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -65,7 +65,6 @@ export function condaExecutable(
 /** Detect the presence of mamba */
 export function isMambaInstalled(options: types.IDynamicOptions) {
   const mamba = condaExecutable({ ...options, useMamba: true });
-  core.info("testing existence: ${mamba}, trust: ${constants.TRUST_BUNDLED}");
   return fs.existsSync(mamba);
 }
 

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -65,6 +65,7 @@ export function condaExecutable(
 /** Detect the presence of mamba */
 export function isMambaInstalled(options: types.IDynamicOptions) {
   const mamba = condaExecutable({ ...options, useMamba: true });
+  core.info('testing existence: ${mamba}, trust: ${constants.TRUST_BUNDLED}');
   return fs.existsSync(mamba);
 }
 

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -65,7 +65,7 @@ export function condaExecutable(
 /** Detect the presence of mamba */
 export function isMambaInstalled(options: types.IDynamicOptions) {
   const mamba = condaExecutable({ ...options, useMamba: true });
-  core.info('testing existence: ${mamba}, trust: ${constants.TRUST_BUNDLED}');
+  core.info("testing existence: ${mamba}, trust: ${constants.TRUST_BUNDLED}");
   return fs.existsSync(mamba);
 }
 

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -18,7 +18,7 @@ import * as utils from "./utils";
  */
 export function condaBasePath(options: types.IDynamicOptions): string {
   let condaPath: string = constants.MINICONDA_DIR_PATH;
-  if (!options.useBundled) {
+  if (!options.useBundled && !constants.TRUST_BUNDLED) {
     if (constants.IS_MAC) {
       condaPath = "/Users/runner/miniconda3";
     } else {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ import * as types from "./types";
 // Constants
 //-----------------------------------------------------------------------
 export const MINICONDA_DIR_PATH: string = process.env["CONDA"] || "";
+export const TRUST_BUNDLED: boolean = process.env["TRUST_CONDA"] === "true" || false;
 export const IS_WINDOWS: boolean = process.platform === "win32";
 export const IS_MAC: boolean = process.platform === "darwin";
 export const IS_LINUX: boolean = process.platform === "linux";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,8 @@ import * as types from "./types";
 // Constants
 //-----------------------------------------------------------------------
 export const MINICONDA_DIR_PATH: string = process.env["CONDA"] || "";
-export const TRUST_BUNDLED: boolean = process.env["TRUST_CONDA"] === "true" || false;
+export const TRUST_BUNDLED: boolean =
+  process.env["TRUST_CONDA"] === "true" || false;
 export const IS_WINDOWS: boolean = process.platform === "win32";
 export const IS_MAC: boolean = process.platform === "darwin";
 export const IS_LINUX: boolean = process.platform === "linux";

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -17,7 +17,7 @@ import * as baseTools from "./base-tools";
 async function setupMiniconda(inputs: types.IActionInputs): Promise<void> {
   let options: types.IDynamicOptions = {
     useBundled: true,
-    useMamba: false,
+    useMamba: constants.TRUST_BUNDLED ? inputs.useMamba === "true" : false,
     mambaInInstaller: false,
     condaConfig: { ...inputs.condaConfig },
   };


### PR DESCRIPTION
I'm using https://github.com/nektos/act to run actions locally (actually pre-release capabilities).  The host / runner is a vagrant / ubuntu box where I have installed latest version of mamba forge.  Hence when using **setup-miniconda** action I want to use bundled conda / mamba and *trust* it so that it uses **mamba** if `use-mamba` parameter is set.

To keep with approach used for bundled where `CONDA` environment variable needs to be set, have added a second environment variable `TRUST_BUNDLED` which then means **mamba** will be used if installed and `use-mamba` is set.