### PR TITLE
Add dependabot config to update action versions in workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Creates PRs as they can be seen [here](https://github.com/dbast/setup-miniconda/pulls?q=is%3Apr+is%3Aopen+label%3Adependencies)