### PR TITLE
Ignore conda cygpath warning

### DIFF
--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -26253,6 +26253,8 @@ exports.IGNORED_WARNINGS = [
     `Key 'use_only_tar_bz2' is not a known primitive parameter.`,
     // Channel warnings are very boring and noisy
     `moving to the top`,
+    // This warning has no consequence for the installation and is noisy
+    `cygpath is not available, fallback to manual path conversion`,
 ];
 /**
  * Warnings that should be errors

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -47559,6 +47559,8 @@ exports.IGNORED_WARNINGS = [
     `Key 'use_only_tar_bz2' is not a known primitive parameter.`,
     // Channel warnings are very boring and noisy
     `moving to the top`,
+    // This warning has no consequence for the installation and is noisy
+    `cygpath is not available, fallback to manual path conversion`,
 ];
 /**
  * Warnings that should be errors

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,6 +86,8 @@ export const IGNORED_WARNINGS = [
   `Key 'use_only_tar_bz2' is not a known primitive parameter.`,
   // Channel warnings are very boring and noisy
   `moving to the top`,
+  // This warning has no consequence for the installation and is noisy
+  `cygpath is not available, fallback to manual path conversion`,
 ];
 
 /**


### PR DESCRIPTION
`cygpath` is generally not available on Windows and the fallback solution works just fine. The resulting warning is confusing and visible in the summary of the run. Add the cygpath warning to the list of warnings to ignore.

Closes #354 