### PR TITLE
Fall back to miniconda3 latest when no bundled version + empty with params

### DIFF
--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -25,7 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macos-14"]
-        variant: ["Miniforge3", "Mambaforge", "Miniconda", "no-variant"]
+        variant:
+          ["Miniforge3", "Mambaforge", "Miniconda", "no-variant", "empty-with"]
     steps:
       - uses: actions/checkout@v4
       - uses: ./
@@ -46,10 +47,14 @@ jobs:
           miniconda-version: latest
       - uses: ./
         if: matrix.variant == 'no-variant'
-        id: setup-miniconda2
+        id: setup-miniconda-no-variant
         continue-on-error: true
         with:
           miniforge-version: latest
+      - uses: ./
+        if: matrix.variant == 'empty-with'
+        id: setup-miniconda-empty-with
+        continue-on-error: true
       - name: Conda info
         shell: bash -el {0}
         run: conda info

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -68,7 +68,7 @@ jobs:
         shell: bash -el {0}
         run: conda create -n unused --dry-run zlib
       - name: Run mamba
-        if: matrix.variant != 'Miniconda'
+        if: matrix.variant == 'Miniforge3' || matrix.variant == 'Mambaforge'
         shell: bash -el {0}
         run: mamba --version
       - name: Install Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [#335] Bump conda-incubator/setup-miniconda from 3.0.1 to 3.0.2
 
 [v3.0.3]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v3.0.3
-[#335]: https://github.com/conda-incubator/setup-miniconda/pull/336
+[#335]: https://github.com/conda-incubator/setup-miniconda/pull/335
 [#336]: https://github.com/conda-incubator/setup-miniconda/pull/336
 
 ## [v3.0.2] (2024-02-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## [v3.0.3] (2024-02-27)
+
+### Fixes
+
+- [#336] Fall back to miniconda3 latest when no bundled version + empty with
+  params
+
+### Tasks and Maintenance
+
+- [#335] Bump conda-incubator/setup-miniconda from 3.0.1 to 3.0.2
+
+[v3.0.3]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v3.0.3
+[#335]: https://github.com/conda-incubator/setup-miniconda/pull/336
+[#336]: https://github.com/conda-incubator/setup-miniconda/pull/336
+
 ## [v3.0.2] (2024-02-22)
 
 ### Fixes

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -49176,7 +49176,7 @@ const bundled_miniconda_1 = __nccwpck_require__(3390);
  * - add any new RULEs in ../input.ts, for example if the installer is not
  *   compatible with some architectures
  * - add a test!
- * - The order is impprtant:
+ * - The order is important:
  *   - the first provider that provides according to the inputs/options is used.
  *   - the last provider has a fallback in case of no inputs given.
  */

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -48920,7 +48920,8 @@ function downloadMiniconda(pythonMajorVersion, inputs) {
         }
         let extension = constants.IS_UNIX ? "sh" : "exe";
         let osName = constants.OS_NAMES[process.platform];
-        const minicondaInstallerName = `Miniconda${pythonMajorVersion}-${inputs.minicondaVersion}-${osName}-${arch}.${extension}`;
+        let minicondaVersion = inputs.minicondaVersion || "latest";
+        const minicondaInstallerName = `Miniconda${pythonMajorVersion}-${minicondaVersion}-${osName}-${arch}.${extension}`;
         core.info(minicondaInstallerName);
         // Check version name
         let versions = yield minicondaVersions(arch);
@@ -48948,7 +48949,7 @@ exports.downloadMiniconda = downloadMiniconda;
 exports.minicondaDownloader = {
     label: "download Miniconda",
     provides: (inputs, options) => __awaiter(void 0, void 0, void 0, function* () {
-        return inputs.minicondaVersion !== "" && inputs.installerUrl === "";
+        return inputs.installerUrl === "";
     }),
     installerPath: (inputs, options) => __awaiter(void 0, void 0, void 0, function* () {
         return {
@@ -49175,12 +49176,15 @@ const bundled_miniconda_1 = __nccwpck_require__(3390);
  * - add any new RULEs in ../input.ts, for example if the installer is not
  *   compatible with some architectures
  * - add a test!
+ * - The order is impprtant:
+ *   - the first provider that provides according to the inputs/options is used.
+ *   - the last provider has a fallback in case of no inputs given.
  */
 const INSTALLER_PROVIDERS = [
     bundled_miniconda_1.bundledMinicondaUser,
     download_url_1.urlDownloader,
-    download_miniconda_1.minicondaDownloader,
     download_miniforge_1.miniforgeDownloader,
+    download_miniconda_1.minicondaDownloader,
 ];
 /** See if any provider works with the given inputs and options */
 function getLocalInstallerPath(inputs, options) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -48933,7 +48933,7 @@ function downloadMiniconda(pythonMajorVersion, inputs) {
         return yield base.ensureLocalInstaller({
             url: constants.MINICONDA_BASE_URL + minicondaInstallerName,
             tool: `Miniconda${pythonMajorVersion}`,
-            version: inputs.minicondaVersion,
+            version: minicondaVersion,
             arch: arch,
         });
     });

--- a/src/installer/download-miniconda.ts
+++ b/src/installer/download-miniconda.ts
@@ -59,7 +59,8 @@ export async function downloadMiniconda(
 
   let extension: string = constants.IS_UNIX ? "sh" : "exe";
   let osName: string = constants.OS_NAMES[process.platform];
-  const minicondaInstallerName: string = `Miniconda${pythonMajorVersion}-${inputs.minicondaVersion}-${osName}-${arch}.${extension}`;
+  let minicondaVersion = inputs.minicondaVersion || "latest";
+  const minicondaInstallerName: string = `Miniconda${pythonMajorVersion}-${minicondaVersion}-${osName}-${arch}.${extension}`;
   core.info(minicondaInstallerName);
 
   // Check version name
@@ -90,7 +91,7 @@ export async function downloadMiniconda(
 export const minicondaDownloader: types.IInstallerProvider = {
   label: "download Miniconda",
   provides: async (inputs, options) => {
-    return inputs.minicondaVersion !== "" && inputs.installerUrl === "";
+    return inputs.installerUrl === "";
   },
   installerPath: async (inputs, options) => {
     return {

--- a/src/installer/download-miniconda.ts
+++ b/src/installer/download-miniconda.ts
@@ -76,7 +76,7 @@ export async function downloadMiniconda(
   return await base.ensureLocalInstaller({
     url: constants.MINICONDA_BASE_URL + minicondaInstallerName,
     tool: `Miniconda${pythonMajorVersion}`,
-    version: inputs.minicondaVersion,
+    version: minicondaVersion,
     arch: arch,
   });
 }

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -22,7 +22,7 @@ import { bundledMinicondaUser } from "./bundled-miniconda";
  * - add any new RULEs in ../input.ts, for example if the installer is not
  *   compatible with some architectures
  * - add a test!
- * - The order is impprtant:
+ * - The order is important:
  *   - the first provider that provides according to the inputs/options is used.
  *   - the last provider has a fallback in case of no inputs given.
  */

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -22,12 +22,15 @@ import { bundledMinicondaUser } from "./bundled-miniconda";
  * - add any new RULEs in ../input.ts, for example if the installer is not
  *   compatible with some architectures
  * - add a test!
+ * - The order is impprtant:
+ *   - the first provider that provides according to the inputs/options is used.
+ *   - the last provider has a fallback in case of no inputs given.
  */
 const INSTALLER_PROVIDERS: types.IInstallerProvider[] = [
   bundledMinicondaUser,
   urlDownloader,
-  minicondaDownloader,
   miniforgeDownloader,
+  minicondaDownloader,
 ];
 
 /** See if any provider works with the given inputs and options */


### PR DESCRIPTION
Fall back to miniconda3 latest when no bundled version + empty with params. Fixes the no "with"-parameters case on osx-arm64 while there is no bundled version available as found here https://github.com/conda/conda/actions/runs/8057143952/job/22019628418