### PR TITLE
Switch to main branch based development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Pull requests
 
-Make sure to make your pull requests against the `develop` branch.
+Make sure to make your pull requests against the `main` branch.
 
 ## Build
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,7 @@
 # Release
 
-- Update dependencies and fix any outdated dependencies.
+- Update dependencies and fix any outdated dependencies. (can be skipped as
+  Dependabot keeps everything updated)
 
 ```bash
 npm install -g npm-check-updates
@@ -16,22 +17,14 @@ npm-check-updates
 
 - Run the [build](./CONTRIBUTING.md#build).
 
-- All contributions currently go to the `develop` branch. To make a new
-  releasecheckout to the `main` branch and merge with `develop` and then proceed
-  with the release process. We also keep the `master` branch until `v3` is
-  released with a wrtning so we also merge this with develop.
+- We keep the `master` branch until `v3` is released with a warning so we also
+  merge this with main.
 
 ```bash
-git checkout develop
-git pull origin develop
-git checkout master
-git pull origin master
-git merge develop
+git remote update
+git checkout origin/master -b master
+git merge origin/main
 git push origin master
-git checkout main
-git pull origin main
-git merge develop
-git push origin main
 ```
 
 - Create a new named tag:


### PR DESCRIPTION
Reasons:
* shortens the development process
* ci + linting workflows allow to keep the quality up and potentially do a minor/major release after every PR merge to main... so there won't be that many un-released changes waiting in the main branch, that maybe confuse users as a tagged=releases version behave differently to what the current README says (which happened in the past).
* enables better usage of dependabot, as it analyses the repo default branch (main) and then doing PRs against develop would often fail if that deviates.
* more in line in regards to how other popular actions are devloped (like https://github.com/actions/checkout or https://github.com/actions/cache or https://github.com/docker/build-push-action)