### PR TITLE
Make nodefauls warning explicit

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -46850,8 +46850,8 @@ function applyCondaConfiguration(inputs, options) {
         for (const channel of channels.slice().reverse()) {
             if (channel === "nodefaults") {
                 core.warning("'nodefaults' channel detected: will remove 'defaults' if added implicitly. " +
-                    "In the future, 'nodefaults' as a way of removing 'defaults' won't be supported. " +
-                    "Please set 'conda-remove-defaults' = 'true' to remove this warning.");
+                    "In the future, 'nodefaults' to remove 'defaults' won't be supported. " +
+                    "Please set 'conda-remove-defaults' = 'true' in setup-miniconda to remove this warning.");
                 removeDefaults = true;
                 continue;
             }

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -184,8 +184,8 @@ export async function applyCondaConfiguration(
     if (channel === "nodefaults") {
       core.warning(
         "'nodefaults' channel detected: will remove 'defaults' if added implicitly. " +
-          "In the future, 'nodefaults' as a way of removing 'defaults' won't be supported. " +
-          "Please set 'conda-remove-defaults' = 'true' to remove this warning.",
+          "In the future, 'nodefaults' to remove 'defaults' won't be supported. " +
+          "Please set 'conda-remove-defaults' = 'true' in setup-miniconda to remove this warning.",
       );
       removeDefaults = true;
       continue;


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/setup-miniconda/issues/377

Making this warning more explicit should enhance the end-user experience and point them to where they should make changes in their workflows.
