### PR TITLE
WIP Prepare release: Update CHANGELOG, pump version to 2.3.0

### DIFF
--- a/.github/workflows/example-6.yml
+++ b/.github/workflows/example-6.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: ./
         with:
           python-version: "3.11"
-          mamba-version: "*"
+          mamba-version: ">=1.5.3"
           channels: conda-forge,nodefaults
           channel-priority: true
           activate-environment: ${{ matrix.activate-environment }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # CHANGELOG
 
+## [v2.3.0] (2023-11-17)
+
+### Documentation
+
+- [#263] Update links to GitHub shell docs
+- [#289] Consider leading with conda activation does not work on sh, please use bash
+
+### Features
+
+- [#296] Update Miniconda architectures (enables M1 = osx-arm64 runners)
+
+### Tasks and Maintenance
+
+- [#273] Bump json5 from 1.0.1 to 1.0.2
+- [#293] Remove Python 2.7 from test matrix (EOL since  April 2020, >4 years)
+- [#294] Update dependencies
+- [#295] Add dependabot config to update action versions in workflows by
+- [#300] Fix CI (lint + examples)
+
+[v2.3.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v2.3.0
+[#263]: https://github.com/conda-incubator/setup-miniconda/pull/263
+[#289]: https://github.com/conda-incubator/setup-miniconda/pull/289
+[#296]: https://github.com/conda-incubator/setup-miniconda/pull/296
+[#273]: https://github.com/conda-incubator/setup-miniconda/pull/273
+[#293]: https://github.com/conda-incubator/setup-miniconda/pull/293
+[#294]: https://github.com/conda-incubator/setup-miniconda/pull/294
+[#295]: https://github.com/conda-incubator/setup-miniconda/pull/295
+[#300]: https://github.com/conda-incubator/setup-miniconda/pull/300
+
 ## [v2.2.0] (2021-11-11)
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Documentation
 
 - [#263] Update links to GitHub shell docs
-- [#289] Consider leading with conda activation does not work on sh, please use bash
+- [#289] Consider leading with conda activation does not work on sh, please use
+  bash
 
 ### Features
 
@@ -14,7 +15,7 @@
 ### Tasks and Maintenance
 
 - [#273] Bump json5 from 1.0.1 to 1.0.2
-- [#293] Remove Python 2.7 from test matrix (EOL since  April 2020, >4 years)
+- [#293] Remove Python 2.7 from test matrix (EOL since April 2020, >4 years)
 - [#294] Update dependencies
 - [#295] Add dependabot config to update action versions in workflows by
 - [#300] Fix CI (lint + examples)

--- a/README.md
+++ b/README.md
@@ -57,45 +57,45 @@ possibility of automatically activating the `test` environment on all shells.
 | [Caching environments](#caching-environments)   | [![Caching Env Example Status][caching-env-badge]][caching-env] |
 
 [ex1]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-1.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-1.yml
 [ex1-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Example%201:%20Basic%20usage/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-1.yml/badge.svg?branch=main
 [ex2]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-2.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-2.yml
 [ex2-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Example%202:%20Other%20shells/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-2.yml/badge.svg?branch=main
 [ex3]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-3.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-3.yml
 [ex3-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Example%203:%20Other%20options/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-3.yml/badge.svg?branch=main
 [ex4]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-4.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-4.yml
 [ex4-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Example%204:%20Channels/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-4.yml/badge.svg?branch=main
 [ex5]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-5.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-5.yml
 [ex5-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Example%205:%20Custom%20installer/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-5.yml/badge.svg?branch=main
 [ex6]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-6.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-6.yml
 [ex6-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Example%206:%20Mamba/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-6.yml/badge.svg?branch=main
 [caching]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/caching-example.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/caching-example.yml
 [caching-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Caching%20Example/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/caching-example.yml/badge.svg?branch=main
 [caching-env]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/caching-envs-example.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/caching-envs-example.yml
 [caching-env-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Caching%20Env%20Example/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/caching-envs-example.yml/badge.svg?branch=main
 [ex7]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-7.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-7.yml
 [ex7-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Example%207:%20Explicit%20Environment%20Specification/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-7.yml/badge.svg?branch=main
 [ex10]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-10.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-10.yml
 [ex10-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Example%2010:%20Miniforge,%20etc/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-10.yml/badge.svg?branch=main
 
 ## Other Workflows
 
@@ -106,17 +106,17 @@ possibility of automatically activating the `test` environment on all shells.
 | Workflow Status | [![Linting Status][linting-badge]][linting] | [![Catch Invalid Environments Status][ex8-badge]][ex8] | [![Handle Empty Channels Status][ex9-badge]][ex9] |
 
 [linting]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/lint.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/lint.yml
 [linting-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Linting/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/lint.yml/badge.svg?branch=main
 [ex8]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-8.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-8.yml
 [ex8-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Example%208:%20Catch%20invalid%20environment%20files/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-8.yml/badge.svg?branch=main
 [ex9]:
-  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-9.yml?query=branch%3Amain
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-9.yml
 [ex9-badge]:
-  https://img.shields.io/github/workflow/status/conda-incubator/setup-miniconda/Example%209:%20Empty%20Channels%20in%20file%20dont%20crash%20setup/main
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-9.yml/badge.svg?branch=main
 
 ## Environment activation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-miniconda",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-miniconda",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "GitHub action for setting up conda from default or custom installers",
   "main": "lib/main.js",
   "scripts": {


### PR DESCRIPTION
There hasn't be a release in 2 years. This prepares the CHANGELOG and pumps the version number for a new release. After the merge, develop can be merge into main and a release can be tagged.