### PR TITLE
Faster workflow response / saving resources via timeout/concurrency policy

### DIFF
--- a/.github/workflows/caching-envs-example.yml
+++ b/.github/workflows/caching-envs-example.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   caching-example:
     name: Caching-Env
@@ -27,6 +32,7 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/caching-example.yml
+++ b/.github/workflows/caching-example.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   caching-example:
     # prevent cronjobs from running on forks
@@ -21,6 +26,7 @@ jobs:
       'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
     name: Caching
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Cache conda

--- a/.github/workflows/example-1.yml
+++ b/.github/workflows/example-1.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   example-1:
     # prevent cronjobs from running on forks
@@ -26,6 +31,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.11"]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   example-10-miniforge:
     # prevent cronjobs from running on forks
@@ -76,6 +81,7 @@ jobs:
           - os: macos
             miniforge-variant: Mambaforge
             miniforge-version: "23.3.1-1"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/example-11.yml
+++ b/.github/workflows/example-11.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   example-11:
     # prevent cronjobs from running on forks
@@ -29,6 +34,7 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]
         architecture: ["x86"]
         miniconda-version: ["latest"]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/example-2.yml
+++ b/.github/workflows/example-2.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   example-2-linux:
     # prevent cronjobs from running on forks
@@ -21,6 +26,7 @@ jobs:
       'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
     name: Ex2 Linux
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./
@@ -43,6 +49,7 @@ jobs:
   example-2-mac:
     name: Ex2 Mac
     runs-on: "macos-latest"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./
@@ -71,6 +78,7 @@ jobs:
   example-2-win:
     name: Ex2 Windows
     runs-on: "windows-latest"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/example-3.yml
+++ b/.github/workflows/example-3.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   example-3:
     # prevent cronjobs from running on forks
@@ -24,6 +29,7 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./
@@ -45,6 +51,7 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/example-4.yml
+++ b/.github/workflows/example-4.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   example-4:
     # prevent cronjobs from running on forks
@@ -24,6 +29,7 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/example-5.yml
+++ b/.github/workflows/example-5.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   example-5-linux:
     # prevent cronjobs from running on forks
@@ -26,6 +31,7 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -50,6 +56,7 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./
@@ -68,6 +75,7 @@ jobs:
   example-5-win:
     name: Ex5 Windows
     runs-on: "windows-latest"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/example-6.yml
+++ b/.github/workflows/example-6.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   example-6:
     # prevent cronjobs from running on forks
@@ -35,6 +40,7 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/example-7.yml
+++ b/.github/workflows/example-7.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   example-7:
     # prevent cronjobs from running on forks
@@ -28,6 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/example-8.yml
+++ b/.github/workflows/example-8.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   example-8:
     # prevent cronjobs from running on forks
@@ -26,6 +31,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.11"]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/example-9.yml
+++ b/.github/workflows/example-9.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   example-9:
     # prevent cronjobs from running on forks
@@ -26,6 +31,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.11"]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,16 @@ on:
       - "main"
       - "master"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -27,6 +33,7 @@ jobs:
   build:
     name: Build
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/regression-checks.yml
+++ b/.github/workflows/regression-checks.yml
@@ -13,6 +13,11 @@ on:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"
 
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   issue-114:
     # prevent cronjobs from running on forks
@@ -29,6 +34,7 @@ jobs:
       matrix:
         os: ["ubuntu", "macos", "windows"]
         python-version: ["3.9"]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./


### PR DESCRIPTION
All the workflows normally finish within <5 minutes. If they take longer (there are several runs >30 minutes in the action history) they always fail and the causes are temporary issues with CDN / dependencies not solvable etc. There is no point then continuing those runs as they anyway fail. Thus setting an upper limit of 30 minutes to save some free Action minutes in the incubator org.

Also setting a concurrency policy for all workflows for faster PR responses when doing repeated pushes to PRs, inspired by [conda](https://github.com/conda/conda/blob/main/.github/workflows/tests.yml#L21).