### PR TITLE
Split lint into check and build, switch from `npm install` to `npm ci`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,27 +9,44 @@ on:
       - "develop"
       - "main"
       - "master"
-  schedule:
-    # Note that cronjobs run on master/main by default
-    - cron: "0 0 * * *"
 
 jobs:
   lint:
-    # prevent cronjobs from running on forks
-    if:
-      (github.event_name == 'schedule' && github.repository ==
-      'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
     name: Lint
     runs-on: "ubuntu-latest"
-    defaults:
-      run:
-        shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: |
-          npm install
+          # ci: install exact versions from package-lock.json
+          #     fast, secure, predictable compared to npm install
+          npm ci
           npm run check
+  build:
+    name: Build
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Build
+        run: |
+          # ci: install exact versions from package-lock.json
+          #     fast, secure, predictable compared to npm install
+          npm ci
           npm run build
+
+      - name: Check that all built are committed
+        run: |
+          # Check if any changes are to be committed
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "There are uncommitted changes, please run:"
+            echo "  npm run format"
+            echo "  npm run build"
+            echo "and commit the resulting changes before pushing."
+            echo "See also CONTRIBUTING.md"
+            exit 1
+          fi


### PR DESCRIPTION
This splits the lint flow into two jobs:
* one only calling `npm run check`, which can just reveal some unrelated formatting changes missing. Those findings still have to be fixed, but in most cases have no consequences in regards to if the example workflow runs are all valid or not.
* one calling `npm run build` and checking if there are no updates = all updates in the ./dist folder are committed... If this job fails, then all the examples runs have to be taken with a grain of salt, as they run agains an outdated ./dist folder, thus being invalid!

This information was previously not visible / masked as mostly `npm run check` failed and prevented `npm run build` from running ... it was then unclear, if that has consequences to the ncc compiled stuff in ./dist or not.

Also switching `npm install` to `npm ci` to install the exact versions from package-lock.json (managed by dependabot). This is faster, more secure and 100% predictable. Thus removing the cron triggers as those won't find anything new.