### PR TITLE
Update Miniconda architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,8 +711,7 @@ jobs:
   executed with `bash --noprofile --norc -eo pipefail {0}` thus ignoring updated
   on bash profile files made by `conda init bash`. See
   [Github Actions Documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#custom-shell)
-  and
-  [thread](https://github.com/orgs/community/discussions/25061).
+  and [thread](https://github.com/orgs/community/discussions/25061).
 - Sh shells do not use `~/.profile` or `~/.bashrc` so these shells need to be
   explicitely declared as `shell: sh -l {0}` on steps that need to be properly
   activated (or use a default shell). This is because sh shells are executed

--- a/action.yml
+++ b/action.yml
@@ -235,8 +235,8 @@ inputs:
     default: ""
   architecture:
     description:
-      'Architecture of Miniconda that should be installed. Default is "x64".
-      The CPU architecture of the runner is not detected by the workflow.'
+      'Architecture of Miniconda that should be installed. Default is "x64". The
+      CPU architecture of the runner is not detected by the workflow.'
     required: false
     default: "x64"
   clean-patched-environment-file:

--- a/action.yml
+++ b/action.yml
@@ -235,9 +235,9 @@ inputs:
     default: ""
   architecture:
     description:
-      'Architecture of Miniconda that should be installed. Default is "x64".
-      It is recommended to provide this value because the CPU architecture
-      of the runner is not detected by the workflow.'
+      'Architecture of Miniconda that should be installed. Default is "x64". It
+      is recommended to provide this value because the CPU architecture of the
+      runner is not detected by the workflow.'
     required: false
     default: "x64"
   clean-patched-environment-file:

--- a/action.yml
+++ b/action.yml
@@ -235,9 +235,8 @@ inputs:
     default: ""
   architecture:
     description:
-      'Architecture of Miniconda that should be installed. Default is "x64". It
-      is recommended to provide this value because the CPU architecture of the
-      runner is not detected by the workflow.'
+      'Architecture of Miniconda that should be installed. Default is "x64".
+      The CPU architecture of the runner is not detected by the workflow.'
     required: false
     default: "x64"
   clean-patched-environment-file:

--- a/action.yml
+++ b/action.yml
@@ -235,8 +235,9 @@ inputs:
     default: ""
   architecture:
     description:
-      'Architecture of Miniconda that should be installed. Available options on
-      GitHub-hosted runners are "x86" and "x64". Default is "x64".'
+      'Architecture of Miniconda that should be installed. Default is "x64".
+      It is recommended to provide this value because the CPU architecture
+      of the runner is not detected by the workflow.'
     required: false
     default: "x64"
   clean-patched-environment-file:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,10 +17,14 @@ export const MINICONDA_BASE_URL: string =
 
 /** Processor architectures supported by Miniconda */
 export const MINICONDA_ARCHITECTURES: types.IArchitectures = {
+  aarch64: "aarch64",
+  arm64: "arm64",
+  ppc64le: "ppc64le",
+  s390x: "s390x",
   x64: "x86_64",
+  x86_64: "x86_64",
   x86: "x86",
-  ARM64: "aarch64", // To be supported by github runners
-  ARM32: "armv7l", // To be supported by github runners
+  arm32: "armv7l", // To be supported by github runners
 };
 
 /** Processor architectures supported by Miniforge */

--- a/src/installer/download-miniconda.ts
+++ b/src/installer/download-miniconda.ts
@@ -47,9 +47,13 @@ export async function downloadMiniconda(
   inputs: types.IActionInputs
 ): Promise<string> {
   // Check valid arch
-  const arch: string = constants.MINICONDA_ARCHITECTURES[inputs.architecture.toLowerCase()];
+  let arch: string = constants.MINICONDA_ARCHITECTURES[inputs.architecture.toLowerCase()];
   if (!arch) {
     throw new Error(`Invalid arch "${inputs.architecture}"!`);
+  }
+  // Backwards compatibility: ARM64 used to map to aarch64
+  if (arch === "arm64" && constants.is_LINUX) {
+    arch = constants.MINICONDA_ARCHITECTURES["aarch64"]
   }
 
   let extension: string = constants.IS_UNIX ? "sh" : "exe";

--- a/src/installer/download-miniconda.ts
+++ b/src/installer/download-miniconda.ts
@@ -47,7 +47,7 @@ export async function downloadMiniconda(
   inputs: types.IActionInputs
 ): Promise<string> {
   // Check valid arch
-  const arch: string = constants.MINICONDA_ARCHITECTURES[inputs.architecture];
+  const arch: string = constants.MINICONDA_ARCHITECTURES[inputs.architecture.toLowerCase()];
   if (!arch) {
     throw new Error(`Invalid arch "${inputs.architecture}"!`);
   }

--- a/src/installer/download-miniconda.ts
+++ b/src/installer/download-miniconda.ts
@@ -47,13 +47,14 @@ export async function downloadMiniconda(
   inputs: types.IActionInputs
 ): Promise<string> {
   // Check valid arch
-  let arch: string = constants.MINICONDA_ARCHITECTURES[inputs.architecture.toLowerCase()];
+  let arch: string =
+    constants.MINICONDA_ARCHITECTURES[inputs.architecture.toLowerCase()];
   if (!arch) {
     throw new Error(`Invalid arch "${inputs.architecture}"!`);
   }
   // Backwards compatibility: ARM64 used to map to aarch64
-  if (arch === "arm64" && constants.is_LINUX) {
-    arch = constants.MINICONDA_ARCHITECTURES["aarch64"]
+  if (arch === "arm64" && constants.IS_LINUX) {
+    arch = constants.MINICONDA_ARCHITECTURES["aarch64"];
   }
 
   let extension: string = constants.IS_UNIX ? "sh" : "exe";


### PR DESCRIPTION
The supported Miniconda architectures are outdated and do not cover all available installers. In particular, with the addition of M1 runners, `osx-arm64` installers need to be supported.

CI failures appear to be unrelated to this PR.