### PR TITLE
set CONDA environment variable regardless of useBundled option

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -49516,10 +49516,8 @@ function setPathVariables(options) {
         const condaPath = conda.condaBasePath(options);
         core.info(`Add "${condaBin}" to PATH`);
         core.addPath(condaBin);
-        if (!options.useBundled) {
-            core.info(`Set 'CONDA="${condaPath}"'`);
-            core.exportVariable("CONDA", condaPath);
-        }
+        core.info(`Set 'CONDA="${condaPath}"'`);
+        core.exportVariable("CONDA", condaPath);
     });
 }
 exports.setPathVariables = setPathVariables;

--- a/src/outputs.ts
+++ b/src/outputs.ts
@@ -20,10 +20,8 @@ export async function setPathVariables(
   const condaPath: string = conda.condaBasePath(options);
   core.info(`Add "${condaBin}" to PATH`);
   core.addPath(condaBin);
-  if (!options.useBundled) {
-    core.info(`Set 'CONDA="${condaPath}"'`);
-    core.exportVariable("CONDA", condaPath);
-  }
+  core.info(`Set 'CONDA="${condaPath}"'`);
+  core.exportVariable("CONDA", condaPath);
 }
 
 /**


### PR DESCRIPTION
This change fixes #349  

I have tested this change using the workflow file in the issue. I can't think of any reason you would not want `CONDA` environment variable set after `setup-miniconda` actions runs. Therefore, regardless of the value of `useBundled` let's set `CONDA` environment variable.