### PR TITLE
Enable ARM64 on macOS for Miniforge and Mambaforge.

### DIFF
--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -1,0 +1,55 @@
+name: "Example 13: ARM64 for Miniforge and Mambaforge"
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "develop"
+      - "main"
+      - "master"
+  schedule:
+    # Note that cronjobs run on master/main by default
+    - cron: "0 0 * * *"
+
+jobs:
+  example-13:
+    # prevent cronjobs from running on forks
+    if:
+      (github.event_name == 'schedule' && github.repository ==
+      'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
+    name: Ex13 (os=${{ matrix.os }} variant=${{ matrix.variant }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["macos-14"]
+        variant: ["Miniforge3", "Mambaforge"]
+        version: ["latest"]
+        architecture: ["arm64", "ARM64"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        id: setup-miniconda
+        continue-on-error: true
+        with:
+          auto-update-conda: true
+          architecture: ${{ matrix.architecture }}
+          miniforge-variant: ${{ matrix.variant }}
+          miniforge-version: ${{ matrix.version }}
+      - name: Conda info
+        shell: bash -el {0}
+        run: conda info
+      - name: Conda list
+        shell: bash -el {0}
+        run: conda list
+      - name: Environment
+        shell: bash -el {0}
+        run: printenv | sort
+      - name: Create an environment
+        shell: bash -el {0}
+        run: conda create -n unused --dry-run zlib
+      - name: Run mamba
+        shell: bash -el {0}
+        run: mamba --version

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -19,7 +19,7 @@ jobs:
     if:
       (github.event_name == 'schedule' && github.repository ==
       'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
-    name: Ex13 (os=${{ matrix.os }} variant=${{ matrix.variant }})
+    name: Ex13 (os=${{ matrix.os }} variant=${{ matrix.variant }} version=${{ matrix.version }} architecture=${{ matrix.architecture }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -19,7 +19,9 @@ jobs:
     if:
       (github.event_name == 'schedule' && github.repository ==
       'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
-    name: Ex13 (os=${{ matrix.os }} variant=${{ matrix.variant }} version=${{ matrix.version }} architecture=${{ matrix.architecture }})
+    name:
+      Ex13 (os=${{ matrix.os }} variant=${{ matrix.variant }} version=${{
+      matrix.version }} architecture=${{ matrix.architecture }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -14,7 +14,7 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  example-13:
+  example-13-1:
     # prevent cronjobs from running on forks
     if:
       (github.event_name == 'schedule' && github.repository ==
@@ -40,6 +40,40 @@ jobs:
           architecture: ${{ matrix.architecture }}
           miniforge-variant: ${{ matrix.variant }}
           miniforge-version: ${{ matrix.version }}
+      - name: Conda info
+        shell: bash -el {0}
+        run: conda info
+      - name: Conda list
+        shell: bash -el {0}
+        run: conda list
+      - name: Environment
+        shell: bash -el {0}
+        run: printenv | sort
+      - name: Create an environment
+        shell: bash -el {0}
+        run: conda create -n unused --dry-run zlib
+      - name: Run mamba
+        shell: bash -el {0}
+        run: mamba --version
+  example-13-2:
+    # prevent cronjobs from running on forks
+    if:
+      (github.event_name == 'schedule' && github.repository ==
+      'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
+    name: Ex13 (os=${{ matrix.os }} version=${{matrix.version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["macos-14"]
+        version: ["latest"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        id: setup-miniconda
+        continue-on-error: true
+        with:
+          miniforge-version: ${{matrix.version }}
       - name: Conda info
         shell: bash -el {0}
         run: conda info

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -19,8 +19,7 @@ jobs:
     if:
       (github.event_name == 'schedule' && github.repository ==
       'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
-    name:
-      Ex13 (os=${{ matrix.os }} variant=${{ matrix.variant }})
+    name: Ex13 (os=${{ matrix.os }} variant=${{ matrix.variant }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -60,6 +60,9 @@ jobs:
         if: matrix.variant != 'Miniconda'
         shell: bash -el {0}
         run: mamba --version
+      - name: Install Python
+        shell: bash -el {0}
+        run: conda install -y python
       - name: Check arm64
         shell: bash -el {0}
         run:

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -71,6 +71,5 @@ jobs:
         run: conda install -y python
       - name: Check arm64
         shell: bash -el {0}
-        run:
-          python -c "import platform; assert platform.machine() == 'arm64',
-          platform.machine()"
+        run: |
+          python -c "import platform; assert platform.machine() == 'arm64', platform.machine()"

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -20,26 +20,24 @@ jobs:
       (github.event_name == 'schedule' && github.repository ==
       'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
     name:
-      Ex13 (os=${{ matrix.os }} variant=${{ matrix.variant }} version=${{
-      matrix.version }} architecture=${{ matrix.architecture }})
+      Ex13 (os=${{ matrix.os }} variant=${{ matrix.variant }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ["macos-14"]
-        variant: ["Miniforge3", "Mambaforge"]
-        version: ["latest"]
-        architecture: ["arm64", "ARM64"]
+        variant: ["Miniforge3", "Mambaforge", "Miniconda"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./
-        id: setup-miniconda
+        if: matrix.variant != 'Miniconda'
+        id: setup-miniforge
         continue-on-error: true
         with:
           auto-update-conda: true
-          architecture: ${{ matrix.architecture }}
+          architecture: arm64
           miniforge-variant: ${{ matrix.variant }}
-          miniforge-version: ${{ matrix.version }}
+          miniforge-version: latest
       - name: Conda info
         shell: bash -el {0}
         run: conda info
@@ -57,26 +55,54 @@ jobs:
         run: mamba --version
       - name: Check arm64
         shell: bash -el {0}
-        run: python -c "import platform; assert platform.machine() == 'arm64', platform.machine()"
+        run:
+          python -c "import platform; assert platform.machine() == 'arm64',
+          platform.machine()"
+      - uses: ./
+        if: matrix.variant == 'Miniconda'
+        id: setup-miniconda
+        continue-on-error: true
+        with:
+          auto-update-conda: true
+          miniconda-version: latest
+      - name: Conda info
+        shell: bash -el {0}
+        run: conda info
+      - name: Conda list
+        shell: bash -el {0}
+        run: conda list
+      - name: Environment
+        shell: bash -el {0}
+        run: printenv | sort
+      - name: Create an environment
+        shell: bash -el {0}
+        run: conda create -n unused --dry-run zlib
+      - name: Run mamba
+        shell: bash -el {0}
+        run: mamba --version
+      - name: Check arm64
+        shell: bash -el {0}
+        run:
+          python -c "import platform; assert platform.machine() == 'arm64',
+          platform.machine()"
   example-13-2:
     # prevent cronjobs from running on forks
     if:
       (github.event_name == 'schedule' && github.repository ==
       'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
-    name: Ex13 (os=${{ matrix.os }} version=${{matrix.version }})
+    name: Ex13 (os=${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ["macos-14"]
-        version: ["latest"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./
         id: setup-miniconda
         continue-on-error: true
         with:
-          miniforge-version: ${{matrix.version }}
+          miniforge-version: latest
       - name: Conda info
         shell: bash -el {0}
         run: conda info
@@ -94,4 +120,6 @@ jobs:
         run: mamba --version
       - name: Check arm64
         shell: bash -el {0}
-        run: python -c "import platform; assert platform.machine() == 'arm64', platform.machine()"
+        run:
+          python -c "import platform; assert platform.machine() == 'arm64',
+          platform.machine()"

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -1,4 +1,4 @@
-name: "Example 13: ARM64 for Miniforge and Mambaforge"
+name: "Example 13: Apple Silicon"
 
 on:
   pull_request:

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -37,26 +37,6 @@ jobs:
           architecture: arm64
           miniforge-variant: ${{ matrix.variant }}
           miniforge-version: latest
-      - name: Conda info
-        shell: bash -el {0}
-        run: conda info
-      - name: Conda list
-        shell: bash -el {0}
-        run: conda list
-      - name: Environment
-        shell: bash -el {0}
-        run: printenv | sort
-      - name: Create an environment
-        shell: bash -el {0}
-        run: conda create -n unused --dry-run zlib
-      - name: Run mamba
-        shell: bash -el {0}
-        run: mamba --version
-      - name: Check arm64
-        shell: bash -el {0}
-        run:
-          python -c "import platform; assert platform.machine() == 'arm64',
-          platform.machine()"
       - uses: ./
         if: matrix.variant == 'Miniconda'
         id: setup-miniconda
@@ -77,6 +57,7 @@ jobs:
         shell: bash -el {0}
         run: conda create -n unused --dry-run zlib
       - name: Run mamba
+        if: matrix.variant != 'Miniconda'
         shell: bash -el {0}
         run: mamba --version
       - name: Check arm64

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -14,7 +14,7 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  example-13-1:
+  example-13:
     # prevent cronjobs from running on forks
     if:
       (github.event_name == 'schedule' && github.repository ==
@@ -25,11 +25,11 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macos-14"]
-        variant: ["Miniforge3", "Mambaforge", "Miniconda"]
+        variant: ["Miniforge3", "Mambaforge", "Miniconda", "no-variant"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./
-        if: matrix.variant != 'Miniconda'
+        if: matrix.variant == 'Miniforge3' || matrix.variant == 'Mambaforge'
         id: setup-miniforge
         continue-on-error: true
         with:
@@ -44,6 +44,12 @@ jobs:
         with:
           auto-update-conda: true
           miniconda-version: latest
+      - uses: ./
+        if: matrix.variant == 'no-variant'
+        id: setup-miniconda2
+        continue-on-error: true
+        with:
+          miniforge-version: latest
       - name: Conda info
         shell: bash -el {0}
         run: conda info
@@ -63,44 +69,6 @@ jobs:
       - name: Install Python
         shell: bash -el {0}
         run: conda install -y python
-      - name: Check arm64
-        shell: bash -el {0}
-        run:
-          python -c "import platform; assert platform.machine() == 'arm64',
-          platform.machine()"
-  example-13-2:
-    # prevent cronjobs from running on forks
-    if:
-      (github.event_name == 'schedule' && github.repository ==
-      'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
-    name: Ex13 (os=${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["macos-14"]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./
-        id: setup-miniconda
-        continue-on-error: true
-        with:
-          miniforge-version: latest
-      - name: Conda info
-        shell: bash -el {0}
-        run: conda info
-      - name: Conda list
-        shell: bash -el {0}
-        run: conda list
-      - name: Environment
-        shell: bash -el {0}
-        run: printenv | sort
-      - name: Create an environment
-        shell: bash -el {0}
-        run: conda create -n unused --dry-run zlib
-      - name: Run mamba
-        shell: bash -el {0}
-        run: mamba --version
       - name: Check arm64
         shell: bash -el {0}
         run:

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Run mamba
         shell: bash -el {0}
         run: mamba --version
+      - name: Check arm64
+        shell: bash -el {0}
+        run: python -c "import platform; assert platform.machine() == 'arm64', platform.machine()"
   example-13-2:
     # prevent cronjobs from running on forks
     if:
@@ -89,3 +92,6 @@ jobs:
       - name: Run mamba
         shell: bash -el {0}
         run: mamba --version
+      - name: Check arm64
+        shell: bash -el {0}
+        run: python -c "import platform; assert platform.machine() == 'arm64', platform.machine()"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,23 @@
 # CHANGELOG
 
-## [v3.0.2] (UNRELEASED)
+## [v3.0.2] (2024-02-22)
 
 ### Fixes
 
-- [#312] Enable ARM64 on macOS for Miniforge and Mambaforge.
+- [#312] Enable ARM64 on macOS for Miniforge and Mambaforge including automatic
+  architecture detection.
+
+### Tasks and Maintenance
+
+- [#327] Bump conda-incubator/setup-miniconda from 3.0.0 to 3.0.1
+- [#330] Bump actions/cache from 3 to 4
+- [#334] Bump undici from 5.27.2 to 5.28.3
+
+[v3.0.2]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v3.0.2
+[#312]: https://github.com/conda-incubator/setup-miniconda/pull/312
+[#327]: https://github.com/conda-incubator/setup-miniconda/pull/327
+[#330]: https://github.com/conda-incubator/setup-miniconda/pull/330
+[#334]: https://github.com/conda-incubator/setup-miniconda/pull/334
 
 ## [v3.0.1] (2023-11-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v3.0.2] (UNRELEASED)
+
+### Fixes
+
+- [#312] Enable ARM64 on macOS for Miniforge and Mambaforge.
+
 ## [v3.0.1] (2023-11-29)
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ jobs:
       - name: Check arm64
         shell: bash -el {0}
         run:
+          conda install -y python
           python -c "import platform; assert platform.machine() == 'arm64',
           platform.machine()"
 ```

--- a/README.md
+++ b/README.md
@@ -621,10 +621,9 @@ jobs:
           miniconda-version: latest
       - name: Check arm64
         shell: bash -el {0}
-        run:
+        run: |
           conda install -y python
-          python -c "import platform; assert platform.machine() == 'arm64',
-          platform.machine()"
+          python -c "import platform; assert platform.machine() == 'arm64', platform.machine()"
 ```
 
 ## Caching

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ possibility of automatically activating the `test` environment on all shells.
 | [Configure conda solver](#example-12-configure-conda-solver)       | [![Configure conda solver][ex12-badge]][ex12]                   |
 | [Caching packages](#caching-packages)                              | [![Caching Example Status][caching-badge]][caching]             |
 | [Caching environments](#caching-environments)                      | [![Caching Env Example Status][caching-env-badge]][caching-env] |
+| [Apple Silicon](#example-13-apple-silicon)                         | [![Apple Silicon][ex13-badge]][ex13]                            |
 
 [ex1]:
   https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-1.yml
@@ -107,6 +108,10 @@ possibility of automatically activating the `test` environment on all shells.
   https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-12.yml
 [ex12-badge]:
   https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-12.yml/badge.svg?branch=main
+[ex13]:
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-13.yml
+[ex13-badge]:
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-13.yml/badge.svg?branch=main
 
 ## Other Workflows
 
@@ -594,6 +599,31 @@ jobs:
           auto-update-conda: true
           conda-solver: ${{ matrix.solver }}
           python-version: "3.9"
+```
+
+### Example 13: Apple Silicon
+
+```yaml
+jobs:
+  example-13:
+    name: Ex13 (os=${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["macos-14"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        id: setup-miniconda
+        continue-on-error: true
+        with:
+          miniconda-version: latest
+      - name: Check arm64
+        shell: bash -el {0}
+        run:
+          python -c "import platform; assert platform.machine() == 'arm64',
+          platform.machine()"
 ```
 
 ## Caching

--- a/action.yml
+++ b/action.yml
@@ -242,10 +242,11 @@ inputs:
     default: "libmamba"
   architecture:
     description:
-      'Architecture of Miniconda that should be installed. Default is "x64". The
-      CPU architecture of the runner is not detected by the workflow.'
+      'Architecture of Miniconda that should be installed. This is automatically
+      detected by the runner. If you want to override it, you can use "x64",
+      "x86", "arm64", "aarch64", "s390x".'
     required: false
-    default: "x64"
+    default: ""
   clean-patched-environment-file:
     description:
       "Whether a patched environment-file (if created) should be cleaned"

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -48618,7 +48618,7 @@ function parseInputs() {
     return __awaiter(this, void 0, void 0, function* () {
         const inputs = Object.freeze({
             activateEnvironment: core.getInput("activate-environment"),
-            architecture: core.getInput("architecture"),
+            architecture: core.getInput("architecture") || process.arch,
             condaBuildVersion: core.getInput("conda-build-version"),
             condaConfigFile: core.getInput("condarc-file"),
             condaVersion: core.getInput("conda-version"),
@@ -48662,6 +48662,9 @@ function parseInputs() {
         }, []);
         if (errors.length) {
             throw Error(`${errors.length} errors found in action inputs`);
+        }
+        if (core.isDebug()) {
+            core.info(JSON.stringify(inputs));
         }
         return inputs;
     });

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -48550,7 +48550,7 @@ function downloadMiniforge(inputs, options) {
     return __awaiter(this, void 0, void 0, function* () {
         const tool = inputs.miniforgeVariant.trim() || constants.MINIFORGE_DEFAULT_VARIANT;
         const version = inputs.miniforgeVersion.trim() || constants.MINIFORGE_DEFAULT_VERSION;
-        const arch = constants.MINIFORGE_ARCHITECTURES[inputs.architecture];
+        const arch = constants.MINIFORGE_ARCHITECTURES[inputs.architecture.toLowerCase()];
         // Check valid arch
         if (!arch) {
             throw new Error(`Invalid 'architecture: ${inputs.architecture}'`);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -48148,8 +48148,6 @@ const RULES = [
     (i) => !!(i.installerUrl &&
         !constants.KNOWN_EXTENSIONS.includes(urlExt(i.installerUrl))) &&
         `'installer-url' extension '${urlExt(i.installerUrl)}' must be one of: ${constants.KNOWN_EXTENSIONS}`,
-    (i) => !!(!i.minicondaVersion && i.architecture !== "x64") &&
-        `'architecture: ${i.architecture}' requires "miniconda-version"`,
     (i) => !!(i.architecture === "x86" && !constants.IS_WINDOWS) &&
         `'architecture: ${i.architecture}' is only available for recent versions on Windows`,
     (i) => !!(!["latest", ""].includes(i.minicondaVersion) &&

--- a/src/input.ts
+++ b/src/input.ts
@@ -60,9 +60,6 @@ const RULES: IRule[] = [
     `'installer-url' extension '${urlExt(i.installerUrl)}' must be one of: ${
       constants.KNOWN_EXTENSIONS
     }`,
-  (i) =>
-    !!(!i.minicondaVersion && i.architecture !== "x64") &&
-    `'architecture: ${i.architecture}' requires "miniconda-version"`,
   (
     i, // Miniconda x86 is only published for Windows lately (last Linux was 2019, last MacOS 2015)
   ) =>

--- a/src/input.ts
+++ b/src/input.ts
@@ -81,7 +81,7 @@ const RULES: IRule[] = [
 export async function parseInputs(): Promise<types.IActionInputs> {
   const inputs: types.IActionInputs = Object.freeze({
     activateEnvironment: core.getInput("activate-environment"),
-    architecture: core.getInput("architecture"),
+    architecture: core.getInput("architecture") || process.arch,
     condaBuildVersion: core.getInput("conda-build-version"),
     condaConfigFile: core.getInput("condarc-file"),
     condaVersion: core.getInput("conda-version"),
@@ -131,6 +131,10 @@ export async function parseInputs(): Promise<types.IActionInputs> {
 
   if (errors.length) {
     throw Error(`${errors.length} errors found in action inputs`);
+  }
+
+  if (core.isDebug()) {
+    core.info(JSON.stringify(inputs));
   }
 
   return inputs;

--- a/src/installer/download-miniforge.ts
+++ b/src/installer/download-miniforge.ts
@@ -16,7 +16,8 @@ export async function downloadMiniforge(
     inputs.miniforgeVariant.trim() || constants.MINIFORGE_DEFAULT_VARIANT;
   const version =
     inputs.miniforgeVersion.trim() || constants.MINIFORGE_DEFAULT_VERSION;
-  const arch = constants.MINIFORGE_ARCHITECTURES[inputs.architecture.toLowerCase()];
+  const arch =
+    constants.MINIFORGE_ARCHITECTURES[inputs.architecture.toLowerCase()];
 
   // Check valid arch
   if (!arch) {

--- a/src/installer/download-miniforge.ts
+++ b/src/installer/download-miniforge.ts
@@ -16,7 +16,7 @@ export async function downloadMiniforge(
     inputs.miniforgeVariant.trim() || constants.MINIFORGE_DEFAULT_VARIANT;
   const version =
     inputs.miniforgeVersion.trim() || constants.MINIFORGE_DEFAULT_VERSION;
-  const arch = constants.MINIFORGE_ARCHITECTURES[inputs.architecture];
+  const arch = constants.MINIFORGE_ARCHITECTURES[inputs.architecture.toLowerCase()];
 
   // Check valid arch
   if (!arch) {


### PR DESCRIPTION
Closes #312.

See https://github.com/jezdez/setup-miniconda-test/actions for examples.