### PR TITLE
Fix condaBasePath when useBundled is false, and there's no pre-existing conda

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -47248,14 +47248,12 @@ const utils = __importStar(__nccwpck_require__(1314));
  * Provide current location of miniconda or location where it will be installed
  */
 function condaBasePath(options) {
-    let condaPath = constants.MINICONDA_DIR_PATH;
-    if (!options.useBundled) {
-        if (constants.IS_MAC) {
-            condaPath = "/Users/runner/miniconda3";
-        }
-        else {
-            condaPath += "3";
-        }
+    let condaPath;
+    if (options.useBundled) {
+        condaPath = constants.MINICONDA_DIR_PATH;
+    }
+    else {
+        condaPath = path.join(os.homedir(), "miniconda3");
     }
     return condaPath;
 }

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -17,13 +17,11 @@ import * as utils from "./utils";
  * Provide current location of miniconda or location where it will be installed
  */
 export function condaBasePath(options: types.IDynamicOptions): string {
-  let condaPath: string = constants.MINICONDA_DIR_PATH;
-  if (!options.useBundled) {
-    if (constants.IS_MAC) {
-      condaPath = "/Users/runner/miniconda3";
-    } else {
-      condaPath += "3";
-    }
+  let condaPath: string;
+  if (options.useBundled) {
+    condaPath = constants.MINICONDA_DIR_PATH;
+  } else {
+    condaPath = path.join(os.homedir(), "miniconda3");
   }
   return condaPath;
 }


### PR DESCRIPTION
Useful when using setup-miniconda with self-hosted runners without conda installed.