### PR TITLE
Add update-example-lockfiles workflow

### DIFF
--- a/.github/workflows/update-example-lockfiles.yml
+++ b/.github/workflows/update-example-lockfiles.yml
@@ -1,0 +1,57 @@
+name: Update example lockfiles
+on:
+  schedule:
+    # Once per week on Sunday
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: ./
+        with:
+          environment-file: ./etc/example-environment-explicit.yml
+          python-version: "3.9"
+      - name: Update lockfile
+        run: |
+          conda-lock \
+            --file ./etc/example-environment-explicit.yml \
+            --platform linux-64 \
+            --kind explicit \
+            --filename-template './etc/example-explicit.Linux.conda.lock'
+          conda-lock \
+            --file ./etc/example-environment-explicit.yml \
+            --platform osx-64 \
+            --kind explicit \
+            --filename-template './etc/example-explicit.macOS.conda.lock'
+          conda-lock \
+            --file ./etc/example-environment-explicit.yml \
+            --platform win-64 \
+            --kind explicit \
+            --filename-template './etc/example-explicit.Windows.conda.lock'
+      - name: Show changes
+        run: |
+          git diff
+          git status
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: "chore(deps): Update example lockfiles"
+          body: |
+            This PR updates the example lockfiles to the latest versions of the dependencies.
+
+            Please close and re-open the PR to trigger the CI checks / example workflows.
+          branch-suffix: random
+          draft: false
+          add-paths: etc/example-explicit.*.conda.lock

--- a/README.md
+++ b/README.md
@@ -450,8 +450,10 @@ This means explicitly-defined environments which:
   platform/architecture information
 - can become broken if any file becomes unavailable
 
-This approach can be useful as part of a larger system e.g., a separate workflow
-that runs `conda-lock` for all the platforms needed in a separate job.
+This approach can be useful as part of a larger system e.g., a
+[separate workflow](https://github.com/conda-incubator/setup-miniconda/actions/workflows/update-example-lockfiles.yml)
+that runs `conda-lock` for all the platforms needed in a separate job and
+creates update Pull-Requests.
 
 [conda-lock]: https://github.com/conda/conda-lock
 [explicit-spec]:


### PR DESCRIPTION
Helps to describe how to combine setup-miniconda, conda lock files and keeping the lock files automatically updated. And as side-effect also updates our example lock files.

Creates PRs like https://github.com/dbast/setup-miniconda/pull/6

The workflow runs once per week and can be manually triggered, once the PR is merged (due to `workflow_dispatch:`) by going to the actions tab in the repo and selecting+triggering another run.