### PR TITLE
Add `installation-dir` to customize where the installers are installed to

### DIFF
--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -45,7 +45,7 @@ jobs:
           conda list
           python -VV
           printenv | sort
-  
+
   example-10-miniforge-installation-dir:
     # prevent cronjobs from running on forks
     if:

--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -45,6 +45,34 @@ jobs:
           conda list
           python -VV
           printenv | sort
+  
+  example-10-miniforge-installation-dir:
+    # prevent cronjobs from running on forks
+    if:
+      (github.event_name == 'schedule' && github.repository ==
+      'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
+    name: Ex10 (${{ matrix.os }}, Miniforge)
+    runs-on: ${{ matrix.os }}-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu", "macos", "windows"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        id: setup-miniconda
+        with:
+          environment-file: etc/example-environment.yml
+          miniforge-version: latest
+          installation-dir: ${{ github.workspace }}/miniforge-latest
+      - run: |
+          conda info
+          conda list
+          python -VV
+          printenv | sort
 
   example-10-mambaforge:
     # NOTE: Mambaforge is now equivalent to Miniforge.

--- a/README.md
+++ b/README.md
@@ -521,8 +521,8 @@ jobs:
 In addition to `Miniforge3` with `conda`, `mamba` and `CPython`, you can also
 install `Miniforge-pypy3`, which replaces `CPython` with `PyPy.
 
-> [!TIP]
-> You can customize the installation directory via the `installation-dir` option.
+> [!TIP] You can customize the installation directory via the `installation-dir`
+> option.
 
 ### Example 11: Alternative Architectures
 

--- a/README.md
+++ b/README.md
@@ -521,6 +521,9 @@ jobs:
 In addition to `Miniforge3` with `conda`, `mamba` and `CPython`, you can also
 install `Miniforge-pypy3`, which replaces `CPython` with `PyPy.
 
+> [!TIP]
+> You can customize the installation directory via the `installation-dir` option.
+
 ### Example 11: Alternative Architectures
 
 In addition to the default 64-bit builds of Miniconda, 32-bit versions are

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,11 @@ inputs:
       installers"
     required: false
     default: ""
+  install-dir:
+    description:
+      "If provided, the installer will be installed in the given directory."
+    required: false
+    default: ""
   miniconda-version:
     description:
       "If provided, this version of Miniconda3 will be downloaded and installed.

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -47236,7 +47236,9 @@ function condaBasePath(inputs, options) {
         condaPath = constants.MINICONDA_DIR_PATH;
     }
     else if (inputs.installationDir) {
-        condaPath = inputs.installationDir;
+        condaPath = constants.IS_WINDOWS
+            ? inputs.installationDir.replace("/", "\\")
+            : inputs.installationDir;
     }
     else {
         condaPath = path.join(os.homedir(), "miniconda3");

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -47290,10 +47290,15 @@ function condaExecutable(inputs, options, subcommand) {
     throw Error(`No existing ${options.useMamba ? "mamba" : "conda"} executable found at any of ${locations}`);
 }
 exports.condaExecutable = condaExecutable;
-/** Detect the presence of mamba */
+/**
+ * Detect the presence of mamba
+ */
 function isMambaInstalled(inputs, options) {
-    const mamba = condaExecutable(inputs, Object.assign(Object.assign({}, options), { useMamba: true }));
-    return fs.existsSync(mamba);
+    for (const exe of condaExecutableLocations(inputs, Object.assign(Object.assign({}, options), { useMamba: true }))) {
+        if (fs.existsSync(exe))
+            return true;
+    }
+    return false;
 }
 exports.isMambaInstalled = isMambaInstalled;
 /**
@@ -47302,7 +47307,11 @@ exports.isMambaInstalled = isMambaInstalled;
 function condaCommand(cmd, inputs, options) {
     return __awaiter(this, void 0, void 0, function* () {
         const command = [condaExecutable(inputs, options, cmd[0]), ...cmd];
-        return yield utils.execute(command);
+        let env = {};
+        if (options.useMamba) {
+            env.MAMBA_ROOT_PREFIX = condaBasePath(inputs, options);
+        }
+        return yield utils.execute(command, env);
     });
 }
 exports.condaCommand = condaCommand;

--- a/src/base-tools/index.ts
+++ b/src/base-tools/index.ts
@@ -55,7 +55,11 @@ export async function installBaseTools(
   }
 
   if (tools.length) {
-    await conda.condaCommand(["install", "--name", "base", ...tools], options);
+    await conda.condaCommand(
+      ["install", "--name", "base", ...tools],
+      inputs,
+      options,
+    );
 
     // *Now* use the new options, as we may have a new conda/mamba with more supported
     // options that previously failed

--- a/src/base-tools/update-mamba.ts
+++ b/src/base-tools/update-mamba.ts
@@ -29,7 +29,7 @@ export const updateMamba: types.IToolProvider = {
     }
     core.info("Creating bash wrapper for `mamba`...");
     // Add bat-less forwarder for bash users on Windows
-    const mambaBat = conda.condaExecutable(options).replace(/\\/g, "/");
+    const mambaBat = conda.condaExecutable(inputs, options).replace(/\\/g, "/");
 
     const contents = `bash.exe -c "exec '${mambaBat}' $*" || exit 1`;
     fs.writeFileSync(mambaBat.slice(0, -4), contents);

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -95,13 +95,20 @@ export function condaExecutable(
   );
 }
 
-/** Detect the presence of mamba */
+/**
+ * Detect the presence of mamba
+ */
 export function isMambaInstalled(
   inputs: types.IActionInputs,
   options: types.IDynamicOptions,
 ) {
-  const mamba = condaExecutable(inputs, { ...options, useMamba: true });
-  return fs.existsSync(mamba);
+  for (const exe of condaExecutableLocations(inputs, {
+    ...options,
+    useMamba: true,
+  })) {
+    if (fs.existsSync(exe)) return true;
+  }
+  return false;
 }
 
 /**
@@ -113,7 +120,11 @@ export async function condaCommand(
   options: types.IDynamicOptions,
 ): Promise<void> {
   const command = [condaExecutable(inputs, options, cmd[0]), ...cmd];
-  return await utils.execute(command);
+  let env: { [key: string]: string } = {};
+  if (options.useMamba) {
+    env.MAMBA_ROOT_PREFIX = condaBasePath(inputs, options);
+  }
+  return await utils.execute(command, env);
 }
 
 /**

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -24,7 +24,9 @@ export function condaBasePath(
   if (options.useBundled) {
     condaPath = constants.MINICONDA_DIR_PATH;
   } else if (inputs.installationDir) {
-    condaPath = inputs.installationDir;
+    condaPath = constants.IS_WINDOWS
+      ? inputs.installationDir.replace("/", "\\")
+      : inputs.installationDir;
   } else {
     condaPath = path.join(os.homedir(), "miniconda3");
   }

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -42,7 +42,7 @@ export async function ensureEnvironment(
       const args = await provider.condaArgs(inputs, options);
       return await core.group(
         `Updating '${inputs.activateEnvironment}' env from ${provider.label}...`,
-        () => conda.condaCommand(args, options),
+        () => conda.condaCommand(args, inputs, options),
       );
     }
   }

--- a/src/input.ts
+++ b/src/input.ts
@@ -87,6 +87,7 @@ export async function parseInputs(): Promise<types.IActionInputs> {
     condaVersion: core.getInput("conda-version"),
     environmentFile: core.getInput("environment-file"),
     installerUrl: core.getInput("installer-url"),
+    installDir: core.getInput("install-dir"),
     mambaVersion: core.getInput("mamba-version"),
     useMamba: core.getInput("use-mamba"),
     minicondaVersion: core.getInput("miniconda-version"),

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -85,7 +85,7 @@ export async function runInstaller(
   await utils.execute(command);
 
   // The installer may have provisioned `mamba` in `base`: use now if requested
-  const mambaInInstaller = conda.isMambaInstalled(options);
+  const mambaInInstaller = conda.isMambaInstalled(inputs, options);
   if (mambaInInstaller) {
     core.info("Mamba was found in the `base` env");
     options = {

--- a/src/outputs.ts
+++ b/src/outputs.ts
@@ -14,10 +14,14 @@ import * as utils from "./utils";
  * Add Conda executable to PATH environment variable
  */
 export async function setPathVariables(
+  inputs: types.IActionInputs,
   options: types.IDynamicOptions,
 ): Promise<void> {
-  const condaBin: string = path.join(conda.condaBasePath(options), "condabin");
-  const condaPath: string = conda.condaBasePath(options);
+  const condaBin: string = path.join(
+    conda.condaBasePath(inputs, options),
+    "condabin",
+  );
+  const condaPath: string = conda.condaBasePath(inputs, options);
   core.info(`Add "${condaBin}" to PATH`);
   core.addPath(condaBin);
   if (!options.useBundled) {
@@ -29,9 +33,16 @@ export async function setPathVariables(
 /**
  * Ensure the conda cache path is available as an environment variable
  */
-export async function setCacheVariable(options: types.IDynamicOptions) {
+export async function setCacheVariable(
+  inputs: types.IActionInputs,
+  options: types.IDynamicOptions,
+) {
   const folder = utils.cacheFolder();
-  await conda.condaCommand(["config", "--add", "pkgs_dirs", folder], options);
+  await conda.condaCommand(
+    ["config", "--add", "pkgs_dirs", folder],
+    inputs,
+    options,
+  );
   core.exportVariable(constants.ENV_VAR_CONDA_PKGS, folder);
 }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -34,7 +34,7 @@ async function setupMiniconda(inputs: types.IActionInputs): Promise<void> {
   // The desired installer may change the options
   options = { ...options, ...installerInfo.options };
 
-  const basePath = conda.condaBasePath(options);
+  const basePath = conda.condaBasePath(inputs, options);
 
   if (installerInfo.localInstallerPath && !options.useBundled) {
     options = await core.group("Running installer...", () =>
@@ -59,7 +59,7 @@ async function setupMiniconda(inputs: types.IActionInputs): Promise<void> {
   }
 
   await core.group("Setup environment variables...", () =>
-    outputs.setPathVariables(options),
+    outputs.setPathVariables(inputs, options),
   );
 
   if (inputs.condaConfigFile) {
@@ -72,7 +72,7 @@ async function setupMiniconda(inputs: types.IActionInputs): Promise<void> {
   );
 
   await core.group("Configuring conda package cache...", () =>
-    outputs.setCacheVariable(options),
+    outputs.setCacheVariable(inputs, options),
   );
 
   await core.group("Applying initial configuration...", () =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,7 @@ export interface IActionInputs {
   readonly condaVersion: string;
   readonly environmentFile: string;
   readonly installerUrl: string;
+  readonly installDir: string;
   readonly mambaVersion: string;
   readonly minicondaVersion: string;
   readonly miniforgeVariant: string;


### PR DESCRIPTION
This is useful for self-hosted runners where we can change the installation directory to the workspace directory to allow automatic cleaning up of the miniforge/miniconda environments.