### PR TITLE
Specify team conda-incubator/setup-miniconda as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Syntax for this file at https://help.github.com/articles/about-codeowners/
+#
+* @conda-incubator/setup-miniconda


### PR DESCRIPTION
This auto-assigns the team as PR reviewers, which has 3 advantages:
* contributors can see from whom potentially to expect feedback in PRs.
* the maintainers aka team members get a better signal to filter for PRs to be reviewed by them.
* allows to enable branch protections (in case we want that in the future) where at least one approval by a codeowner is required for PRs to be merged.