### PR TITLE
Run dependabot against main branch and also update node packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,14 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "daily"
+    versioning-strategy: "increase"
+    allow:
+      - dependency-type: "production"


### PR DESCRIPTION
To avoid failures when there is no develop branch and issues where dependabot analyses the main branch, but then tries to open a PR against develop, which maybe is already updated.

This should also help to resolve security findings in node packages.