### PR TITLE
Prepare release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # CHANGELOG
 
+## [v3.0.0] (2023-11-27)
+
+### Features
+
+- [#308] Update to node20
+- [#291] Add conda-solver option (defaults to libmamba)
+
+### Fixes
+
+- [#299] Fix condaBasePath when useBundled is false, and there's no pre-existing
+  conda
+
+### Documentation
+
+- [#309] Switch to main branch based development
+- [#313] Specify team conda-incubator/setup-miniconda as codeowners
+- [#318] README: update actions in examples, add security section, similar
+  actions
+
+### Tasks and Maintenance
+
+- [#307] Run dependabot against main branch and also update node packages
+- [#311] Bump actions/checkout from 2 to 4
+- [#310] Bump actions/cache from 1 to 3
+- [#314] Strip/update dependencies
+- [#315] Split lint into check and build, switch from `npm install` to `npm ci`
+- [#317] Bump normalize-url from 4.5.1 to 8.0.0
+- [#316] Faster workflow response / saving resources via timeout/concurrency
+  policy
+
+[v3.0.0]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v2.3.0
+[#308]: https://github.com/conda-incubator/setup-miniconda/pull/308
+[#291]: https://github.com/conda-incubator/setup-miniconda/pull/291
+[#299]: https://github.com/conda-incubator/setup-miniconda/pull/299
+[#309]: https://github.com/conda-incubator/setup-miniconda/pull/309
+[#313]: https://github.com/conda-incubator/setup-miniconda/pull/313
+[#318]: https://github.com/conda-incubator/setup-miniconda/pull/318
+[#307]: https://github.com/conda-incubator/setup-miniconda/pull/307
+[#311]: https://github.com/conda-incubator/setup-miniconda/pull/311
+[#310]: https://github.com/conda-incubator/setup-miniconda/pull/310
+[#314]: https://github.com/conda-incubator/setup-miniconda/pull/314
+[#315]: https://github.com/conda-incubator/setup-miniconda/pull/315
+[#317]: https://github.com/conda-incubator/setup-miniconda/pull/317
+[#316]: https://github.com/conda-incubator/setup-miniconda/pull/316
+
 ## [v2.3.0] (2023-11-22)
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ You can change the default `test` environment to have a different name or path
 by setting the `activate-environment` input option.
 
 ```yaml
-- uses: conda-incubator/setup-miniconda@v2
+- uses: conda-incubator/setup-miniconda@v3
   with:
     activate-environment: whatever
 ```
@@ -172,7 +172,7 @@ to do **both** of:
 - set `auto-activate-base` to `true`
 
 ```yaml
-- uses: conda-incubator/setup-miniconda@v2
+- uses: conda-incubator/setup-miniconda@v3
   with:
     auto-activate-base: true
     activate-environment: ""
@@ -198,7 +198,7 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.7", "3.11"]
     steps:
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
@@ -222,7 +222,7 @@ jobs:
     name: Ex2 Linux
     runs-on: "ubuntu-latest"
     steps:
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
           activate-environment: foo
@@ -241,7 +241,7 @@ jobs:
     name: Ex2 Mac
     runs-on: "macos-latest"
     steps:
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
           activate-environment: foo
@@ -265,7 +265,7 @@ jobs:
     name: Ex2 Windows
     runs-on: "windows-latest"
     steps:
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
           activate-environment: foo
@@ -309,7 +309,7 @@ jobs:
         shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: anaconda-client-env
           environment-file: etc/example-environment.yml
@@ -341,7 +341,7 @@ jobs:
         shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: foo
           python-version: 3.6
@@ -383,7 +383,7 @@ jobs:
         shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           installer-url: https://github.com/conda-forge/miniforge/releases/download/4.8.3-2/Miniforge-pypy3-4.8.3-2-Linux-x86_64.sh
           allow-softlinks: true
@@ -415,7 +415,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: 3.6
           mamba-version: "*"
@@ -467,7 +467,7 @@ jobs:
         shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: false
           activate-environment: explicit-env
@@ -498,7 +498,7 @@ jobs:
         os: ["ubuntu", "macos", "windows"]
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           environment-file: etc/example-environment.yml
           miniforge-version: latest
@@ -530,7 +530,7 @@ jobs:
             miniforge-variant: Mambaforge
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           condarc-file: ${{ matrix.condarc-file }}
           environment-file: ${{ matrix.environment-file }}
@@ -560,7 +560,7 @@ jobs:
         miniconda-version: ["latest"]
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           architecture: ${{ matrix.architecture }}
           miniconda-version: $${{ matrix.miniconda-version }}
@@ -587,7 +587,7 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         id: setup-miniconda
         continue-on-error: true
         with:
@@ -629,7 +629,7 @@ jobs:
           key:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('etc/example-environment.yml') }}
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: anaconda-client-env
           channel-priority: strict
@@ -649,7 +649,7 @@ a environment file.
 
 ```yaml
 - name: Setup Mambaforge
-  uses: conda-incubator/setup-miniconda@v2
+  uses: conda-incubator/setup-miniconda@v3
   with:
     miniforge-variant: Mambaforge
     miniforge-version: latest
@@ -731,7 +731,7 @@ jobs:
         shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: anaconda-client-env
           environment-file: etc/example-environment-caching.yml

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,40 +10,34 @@ npm-check-updates
 
 - Ensure the [CHANGELOG](./CHANGELOG.md) is up-to-date.
 
-- Update the `version` in [package.json](./package.json).
+- If this release is a major version, update all the example YAML in the
+  [README](./README.md), e.g. `4.0.0` would need `@v3` -> `@v4`.
 
-  - If this release is a major version, update all the example YAML in the
-    [README](./README.md), e.g. `3.0.0` would need `@v2` -> `@v3`.
+- Ensure that all
+  [workflow runs](https://github.com/conda-incubator/setup-miniconda/actions?query=branch%3Amain)
+  for the latest commit on main are green.
 
-- Run the [build](./CONTRIBUTING.md#build).
+- Create a new release via "Draft a new release" button at the
+  [Release page](https://github.com/conda-incubator/setup-miniconda/releases):
 
-- We keep the `master` branch until `v3` is released with a warning so we also
-  merge this with main.
-
-```bash
-git remote update
-git checkout origin/master -b master
-git merge origin/main
-git push origin master
-```
-
-- Create a new named tag:
-
-```bash
-git tag -a vX.Y.Z -m 'Release version vX.Y.Z'
-```
+  - Choose a new tag like `vX.Y.Z` that targets the current main branch and that
+    is created on publish of the release
+  - Choose the title `Version X.Y.Z`
+  - Paste the relevant [CHANGELOG](./CHANGELOG.md) section into the description
+    field
+  - Publish the release
 
 Replace `X.Y.Z` by the appropriate version number.
 
 - Point the old `vX` tag to latest `vX.Y.Z` tag:
 
 ```bash
-git checkout main
+git remote update
 git tag -d vX
 git push origin :refs/tags/vX
+git checkout vX.Y.Z
 git tag -a vX -m 'Release version vX.Y.Z'
 git push origin --tags
-git push origin main
 ```
 
 Replace `X.Y.Z` by the appropriate version number.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "setup-miniconda",
-  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-miniconda",
-      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "setup-miniconda",
-  "version": "2.3.0",
   "description": "GitHub action for setting up conda from default or custom installers",
   "main": "lib/main.js",
   "scripts": {


### PR DESCRIPTION
* Doing a major version pump due to the node20 upgrade (other popular actions like checkout also did that, [see](https://github.com/actions/checkout/releases/tag/v4.0.0))
* Updating CHANGELOG.md and README.md
* Removing the versions from package.json and package-lock.json as they have no function and it simplifies doing a release (other popular actions also don't maintain a version in the package.json, [see e.g.](https://github.com/docker/build-push-action/blob/master/package.json)
* Updating  RELEASE.md for better step descriptions and also removing the steps to update the master branch