### PR TITLE
Remove Python 2.7 from test matrix (EOL since  April 2020, >4 years)

### DIFF
--- a/.github/workflows/example-1.yml
+++ b/.github/workflows/example-1.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "2.7"]
+        python-version: ["3.8", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/.github/workflows/example-8.yml
+++ b/.github/workflows/example-8.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "2.7"]
+        python-version: ["3.8", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/.github/workflows/example-9.yml
+++ b/.github/workflows/example-9.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "2.7"]
+        python-version: ["3.8", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "2.7"]
+        python-version: ["3.7", "3.11"]
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -711,8 +711,7 @@ jobs:
   executed with `bash --noprofile --norc -eo pipefail {0}` thus ignoring updated
   on bash profile files made by `conda init bash`. See
   [Github Actions Documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#custom-shell)
-  and
-  [thread](https://github.com/orgs/community/discussions/25061).
+  and [thread](https://github.com/orgs/community/discussions/25061).
 - Sh shells do not use `~/.profile` or `~/.bashrc` so these shells need to be
   explicitely declared as `shell: sh -l {0}` on steps that need to be properly
   activated (or use a default shell). This is because sh shells are executed


### PR DESCRIPTION
Add Python 3.11 instead as upper bound test (can be upgraded to 3.12 soon).