### PR TITLE
Remove defaults channel on input `channel: nodefaults`

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -47289,7 +47289,7 @@ function applyCondaConfiguration(inputs, options) {
                 try {
                     yield condaCommand(["config", "--remove", "channels", "defaults"], options);
                 }
-                catch (error) {
+                catch (err) {
                     core.info("Removing defaults raised an error -- it was probably not present.");
                 }
             }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -47284,9 +47284,14 @@ function applyCondaConfiguration(inputs, options) {
         // LIFO: reverse order to preserve higher priority as listed in the option
         // .slice ensures working against a copy
         for (const channel of channels.slice().reverse()) {
+            core.info("Removing channel defaults");
             if (channel === "nodefaults") {
-                core.info("Removing channel defaults");
-                yield condaCommand(["config", "--remove", "channels", "defaults"], options);
+                try {
+                    yield condaCommand(["config", "--remove", "channels", "defaults"], options);
+                }
+                catch (error) {
+                    core.info("Removing defaults raised an error -- it was probably not present.");
+                }
             }
             else {
                 core.info(`Adding channel '${channel}'`);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -47284,8 +47284,8 @@ function applyCondaConfiguration(inputs, options) {
         // LIFO: reverse order to preserve higher priority as listed in the option
         // .slice ensures working against a copy
         for (const channel of channels.slice().reverse()) {
-            core.info("Removing channel defaults");
             if (channel === "nodefaults") {
+                core.info("Removing channel defaults");
                 try {
                     yield condaCommand(["config", "--remove", "channels", "defaults"], options);
                 }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -47284,8 +47284,14 @@ function applyCondaConfiguration(inputs, options) {
         // LIFO: reverse order to preserve higher priority as listed in the option
         // .slice ensures working against a copy
         for (const channel of channels.slice().reverse()) {
-            core.info(`Adding channel '${channel}'`);
-            yield condaCommand(["config", "--add", "channels", channel], options);
+            if (channel === "nodefaults") {
+                core.info("Removing channel defaults");
+                yield condaCommand(["config", "--remove", "channels", "defaults"], options);
+            }
+            else {
+                core.info(`Adding channel '${channel}'`);
+                yield condaCommand(["config", "--add", "channels", channel], options);
+            }
         }
         // All other options are just passed as their string representations
         for (const [key, value] of configEntries) {

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -133,7 +133,7 @@ export async function applyCondaConfiguration(
           ["config", "--remove", "channels", "defaults"],
           options,
         );
-      } catch (error) {
+      } catch (err) {
         core.info(
           "Removing defaults raised an error -- it was probably not present.",
         );

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -126,12 +126,18 @@ export async function applyCondaConfiguration(
   // LIFO: reverse order to preserve higher priority as listed in the option
   // .slice ensures working against a copy
   for (const channel of channels.slice().reverse()) {
+    core.info("Removing channel defaults");
     if (channel === "nodefaults") {
-      core.info("Removing channel defaults");
-      await condaCommand(
-        ["config", "--remove", "channels", "defaults"],
-        options,
-      );
+      try {
+        await condaCommand(
+          ["config", "--remove", "channels", "defaults"],
+          options,
+        );
+      } catch (error) {
+        core.info(
+          "Removing defaults raised an error -- it was probably not present.",
+        );
+      }
     } else {
       core.info(`Adding channel '${channel}'`);
       await condaCommand(["config", "--add", "channels", channel], options);

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -126,8 +126,8 @@ export async function applyCondaConfiguration(
   // LIFO: reverse order to preserve higher priority as listed in the option
   // .slice ensures working against a copy
   for (const channel of channels.slice().reverse()) {
-    core.info("Removing channel defaults");
     if (channel === "nodefaults") {
+      core.info("Removing channel defaults");
       try {
         await condaCommand(
           ["config", "--remove", "channels", "defaults"],

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -126,8 +126,16 @@ export async function applyCondaConfiguration(
   // LIFO: reverse order to preserve higher priority as listed in the option
   // .slice ensures working against a copy
   for (const channel of channels.slice().reverse()) {
-    core.info(`Adding channel '${channel}'`);
-    await condaCommand(["config", "--add", "channels", channel], options);
+    if (channel === "nodefaults") {
+      core.info("Removing channel defaults");
+      await condaCommand(
+        ["config", "--remove", "channels", "defaults"],
+        options,
+      );
+    } else {
+      core.info(`Adding channel '${channel}'`);
+      await condaCommand(["config", "--add", "channels", channel], options);
+    }
   }
 
   // All other options are just passed as their string representations


### PR DESCRIPTION
Changes conda setup to run `conda config --remove channels defaults` when `nodefaults` is found in the `channels` input instead of adding the `- nodefaults` channel. I.e.

```
- uses: conda-incubator/setup-miniconda
      with:
        channels: conda-forge,nodefaults
        channel-priority: strict
```

Will correctly give

```
channels:
- conda-forge
dependencies:
...
```

Instead of 


```
channels:
- conda-forge
- nodefaults
dependencies:
...
```

[Here is a log](https://github.com/liamhuber/test-setup-minconda/actions/runs/10568363909/job/29279169033) of the modified version in action.

Closes #207 