### PR TITLE
Ignore auto_activate warning

### DIFF
--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -28434,6 +28434,8 @@ exports.IGNORED_WARNINGS = [
     `moving to the top`,
     // This warning has no consequence for the installation and is noisy
     `cygpath is not available, fallback to manual path conversion`,
+    // Harmless warning for older Conda versions use auto_activate instead of auto_activate_base
+    `'auto_activate': unknown parameter`,
 ];
 /**
  * Warnings that should be errors

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -47260,6 +47260,8 @@ exports.IGNORED_WARNINGS = [
     `moving to the top`,
     // This warning has no consequence for the installation and is noisy
     `cygpath is not available, fallback to manual path conversion`,
+    // Harmless warning for older Conda versions use auto_activate instead of auto_activate_base
+    `'auto_activate': unknown parameter`,
 ];
 /**
  * Warnings that should be errors

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -88,6 +88,8 @@ export const IGNORED_WARNINGS = [
   `moving to the top`,
   // This warning has no consequence for the installation and is noisy
   `cygpath is not available, fallback to manual path conversion`,
+  // Harmless warning for older Conda versions use auto_activate instead of auto_activate_base
+  `'auto_activate': unknown parameter`,
 ];
 
 /**


### PR DESCRIPTION
This warning appears with older Conda versions that use auto_activate instead of auto_activate_base

Closes: https://github.com/conda-incubator/setup-miniconda/issues/407