### PR TITLE
Activate default environment instead of `base` environment

### DIFF
--- a/.github/workflows/example-16.yml
+++ b/.github/workflows/example-16.yml
@@ -1,0 +1,126 @@
+name: "Example 16: Default environment activation"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - default-env-condarc-test
+  schedule:
+    # Note that cronjobs run on master/main by default
+    - cron: "0 0 * * *"
+
+jobs:
+  example-16:
+    # prevent cronjobs from running on forks
+    if:
+      (github.event_name == 'schedule' && github.repository ==
+      'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
+    name:
+      Ex16 (os=${{matrix.os}}, default env=${{ matrix.add-activation-env ==
+      'true' && 'default' || 'base' }})
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        add-activation-env: ["false", "true"]
+        os: ["ubuntu", "windows"]
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download micromamba to create installer
+        uses: mamba-org/setup-micromamba@7f29b8b80078b1b601dfa018b0f7425c587c63bb # v2.0.6
+        with:
+          init-shell: none
+          micromamba-version: "latest"
+
+      - name: Set up Miniconda for installer builds
+        uses: ./
+        with:
+          activate-environment: ""
+          auto-activate: false
+
+      - name: Create installer
+        uses: conda-incubator/installer@2d2df0b03c6795f70e128c56403c7d084cca4fb8 # v0.1.0
+        id: create-installer
+        with:
+          conda-root: ${{ env.CONDA }}
+          environment-yaml-string: |
+            channels:
+              - conda-forge
+            dependencies:
+              - constructor
+            variables:
+              ADD_ACTIVATION_ENV: '${{ matrix.add-activation-env }}'
+              EXT: ${{ matrix.os == 'windows' && 'exe' || 'sh' }}
+          input-directory: etc/example-installers/default-environment/
+
+      - name: Determine installer file name
+        id: installer-file
+        env:
+          ARTIFACTS_DIRECTORY:
+            ${{ steps.create-installer.outputs.artifacts-directory }}
+          EXT: ${{ matrix.os == 'windows' && 'exe' || 'sh' }}
+        run: |
+          INSTALLER_FILE=$(find "${ARTIFACTS_DIRECTORY}" -name "*.${EXT}" | head -n 1)
+          echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
+        shell: bash
+
+      - name: Run installation
+        uses: ./
+        with:
+          activate-environment: ""
+          auto-activate: true
+          installation-dir: ${{ runner.temp }}/installer_test
+          installer-url:
+            file://${{ steps.installer-file.outputs.installer-file }}
+
+      - name: Output conda info (bash)
+        env:
+          DEFAULT_ENV: ${{ matrix.add-activation-env && 'default' || 'base' }}
+          TEST_DIR: ${{ runner.temp }}/installer_output
+        run: |
+          mkdir -p ${TEST_DIR}
+          conda info --json > "${TEST_DIR}/bash.json"
+        shell: bash -el {0}
+
+      - name: Output conda info (cmd.exe)
+        if: matrix.os == 'windows'
+        env:
+          TEST_DIR: ${{ runner.temp }}\installer_output
+        run: |
+          type %CONDA%\condabin\conda_hook.bat
+          conda info --json > "%TEST_DIR%\cmd.exe.json"
+        shell: cmd /C CALL {0}
+
+      - name: Output conda info (PowerShell)
+        if: matrix.os == 'windows'
+        env:
+          TEST_DIR: ${{ runner.temp }}\installer_output
+        run: conda info --json > "${env:TEST_DIR}\pwsh.json"
+        shell: pwsh
+
+      - name: Test default environments
+        env:
+          DEFAULT_ENV:
+            ${{ matrix.add-activation-env == 'true' && 'default' || 'base' }}
+          TEST_DIR: ${{ runner.temp }}/installer_output
+        run: |
+          import json
+          import os
+          from pathlib import Path
+          json_dir = Path(os.environ["TEST_DIR"])
+          default_env_expected = os.environ["DEFAULT_ENV"]
+          incorrect_environments = {}
+          for file in json_dir.iterdir():
+              conda_info = json.loads(file.read_text())
+              default_env = conda_info.get("active_prefix_name")
+              if default_env != default_env_expected:
+                incorrect_environments[str(file.name).removesuffix(".json")] = default_env
+          if incorrect_environments:
+              raise AssertionError(
+                  f"Found incorrect default environments: {incorrect_environments}"
+              )
+        shell: python

--- a/.github/workflows/example-16.yml
+++ b/.github/workflows/example-16.yml
@@ -78,6 +78,10 @@ jobs:
         add-activation-env: ["false", "true"]
         os: ["ubuntu", "windows"]
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
       - name: Obtain artifact
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
@@ -92,7 +96,6 @@ jobs:
           ARTIFACTS_DIRECTORY: ${{ runner.temp }}/_installer
           EXT: ${{ matrix.os == 'windows' && 'exe' || 'sh' }}
         run: |
-          [[ "$(uname)" == MINGW* ]] && ARTIFACTS_DIRECTORY=$(cygpath "${ARTIFACTS_DIRECTORY}")
           INSTALLER_FILE=$(find "${ARTIFACTS_DIRECTORY}" -name "*.${EXT}" | head -n 1)
           echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
         shell: bash

--- a/.github/workflows/example-16.yml
+++ b/.github/workflows/example-16.yml
@@ -29,12 +29,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download micromamba to create installer
-        uses: mamba-org/setup-micromamba@7f29b8b80078b1b601dfa018b0f7425c587c63bb # v2.0.6
-        with:
-          init-shell: none
-          micromamba-version: "latest"
-
       - name: Set up Miniconda for installer builds
         uses: ./
         with:

--- a/.github/workflows/example-16.yml
+++ b/.github/workflows/example-16.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - default-env-condarc-test
   schedule:
     # Note that cronjobs run on master/main by default
     - cron: "0 0 * * *"

--- a/.github/workflows/example-16.yml
+++ b/.github/workflows/example-16.yml
@@ -10,14 +10,14 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  example-16:
+  example-16-build:
     # prevent cronjobs from running on forks
     if:
       (github.event_name == 'schedule' && github.repository ==
       'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
     name:
-      Ex16 (os=${{matrix.os}}, default env=${{ matrix.add-activation-env ==
-      'true' && 'default' || 'base' }})
+      Build Ex16 (os=${{matrix.os}}, default env=${{ matrix.add-activation-env
+      == 'true' && 'default' || 'base' }})
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -56,13 +56,43 @@ jobs:
               EXT: ${{ matrix.os == 'windows' && 'exe' || 'sh' }}
           input-directory: etc/example-installers/default-environment/
 
+      - name: Upload installer to Github artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          path: ${{ steps.create-installer.outputs.artifacts-directory }}/*
+          name:
+            ex16-${{ matrix.os }}-${{ matrix.add-activation-env == 'false' &&
+            'no-' }}-activation-env
+
+  example-16-test:
+    needs: [example-16-build]
+    name:
+      Test Ex16 (os=${{matrix.os}}, default env=${{ matrix.add-activation-env ==
+      'true' && 'default' || 'base' }}, auto-activate-base=${{
+      matrix.auto-activate-base }})
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        auto-activate-base: ["false", "true"]
+        add-activation-env: ["false", "true"]
+        os: ["ubuntu", "windows"]
+    steps:
+      - name: Obtain artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name:
+            ex16-${{ matrix.os }}-${{ matrix.add-activation-env == 'false' &&
+            'no-' }}-activation-env
+          path: ${{ runner.temp }}/_installer
+
       - name: Determine installer file name
         id: installer-file
         env:
-          ARTIFACTS_DIRECTORY:
-            ${{ steps.create-installer.outputs.artifacts-directory }}
+          ARTIFACTS_DIRECTORY: ${{ runner.temp }}/_installer
           EXT: ${{ matrix.os == 'windows' && 'exe' || 'sh' }}
         run: |
+          [[ "$(uname)" == MINGW* ]] && ARTIFACTS_DIRECTORY=$(cygpath "${ARTIFACTS_DIRECTORY}")
           INSTALLER_FILE=$(find "${ARTIFACTS_DIRECTORY}" -name "*.${EXT}" | head -n 1)
           echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
         shell: bash
@@ -71,7 +101,11 @@ jobs:
         uses: ./
         with:
           activate-environment: ""
-          auto-activate: true
+          auto-activate-base:
+            ${{ matrix.auto-activate-base == 'true' && 'true' ||
+            'legacy-placeholder' }}
+          auto-activate:
+            ${{ matrix.auto-activate-base == 'true' && '' || 'true' }}
           installation-dir: ${{ runner.temp }}/installer_test
           installer-url:
             file://${{ steps.installer-file.outputs.installer-file }}
@@ -90,7 +124,6 @@ jobs:
         env:
           TEST_DIR: ${{ runner.temp }}\installer_output
         run: |
-          type %CONDA%\condabin\conda_hook.bat
           conda info --json > "%TEST_DIR%\cmd.exe.json"
         shell: cmd /C CALL {0}
 
@@ -104,12 +137,14 @@ jobs:
       - name: Test default environments
         env:
           DEFAULT_ENV:
-            ${{ matrix.add-activation-env == 'true' && 'default' || 'base' }}
+            ${{ matrix.add-activation-env == 'true' && matrix.auto-activate-base
+            == 'false' && 'default' || 'base' }}
           TEST_DIR: ${{ runner.temp }}/installer_output
         run: |
           import json
           import os
           from pathlib import Path
+
           json_dir = Path(os.environ["TEST_DIR"])
           default_env_expected = os.environ["DEFAULT_ENV"]
           incorrect_environments = {}
@@ -117,7 +152,7 @@ jobs:
               conda_info = json.loads(file.read_text())
               default_env = conda_info.get("active_prefix_name")
               if default_env != default_env_expected:
-                incorrect_environments[str(file.name).removesuffix(".json")] = default_env
+                  incorrect_environments[str(file.name).removesuffix(".json")] = default_env
           if incorrect_environments:
               raise AssertionError(
                   f"Found incorrect default environments: {incorrect_environments}"

--- a/.github/workflows/example-3.yml
+++ b/.github/workflows/example-3.yml
@@ -38,7 +38,7 @@ jobs:
           environment-file: etc/example-environment.yml
           python-version: 3.8
           condarc-file: etc/example-condarc.yml
-          auto-activate-base: false
+          auto-activate: false
           auto-update-conda: true
       - run: |
           conda info
@@ -60,7 +60,7 @@ jobs:
           environment-file: etc/example-environment-no-name.yml
           python-version: 3.8
           condarc-file: etc/example-condarc.yml
-          auto-activate-base: false
+          auto-activate: false
           auto-update-conda: true
       - run: |
           conda info

--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ Miniconda installation.
 
 ### Activate `base` environment
 
-If your specific workflow still needs to activate and use the default environment,
-you will need to do **both**:
+If your specific workflow still needs to activate and use the default
+environment, you will need to do **both**:
 
 - set `activate-environment` to an empty string
 - set `auto-activate` to `true`

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ possibility of automatically activating the `test` environment on all shells.
 | [Apple Silicon](#example-13-apple-silicon)                         | [![Apple Silicon][ex13-badge]][ex13]                            |
 | [Remove defaults](#example-14-remove-defaults-channel)             | [![Remove defaults][ex14-badge]][ex14]                          |
 | [Linux ARM](#example-15-linux-arm)                                 | [![Linux ARM][ex15-badge]][ex15]                                |
+| Default environments                                               | [![Default environments][ex16-badge]][ex16]                     |
 
 [ex1]:
   https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-1.yml
@@ -122,6 +123,10 @@ possibility of automatically activating the `test` environment on all shells.
   https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-15.yml
 [ex15-badge]:
   https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-15.yml/badge.svg?branch=main
+[ex16]:
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-16.yml
+[ex16-badge]:
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-16.yml/badge.svg?branch=main
 
 ## Other Workflows
 
@@ -180,16 +185,16 @@ Miniconda installation.
 
 ### Activate `base` environment
 
-If your specific workflow still needs to activate and use `base` you will need
-to do **both** of:
+If your specific workflow still needs to activate and use the default environment,
+you will need to do **both**:
 
 - set `activate-environment` to an empty string
-- set `auto-activate-base` to `true`
+- set `auto-activate` to `true`
 
 ```yaml
 - uses: conda-incubator/setup-miniconda@v3
   with:
-    auto-activate-base: true
+    auto-activate: true
     activate-environment: ""
 ```
 
@@ -330,7 +335,7 @@ jobs:
           environment-file: etc/example-environment.yml
           python-version: 3.5
           condarc-file: etc/example-condarc.yml
-          auto-activate-base: false
+          auto-activate: false
       - run: |
           conda info
           conda list

--- a/action.yml
+++ b/action.yml
@@ -146,11 +146,11 @@ inputs:
     default: "true"
   auto-activate-base:
     description:
-      (deprecated in favor of `auto-activate`)
-      'Conda configuration. If you’d prefer that conda’s base
-      environment not be activated on startup, set the to "false". Default is
-      "true". This setting always overrides if set to "true" or "false". If you
-      want to use the "condarc-file" setting pass an empty string. See
+      (deprecated in favor of `auto-activate`) 'Conda configuration. If you’d
+      prefer that conda’s base environment not be activated on startup, set the
+      to "false". Default is "true". This setting always overrides if set to
+      "true" or "false". If you want to use the "condarc-file" setting pass an
+      empty string. See
       https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/
       for more information.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ inputs:
       'Conda configuration. If you’d prefer that conda’s base environment not be
       activated on startup, set the to "false". Default is "true". This setting
       always overrides if set to "true" or "false". If you want to use the
-      "condarc-file" setting pass and empty string. See
+      "condarc-file" setting pass an empty string. See
       https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/
       for more information.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -134,16 +134,26 @@ inputs:
       for more information.'
     required: false
     default: ""
-  auto-activate-base:
+  auto-activate:
     description:
-      'Conda configuration. If you’d prefer that conda’s base environment not be
-      activated on startup, set the to "false". Default is "true". This setting
-      always overrides if set to "true" or "false". If you want to use the
-      "condarc-file" setting pass an empty string. See
+      'Conda configuration. If you’d prefer that conda’s default environment not
+      be activated on startup, set the to "false". Default is "true". This
+      setting always overrides if set to "true" or "false". If you want to use
+      the "condarc-file" setting pass an empty string. See
       https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/
       for more information.'
     required: false
     default: "true"
+  auto-activate-base:
+    description:
+      (deprecated) 'Conda configuration. If you’d prefer that conda’s base
+      environment not be activated on startup, set the to "false". Default is
+      "true". This setting always overrides if set to "true" or "false". If you
+      want to use the "condarc-file" setting pass an empty string. See
+      https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/
+      for more information.'
+    required: false
+    default: "legacy-placeholder"
   auto-update-conda:
     description:
       'Conda configuration. When "true", conda updates itself any time a user

--- a/action.yml
+++ b/action.yml
@@ -146,7 +146,8 @@ inputs:
     default: "true"
   auto-activate-base:
     description:
-      (deprecated) 'Conda configuration. If you’d prefer that conda’s base
+      (deprecated in favor of `auto-activate`)
+      'Conda configuration. If you’d prefer that conda’s base
       environment not be activated on startup, set the to "false". Default is
       "true". This setting always overrides if set to "true" or "false". If you
       want to use the "condarc-file" setting pass an empty string. See

--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -28694,10 +28694,15 @@ function parseInputs() {
             arch = "aarch64";
         }
         if (core.getInput("auto-activate-base") !== "legacy-placeholder") {
-            core.warning("`auto-activate-base` is deprecated. Please use `auto-activate`.");
+            core.warning("`auto-activate-base` is deprecated. Please use `auto-activate`. " +
+                "If your installer does not use the `base` environment as the default environment, " +
+                "also add `activate-environment: base`.");
         }
         const inputs = Object.freeze({
-            activateEnvironment: core.getInput("activate-environment"),
+            activateEnvironment: core.getInput("auto-activate-base") === "true" &&
+                core.getInput("activate-environment") === ""
+                ? "base"
+                : core.getInput("activate-environment"),
             architecture: arch,
             condaBuildVersion: core.getInput("conda-build-version"),
             condaConfigFile: core.getInput("condarc-file"),

--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -3189,9 +3189,6 @@ function copyFile(srcFile, destFile, force) {
 /***/ 1532:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const ANY = Symbol('SemVer ANY')
 // hoisted class for cyclic dependency
 class Comparator {
@@ -3339,9 +3336,6 @@ const Range = __nccwpck_require__(9828)
 
 /***/ 9828:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SPACE_CHARACTERS = /\s+/g
 
@@ -3904,9 +3898,6 @@ const testSet = (set, version, options) => {
 /***/ 8088:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const debug = __nccwpck_require__(427)
 const { MAX_LENGTH, MAX_SAFE_INTEGER } = __nccwpck_require__(2293)
 const { safeRe: re, t } = __nccwpck_require__(9523)
@@ -3919,7 +3910,7 @@ class SemVer {
 
     if (version instanceof SemVer) {
       if (version.loose === !!options.loose &&
-        version.includePrerelease === !!options.includePrerelease) {
+          version.includePrerelease === !!options.includePrerelease) {
         return version
       } else {
         version = version.version
@@ -4085,19 +4076,6 @@ class SemVer {
   // preminor will bump the version up to the next minor release, and immediately
   // down to pre-release. premajor and prepatch work the same way.
   inc (release, identifier, identifierBase) {
-    if (release.startsWith('pre')) {
-      if (!identifier && identifierBase === false) {
-        throw new Error('invalid increment argument: identifier is empty')
-      }
-      // Avoid an invalid semver results
-      if (identifier) {
-        const match = `-${identifier}`.match(this.options.loose ? re[t.PRERELEASELOOSE] : re[t.PRERELEASE])
-        if (!match || match[1] !== identifier) {
-          throw new Error(`invalid identifier: ${identifier}`)
-        }
-      }
-    }
-
     switch (release) {
       case 'premajor':
         this.prerelease.length = 0
@@ -4127,12 +4105,6 @@ class SemVer {
           this.inc('patch', identifier, identifierBase)
         }
         this.inc('pre', identifier, identifierBase)
-        break
-      case 'release':
-        if (this.prerelease.length === 0) {
-          throw new Error(`version ${this.raw} is not a prerelease`)
-        }
-        this.prerelease.length = 0
         break
 
       case 'major':
@@ -4176,6 +4148,10 @@ class SemVer {
       // 1.0.0 'pre' would become 1.0.0-0 which is the wrong direction.
       case 'pre': {
         const base = Number(identifierBase) ? 1 : 0
+
+        if (!identifier && identifierBase === false) {
+          throw new Error('invalid increment argument: identifier is empty')
+        }
 
         if (this.prerelease.length === 0) {
           this.prerelease = [base]
@@ -4231,9 +4207,6 @@ module.exports = SemVer
 /***/ 8848:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const parse = __nccwpck_require__(5925)
 const clean = (version, options) => {
   const s = parse(version.trim().replace(/^[=v]+/, ''), options)
@@ -4246,9 +4219,6 @@ module.exports = clean
 
 /***/ 5098:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const eq = __nccwpck_require__(1898)
 const neq = __nccwpck_require__(6017)
@@ -4308,9 +4278,6 @@ module.exports = cmp
 
 /***/ 3466:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const parse = __nccwpck_require__(5925)
@@ -4379,9 +4346,6 @@ module.exports = coerce
 /***/ 2156:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const SemVer = __nccwpck_require__(8088)
 const compareBuild = (a, b, loose) => {
   const versionA = new SemVer(a, loose)
@@ -4396,9 +4360,6 @@ module.exports = compareBuild
 /***/ 2804:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compare = __nccwpck_require__(4309)
 const compareLoose = (a, b) => compare(a, b, true)
 module.exports = compareLoose
@@ -4408,9 +4369,6 @@ module.exports = compareLoose
 
 /***/ 4309:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const compare = (a, b, loose) =>
@@ -4423,9 +4381,6 @@ module.exports = compare
 
 /***/ 4297:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const parse = __nccwpck_require__(5925)
 
@@ -4456,13 +4411,20 @@ const diff = (version1, version2) => {
       return 'major'
     }
 
-    // If the main part has no difference
-    if (lowVersion.compareMain(highVersion) === 0) {
-      if (lowVersion.minor && !lowVersion.patch) {
-        return 'minor'
-      }
+    // Otherwise it can be determined by checking the high version
+
+    if (highVersion.patch) {
+      // anything higher than a patch bump would result in the wrong version
       return 'patch'
     }
+
+    if (highVersion.minor) {
+      // anything higher than a minor bump would result in the wrong version
+      return 'minor'
+    }
+
+    // bumping major/minor/patch all have same result
+    return 'major'
   }
 
   // add the `pre` prefix if we are going to a prerelease version
@@ -4492,9 +4454,6 @@ module.exports = diff
 /***/ 1898:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compare = __nccwpck_require__(4309)
 const eq = (a, b, loose) => compare(a, b, loose) === 0
 module.exports = eq
@@ -4504,9 +4463,6 @@ module.exports = eq
 
 /***/ 4123:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const compare = __nccwpck_require__(4309)
 const gt = (a, b, loose) => compare(a, b, loose) > 0
@@ -4518,9 +4474,6 @@ module.exports = gt
 /***/ 5522:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compare = __nccwpck_require__(4309)
 const gte = (a, b, loose) => compare(a, b, loose) >= 0
 module.exports = gte
@@ -4530,9 +4483,6 @@ module.exports = gte
 
 /***/ 900:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 
@@ -4560,9 +4510,6 @@ module.exports = inc
 /***/ 194:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compare = __nccwpck_require__(4309)
 const lt = (a, b, loose) => compare(a, b, loose) < 0
 module.exports = lt
@@ -4572,9 +4519,6 @@ module.exports = lt
 
 /***/ 7520:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const compare = __nccwpck_require__(4309)
 const lte = (a, b, loose) => compare(a, b, loose) <= 0
@@ -4586,9 +4530,6 @@ module.exports = lte
 /***/ 6688:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const SemVer = __nccwpck_require__(8088)
 const major = (a, loose) => new SemVer(a, loose).major
 module.exports = major
@@ -4598,9 +4539,6 @@ module.exports = major
 
 /***/ 8447:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const minor = (a, loose) => new SemVer(a, loose).minor
@@ -4612,9 +4550,6 @@ module.exports = minor
 /***/ 6017:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compare = __nccwpck_require__(4309)
 const neq = (a, b, loose) => compare(a, b, loose) !== 0
 module.exports = neq
@@ -4624,9 +4559,6 @@ module.exports = neq
 
 /***/ 5925:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const parse = (version, options, throwErrors = false) => {
@@ -4651,9 +4583,6 @@ module.exports = parse
 /***/ 2866:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const SemVer = __nccwpck_require__(8088)
 const patch = (a, loose) => new SemVer(a, loose).patch
 module.exports = patch
@@ -4663,9 +4592,6 @@ module.exports = patch
 
 /***/ 4016:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const parse = __nccwpck_require__(5925)
 const prerelease = (version, options) => {
@@ -4680,9 +4606,6 @@ module.exports = prerelease
 /***/ 6417:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compare = __nccwpck_require__(4309)
 const rcompare = (a, b, loose) => compare(b, a, loose)
 module.exports = rcompare
@@ -4693,9 +4616,6 @@ module.exports = rcompare
 /***/ 8701:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compareBuild = __nccwpck_require__(2156)
 const rsort = (list, loose) => list.sort((a, b) => compareBuild(b, a, loose))
 module.exports = rsort
@@ -4705,9 +4625,6 @@ module.exports = rsort
 
 /***/ 6055:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const Range = __nccwpck_require__(9828)
 const satisfies = (version, range, options) => {
@@ -4726,9 +4643,6 @@ module.exports = satisfies
 /***/ 1426:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compareBuild = __nccwpck_require__(2156)
 const sort = (list, loose) => list.sort((a, b) => compareBuild(a, b, loose))
 module.exports = sort
@@ -4738,9 +4652,6 @@ module.exports = sort
 
 /***/ 9601:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const parse = __nccwpck_require__(5925)
 const valid = (version, options) => {
@@ -4754,9 +4665,6 @@ module.exports = valid
 
 /***/ 1383:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 // just pre-load all the stuff that index.js lazily exports
 const internalRe = __nccwpck_require__(9523)
@@ -4854,9 +4762,6 @@ module.exports = {
 /***/ 2293:
 /***/ ((module) => {
 
-"use strict";
-
-
 // Note: this is the semver.org version of the spec that it implements
 // Not necessarily the package version of this code.
 const SEMVER_SPEC_VERSION = '2.0.0'
@@ -4899,9 +4804,6 @@ module.exports = {
 /***/ 427:
 /***/ ((module) => {
 
-"use strict";
-
-
 const debug = (
   typeof process === 'object' &&
   process.env &&
@@ -4917,9 +4819,6 @@ module.exports = debug
 
 /***/ 2463:
 /***/ ((module) => {
-
-"use strict";
-
 
 const numeric = /^[0-9]+$/
 const compareIdentifiers = (a, b) => {
@@ -4950,9 +4849,6 @@ module.exports = {
 
 /***/ 5339:
 /***/ ((module) => {
-
-"use strict";
-
 
 class LRUCache {
   constructor () {
@@ -5001,9 +4897,6 @@ module.exports = LRUCache
 /***/ 785:
 /***/ ((module) => {
 
-"use strict";
-
-
 // parse out just the options we care about
 const looseOption = Object.freeze({ loose: true })
 const emptyOpts = Object.freeze({ })
@@ -5026,9 +4919,6 @@ module.exports = parseOptions
 /***/ 9523:
 /***/ ((module, exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const {
   MAX_SAFE_COMPONENT_LENGTH,
   MAX_SAFE_BUILD_LENGTH,
@@ -5041,7 +4931,6 @@ exports = module.exports = {}
 const re = exports.re = []
 const safeRe = exports.safeRe = []
 const src = exports.src = []
-const safeSrc = exports.safeSrc = []
 const t = exports.t = {}
 let R = 0
 
@@ -5074,7 +4963,6 @@ const createToken = (name, value, isGlobal) => {
   debug(name, index, value)
   t[name] = index
   src[index] = value
-  safeSrc[index] = safe
   re[index] = new RegExp(value, isGlobal ? 'g' : undefined)
   safeRe[index] = new RegExp(safe, isGlobal ? 'g' : undefined)
 }
@@ -5107,14 +4995,12 @@ createToken('MAINVERSIONLOOSE', `(${src[t.NUMERICIDENTIFIERLOOSE]})\\.` +
 
 // ## Pre-release Version Identifier
 // A numeric identifier, or a non-numeric identifier.
-// Non-numberic identifiers include numberic identifiers but can be longer.
-// Therefore non-numberic identifiers must go first.
 
-createToken('PRERELEASEIDENTIFIER', `(?:${src[t.NONNUMERICIDENTIFIER]
-}|${src[t.NUMERICIDENTIFIER]})`)
+createToken('PRERELEASEIDENTIFIER', `(?:${src[t.NUMERICIDENTIFIER]
+}|${src[t.NONNUMERICIDENTIFIER]})`)
 
-createToken('PRERELEASEIDENTIFIERLOOSE', `(?:${src[t.NONNUMERICIDENTIFIER]
-}|${src[t.NUMERICIDENTIFIERLOOSE]})`)
+createToken('PRERELEASEIDENTIFIERLOOSE', `(?:${src[t.NUMERICIDENTIFIERLOOSE]
+}|${src[t.NONNUMERICIDENTIFIER]})`)
 
 // ## Pre-release Version
 // Hyphen, followed by one or more dot-separated pre-release version
@@ -5257,9 +5143,6 @@ createToken('GTE0PRE', '^\\s*>=\\s*0\\.0\\.0-0\\s*$')
 /***/ 9380:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 // Determine if version is greater than all the versions possible in the range.
 const outside = __nccwpck_require__(420)
 const gtr = (version, range, options) => outside(version, range, '>', options)
@@ -5270,9 +5153,6 @@ module.exports = gtr
 
 /***/ 7008:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const Range = __nccwpck_require__(9828)
 const intersects = (r1, r2, options) => {
@@ -5288,9 +5168,6 @@ module.exports = intersects
 /***/ 3323:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const outside = __nccwpck_require__(420)
 // Determine if version is less than all the versions possible in the range
 const ltr = (version, range, options) => outside(version, range, '<', options)
@@ -5301,9 +5178,6 @@ module.exports = ltr
 
 /***/ 579:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const Range = __nccwpck_require__(9828)
@@ -5337,9 +5211,6 @@ module.exports = maxSatisfying
 /***/ 832:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const SemVer = __nccwpck_require__(8088)
 const Range = __nccwpck_require__(9828)
 const minSatisfying = (versions, range, options) => {
@@ -5370,9 +5241,6 @@ module.exports = minSatisfying
 
 /***/ 4179:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const Range = __nccwpck_require__(9828)
@@ -5441,9 +5309,6 @@ module.exports = minVersion
 
 /***/ 420:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const Comparator = __nccwpck_require__(1532)
@@ -5532,9 +5397,6 @@ module.exports = outside
 /***/ 5297:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 // given a set of versions and a range, create a "simplified" range
 // that includes the same versions that the original range does
 // If the original range is shorter than the simplified one, return that.
@@ -5588,9 +5450,6 @@ module.exports = (versions, range, options) => {
 
 /***/ 7863:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const Range = __nccwpck_require__(9828)
 const Comparator = __nccwpck_require__(1532)
@@ -5846,9 +5705,6 @@ module.exports = subset
 /***/ 2706:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const Range = __nccwpck_require__(9828)
 
 // Mostly just for testing and legacy API reasons
@@ -5863,9 +5719,6 @@ module.exports = toComparators
 
 /***/ 2098:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const Range = __nccwpck_require__(9828)
 const validRange = (range, options) => {
@@ -11490,7 +11343,7 @@ module.exports = {
 
 
 const { parseSetCookie } = __nccwpck_require__(4408)
-const { stringify } = __nccwpck_require__(3121)
+const { stringify, getHeadersList } = __nccwpck_require__(3121)
 const { webidl } = __nccwpck_require__(1744)
 const { Headers } = __nccwpck_require__(554)
 
@@ -11566,13 +11419,14 @@ function getSetCookies (headers) {
 
   webidl.brandCheck(headers, Headers, { strict: false })
 
-  const cookies = headers.getSetCookie()
+  const cookies = getHeadersList(headers).cookies
 
   if (!cookies) {
     return []
   }
 
-  return cookies.map((pair) => parseSetCookie(pair))
+  // In older versions of undici, cookies is a list of name:value.
+  return cookies.map((pair) => parseSetCookie(Array.isArray(pair) ? pair[1] : pair))
 }
 
 /**
@@ -12000,15 +11854,14 @@ module.exports = {
 /***/ }),
 
 /***/ 3121:
-/***/ ((module) => {
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-/**
- * @param {string} value
- * @returns {boolean}
- */
+const assert = __nccwpck_require__(9491)
+const { kHeadersList } = __nccwpck_require__(2785)
+
 function isCTLExcludingHtab (value) {
   if (value.length === 0) {
     return false
@@ -12269,13 +12122,31 @@ function stringify (cookie) {
   return out.join('; ')
 }
 
+let kHeadersListNode
+
+function getHeadersList (headers) {
+  if (headers[kHeadersList]) {
+    return headers[kHeadersList]
+  }
+
+  if (!kHeadersListNode) {
+    kHeadersListNode = Object.getOwnPropertySymbols(headers).find(
+      (symbol) => symbol.description === 'headers list'
+    )
+
+    assert(kHeadersListNode, 'Headers cannot be parsed')
+  }
+
+  const headersList = headers[kHeadersListNode]
+  assert(headersList)
+
+  return headersList
+}
+
 module.exports = {
   isCTLExcludingHtab,
-  validateCookieName,
-  validateCookiePath,
-  validateCookieValue,
-  toIMFDate,
-  stringify
+  stringify,
+  getHeadersList
 }
 
 
@@ -14204,14 +14075,6 @@ const { isUint8Array, isArrayBuffer } = __nccwpck_require__(9830)
 const { File: UndiciFile } = __nccwpck_require__(8511)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(685)
 
-let random
-try {
-  const crypto = __nccwpck_require__(6005)
-  random = (max) => crypto.randomInt(0, max)
-} catch {
-  random = (max) => Math.floor(Math.random(max))
-}
-
 let ReadableStream = globalThis.ReadableStream
 
 /** @type {globalThis['File']} */
@@ -14297,7 +14160,7 @@ function extractBody (object, keepalive = false) {
     // Set source to a copy of the bytes held by object.
     source = new Uint8Array(object.buffer.slice(object.byteOffset, object.byteOffset + object.byteLength))
   } else if (util.isFormDataLike(object)) {
-    const boundary = `----formdata-undici-0${`${random(1e11)}`.padStart(11, '0')}`
+    const boundary = `----formdata-undici-0${`${Math.floor(Math.random() * 1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 
     /*! formdata-polyfill. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
@@ -16279,7 +16142,6 @@ const {
   isValidHeaderName,
   isValidHeaderValue
 } = __nccwpck_require__(2538)
-const util = __nccwpck_require__(3837)
 const { webidl } = __nccwpck_require__(1744)
 const assert = __nccwpck_require__(9491)
 
@@ -16833,9 +16695,6 @@ Object.defineProperties(Headers.prototype, {
   [Symbol.toStringTag]: {
     value: 'Headers',
     configurable: true
-  },
-  [util.inspect.custom]: {
-    enumerable: false
   }
 })
 
@@ -26012,20 +25871,6 @@ class Pool extends PoolBase {
       ? { ...options.interceptors }
       : undefined
     this[kFactory] = factory
-
-    this.on('connectionError', (origin, targets, error) => {
-      // If a connection error occurs, we remove the client from the pool,
-      // and emit a connectionError event. They will not be re-used.
-      // Fixes https://github.com/nodejs/undici/issues/3895
-      for (const target of targets) {
-        // Do not use kRemoveClient here, as it will close the client,
-        // but the client cannot be closed in this state.
-        const idx = this[kClients].indexOf(target)
-        if (idx !== -1) {
-          this[kClients].splice(idx, 1)
-        }
-      }
-    })
   }
 
   [kGetDispatcher] () {
@@ -28667,7 +28512,7 @@ const RULES = [
     (i, c) => !!(i.condaVersion && c.auto_update_conda === "true") &&
         `only one of 'conda-version: ${i.condaVersion}' or 'auto-update-conda: true' may be provided`,
     (i) => !!(i.pythonVersion && !i.activateEnvironment) &&
-        `'python-version: ${i.pythonVersion}' requires 'activate-environment: true'`,
+        `'python-version: ${i.pythonVersion}' requires 'activate-environment' to be set`,
     (i) => !!(i.minicondaVersion && i.miniforgeVersion) &&
         `only one of 'miniconda-version: ${i.minicondaVersion}' or 'miniforge-version: ${i.miniforgeVersion}' may be provided`,
     (i) => !!(i.installerUrl && i.minicondaVersion) &&
@@ -28693,6 +28538,9 @@ function parseInputs() {
             // https://github.com/conda-incubator/setup-miniconda/issues/385
             arch = "aarch64";
         }
+        if (core.getInput("auto-activate-base") !== "legacy-placeholder") {
+            core.warning("`auto-activate-base` is deprecated. Please use `auto-activate`.");
+        }
         const inputs = Object.freeze({
             activateEnvironment: core.getInput("activate-environment"),
             architecture: arch,
@@ -28714,11 +28562,14 @@ function parseInputs() {
                 add_anaconda_token: core.getInput("add-anaconda-token"),
                 add_pip_as_python_dependency: core.getInput("add-pip-as-python-dependency"),
                 allow_softlinks: core.getInput("allow-softlinks"),
-                auto_activate_base: core.getInput("auto-activate-base"),
+                auto_activate: core.getInput("auto-activate-base") === "legacy-placeholder"
+                    ? core.getInput("auto-activate")
+                    : core.getInput("auto-activate-base"),
                 auto_update_conda: core.getInput("auto-update-conda"),
                 channel_alias: core.getInput("channel-alias"),
                 channel_priority: core.getInput("channel-priority"),
                 channels: core.getInput("channels"),
+                default_activation_env: "", // Needed for type definition
                 show_channel_urls: core.getInput("show-channel-urls"),
                 use_only_tar_bz2: core.getInput("use-only-tar-bz2"),
                 solver: core.getInput("conda-solver"),
@@ -28994,14 +28845,6 @@ module.exports = require("https");
 
 "use strict";
 module.exports = require("net");
-
-/***/ }),
-
-/***/ 6005:
-/***/ ((module) => {
-
-"use strict";
-module.exports = require("node:crypto");
 
 /***/ }),
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -21201,9 +21201,6 @@ exports.parse = parse;
 /***/ 1532:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const ANY = Symbol('SemVer ANY')
 // hoisted class for cyclic dependency
 class Comparator {
@@ -21351,9 +21348,6 @@ const Range = __nccwpck_require__(9828)
 
 /***/ 9828:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SPACE_CHARACTERS = /\s+/g
 
@@ -21916,9 +21910,6 @@ const testSet = (set, version, options) => {
 /***/ 8088:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const debug = __nccwpck_require__(427)
 const { MAX_LENGTH, MAX_SAFE_INTEGER } = __nccwpck_require__(2293)
 const { safeRe: re, t } = __nccwpck_require__(9523)
@@ -21931,7 +21922,7 @@ class SemVer {
 
     if (version instanceof SemVer) {
       if (version.loose === !!options.loose &&
-        version.includePrerelease === !!options.includePrerelease) {
+          version.includePrerelease === !!options.includePrerelease) {
         return version
       } else {
         version = version.version
@@ -22097,19 +22088,6 @@ class SemVer {
   // preminor will bump the version up to the next minor release, and immediately
   // down to pre-release. premajor and prepatch work the same way.
   inc (release, identifier, identifierBase) {
-    if (release.startsWith('pre')) {
-      if (!identifier && identifierBase === false) {
-        throw new Error('invalid increment argument: identifier is empty')
-      }
-      // Avoid an invalid semver results
-      if (identifier) {
-        const match = `-${identifier}`.match(this.options.loose ? re[t.PRERELEASELOOSE] : re[t.PRERELEASE])
-        if (!match || match[1] !== identifier) {
-          throw new Error(`invalid identifier: ${identifier}`)
-        }
-      }
-    }
-
     switch (release) {
       case 'premajor':
         this.prerelease.length = 0
@@ -22139,12 +22117,6 @@ class SemVer {
           this.inc('patch', identifier, identifierBase)
         }
         this.inc('pre', identifier, identifierBase)
-        break
-      case 'release':
-        if (this.prerelease.length === 0) {
-          throw new Error(`version ${this.raw} is not a prerelease`)
-        }
-        this.prerelease.length = 0
         break
 
       case 'major':
@@ -22188,6 +22160,10 @@ class SemVer {
       // 1.0.0 'pre' would become 1.0.0-0 which is the wrong direction.
       case 'pre': {
         const base = Number(identifierBase) ? 1 : 0
+
+        if (!identifier && identifierBase === false) {
+          throw new Error('invalid increment argument: identifier is empty')
+        }
 
         if (this.prerelease.length === 0) {
           this.prerelease = [base]
@@ -22243,9 +22219,6 @@ module.exports = SemVer
 /***/ 8848:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const parse = __nccwpck_require__(5925)
 const clean = (version, options) => {
   const s = parse(version.trim().replace(/^[=v]+/, ''), options)
@@ -22258,9 +22231,6 @@ module.exports = clean
 
 /***/ 5098:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const eq = __nccwpck_require__(1898)
 const neq = __nccwpck_require__(6017)
@@ -22320,9 +22290,6 @@ module.exports = cmp
 
 /***/ 3466:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const parse = __nccwpck_require__(5925)
@@ -22391,9 +22358,6 @@ module.exports = coerce
 /***/ 2156:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const SemVer = __nccwpck_require__(8088)
 const compareBuild = (a, b, loose) => {
   const versionA = new SemVer(a, loose)
@@ -22408,9 +22372,6 @@ module.exports = compareBuild
 /***/ 2804:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compare = __nccwpck_require__(4309)
 const compareLoose = (a, b) => compare(a, b, true)
 module.exports = compareLoose
@@ -22420,9 +22381,6 @@ module.exports = compareLoose
 
 /***/ 4309:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const compare = (a, b, loose) =>
@@ -22435,9 +22393,6 @@ module.exports = compare
 
 /***/ 4297:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const parse = __nccwpck_require__(5925)
 
@@ -22468,13 +22423,20 @@ const diff = (version1, version2) => {
       return 'major'
     }
 
-    // If the main part has no difference
-    if (lowVersion.compareMain(highVersion) === 0) {
-      if (lowVersion.minor && !lowVersion.patch) {
-        return 'minor'
-      }
+    // Otherwise it can be determined by checking the high version
+
+    if (highVersion.patch) {
+      // anything higher than a patch bump would result in the wrong version
       return 'patch'
     }
+
+    if (highVersion.minor) {
+      // anything higher than a minor bump would result in the wrong version
+      return 'minor'
+    }
+
+    // bumping major/minor/patch all have same result
+    return 'major'
   }
 
   // add the `pre` prefix if we are going to a prerelease version
@@ -22504,9 +22466,6 @@ module.exports = diff
 /***/ 1898:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compare = __nccwpck_require__(4309)
 const eq = (a, b, loose) => compare(a, b, loose) === 0
 module.exports = eq
@@ -22516,9 +22475,6 @@ module.exports = eq
 
 /***/ 4123:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const compare = __nccwpck_require__(4309)
 const gt = (a, b, loose) => compare(a, b, loose) > 0
@@ -22530,9 +22486,6 @@ module.exports = gt
 /***/ 5522:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compare = __nccwpck_require__(4309)
 const gte = (a, b, loose) => compare(a, b, loose) >= 0
 module.exports = gte
@@ -22542,9 +22495,6 @@ module.exports = gte
 
 /***/ 900:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 
@@ -22572,9 +22522,6 @@ module.exports = inc
 /***/ 194:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compare = __nccwpck_require__(4309)
 const lt = (a, b, loose) => compare(a, b, loose) < 0
 module.exports = lt
@@ -22584,9 +22531,6 @@ module.exports = lt
 
 /***/ 7520:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const compare = __nccwpck_require__(4309)
 const lte = (a, b, loose) => compare(a, b, loose) <= 0
@@ -22598,9 +22542,6 @@ module.exports = lte
 /***/ 6688:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const SemVer = __nccwpck_require__(8088)
 const major = (a, loose) => new SemVer(a, loose).major
 module.exports = major
@@ -22610,9 +22551,6 @@ module.exports = major
 
 /***/ 8447:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const minor = (a, loose) => new SemVer(a, loose).minor
@@ -22624,9 +22562,6 @@ module.exports = minor
 /***/ 6017:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compare = __nccwpck_require__(4309)
 const neq = (a, b, loose) => compare(a, b, loose) !== 0
 module.exports = neq
@@ -22636,9 +22571,6 @@ module.exports = neq
 
 /***/ 5925:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const parse = (version, options, throwErrors = false) => {
@@ -22663,9 +22595,6 @@ module.exports = parse
 /***/ 2866:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const SemVer = __nccwpck_require__(8088)
 const patch = (a, loose) => new SemVer(a, loose).patch
 module.exports = patch
@@ -22675,9 +22604,6 @@ module.exports = patch
 
 /***/ 4016:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const parse = __nccwpck_require__(5925)
 const prerelease = (version, options) => {
@@ -22692,9 +22618,6 @@ module.exports = prerelease
 /***/ 6417:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compare = __nccwpck_require__(4309)
 const rcompare = (a, b, loose) => compare(b, a, loose)
 module.exports = rcompare
@@ -22705,9 +22628,6 @@ module.exports = rcompare
 /***/ 8701:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compareBuild = __nccwpck_require__(2156)
 const rsort = (list, loose) => list.sort((a, b) => compareBuild(b, a, loose))
 module.exports = rsort
@@ -22717,9 +22637,6 @@ module.exports = rsort
 
 /***/ 6055:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const Range = __nccwpck_require__(9828)
 const satisfies = (version, range, options) => {
@@ -22738,9 +22655,6 @@ module.exports = satisfies
 /***/ 1426:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const compareBuild = __nccwpck_require__(2156)
 const sort = (list, loose) => list.sort((a, b) => compareBuild(a, b, loose))
 module.exports = sort
@@ -22750,9 +22664,6 @@ module.exports = sort
 
 /***/ 9601:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const parse = __nccwpck_require__(5925)
 const valid = (version, options) => {
@@ -22766,9 +22677,6 @@ module.exports = valid
 
 /***/ 1383:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 // just pre-load all the stuff that index.js lazily exports
 const internalRe = __nccwpck_require__(9523)
@@ -22866,9 +22774,6 @@ module.exports = {
 /***/ 2293:
 /***/ ((module) => {
 
-"use strict";
-
-
 // Note: this is the semver.org version of the spec that it implements
 // Not necessarily the package version of this code.
 const SEMVER_SPEC_VERSION = '2.0.0'
@@ -22911,9 +22816,6 @@ module.exports = {
 /***/ 427:
 /***/ ((module) => {
 
-"use strict";
-
-
 const debug = (
   typeof process === 'object' &&
   process.env &&
@@ -22929,9 +22831,6 @@ module.exports = debug
 
 /***/ 2463:
 /***/ ((module) => {
-
-"use strict";
-
 
 const numeric = /^[0-9]+$/
 const compareIdentifiers = (a, b) => {
@@ -22962,9 +22861,6 @@ module.exports = {
 
 /***/ 5339:
 /***/ ((module) => {
-
-"use strict";
-
 
 class LRUCache {
   constructor () {
@@ -23013,9 +22909,6 @@ module.exports = LRUCache
 /***/ 785:
 /***/ ((module) => {
 
-"use strict";
-
-
 // parse out just the options we care about
 const looseOption = Object.freeze({ loose: true })
 const emptyOpts = Object.freeze({ })
@@ -23038,9 +22931,6 @@ module.exports = parseOptions
 /***/ 9523:
 /***/ ((module, exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const {
   MAX_SAFE_COMPONENT_LENGTH,
   MAX_SAFE_BUILD_LENGTH,
@@ -23053,7 +22943,6 @@ exports = module.exports = {}
 const re = exports.re = []
 const safeRe = exports.safeRe = []
 const src = exports.src = []
-const safeSrc = exports.safeSrc = []
 const t = exports.t = {}
 let R = 0
 
@@ -23086,7 +22975,6 @@ const createToken = (name, value, isGlobal) => {
   debug(name, index, value)
   t[name] = index
   src[index] = value
-  safeSrc[index] = safe
   re[index] = new RegExp(value, isGlobal ? 'g' : undefined)
   safeRe[index] = new RegExp(safe, isGlobal ? 'g' : undefined)
 }
@@ -23119,14 +23007,12 @@ createToken('MAINVERSIONLOOSE', `(${src[t.NUMERICIDENTIFIERLOOSE]})\\.` +
 
 // ## Pre-release Version Identifier
 // A numeric identifier, or a non-numeric identifier.
-// Non-numberic identifiers include numberic identifiers but can be longer.
-// Therefore non-numberic identifiers must go first.
 
-createToken('PRERELEASEIDENTIFIER', `(?:${src[t.NONNUMERICIDENTIFIER]
-}|${src[t.NUMERICIDENTIFIER]})`)
+createToken('PRERELEASEIDENTIFIER', `(?:${src[t.NUMERICIDENTIFIER]
+}|${src[t.NONNUMERICIDENTIFIER]})`)
 
-createToken('PRERELEASEIDENTIFIERLOOSE', `(?:${src[t.NONNUMERICIDENTIFIER]
-}|${src[t.NUMERICIDENTIFIERLOOSE]})`)
+createToken('PRERELEASEIDENTIFIERLOOSE', `(?:${src[t.NUMERICIDENTIFIERLOOSE]
+}|${src[t.NONNUMERICIDENTIFIER]})`)
 
 // ## Pre-release Version
 // Hyphen, followed by one or more dot-separated pre-release version
@@ -23269,9 +23155,6 @@ createToken('GTE0PRE', '^\\s*>=\\s*0\\.0\\.0-0\\s*$')
 /***/ 9380:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 // Determine if version is greater than all the versions possible in the range.
 const outside = __nccwpck_require__(420)
 const gtr = (version, range, options) => outside(version, range, '>', options)
@@ -23282,9 +23165,6 @@ module.exports = gtr
 
 /***/ 7008:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const Range = __nccwpck_require__(9828)
 const intersects = (r1, r2, options) => {
@@ -23300,9 +23180,6 @@ module.exports = intersects
 /***/ 3323:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const outside = __nccwpck_require__(420)
 // Determine if version is less than all the versions possible in the range
 const ltr = (version, range, options) => outside(version, range, '<', options)
@@ -23313,9 +23190,6 @@ module.exports = ltr
 
 /***/ 579:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const Range = __nccwpck_require__(9828)
@@ -23349,9 +23223,6 @@ module.exports = maxSatisfying
 /***/ 832:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const SemVer = __nccwpck_require__(8088)
 const Range = __nccwpck_require__(9828)
 const minSatisfying = (versions, range, options) => {
@@ -23382,9 +23253,6 @@ module.exports = minSatisfying
 
 /***/ 4179:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const Range = __nccwpck_require__(9828)
@@ -23453,9 +23321,6 @@ module.exports = minVersion
 
 /***/ 420:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const SemVer = __nccwpck_require__(8088)
 const Comparator = __nccwpck_require__(1532)
@@ -23544,9 +23409,6 @@ module.exports = outside
 /***/ 5297:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 // given a set of versions and a range, create a "simplified" range
 // that includes the same versions that the original range does
 // If the original range is shorter than the simplified one, return that.
@@ -23600,9 +23462,6 @@ module.exports = (versions, range, options) => {
 
 /***/ 7863:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const Range = __nccwpck_require__(9828)
 const Comparator = __nccwpck_require__(1532)
@@ -23858,9 +23717,6 @@ module.exports = subset
 /***/ 2706:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-
 const Range = __nccwpck_require__(9828)
 
 // Mostly just for testing and legacy API reasons
@@ -23875,9 +23731,6 @@ module.exports = toComparators
 
 /***/ 2098:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-"use strict";
-
 
 const Range = __nccwpck_require__(9828)
 const validRange = (range, options) => {
@@ -29502,7 +29355,7 @@ module.exports = {
 
 
 const { parseSetCookie } = __nccwpck_require__(4408)
-const { stringify } = __nccwpck_require__(3121)
+const { stringify, getHeadersList } = __nccwpck_require__(3121)
 const { webidl } = __nccwpck_require__(1744)
 const { Headers } = __nccwpck_require__(554)
 
@@ -29578,13 +29431,14 @@ function getSetCookies (headers) {
 
   webidl.brandCheck(headers, Headers, { strict: false })
 
-  const cookies = headers.getSetCookie()
+  const cookies = getHeadersList(headers).cookies
 
   if (!cookies) {
     return []
   }
 
-  return cookies.map((pair) => parseSetCookie(pair))
+  // In older versions of undici, cookies is a list of name:value.
+  return cookies.map((pair) => parseSetCookie(Array.isArray(pair) ? pair[1] : pair))
 }
 
 /**
@@ -30012,15 +29866,14 @@ module.exports = {
 /***/ }),
 
 /***/ 3121:
-/***/ ((module) => {
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-/**
- * @param {string} value
- * @returns {boolean}
- */
+const assert = __nccwpck_require__(9491)
+const { kHeadersList } = __nccwpck_require__(2785)
+
 function isCTLExcludingHtab (value) {
   if (value.length === 0) {
     return false
@@ -30281,13 +30134,31 @@ function stringify (cookie) {
   return out.join('; ')
 }
 
+let kHeadersListNode
+
+function getHeadersList (headers) {
+  if (headers[kHeadersList]) {
+    return headers[kHeadersList]
+  }
+
+  if (!kHeadersListNode) {
+    kHeadersListNode = Object.getOwnPropertySymbols(headers).find(
+      (symbol) => symbol.description === 'headers list'
+    )
+
+    assert(kHeadersListNode, 'Headers cannot be parsed')
+  }
+
+  const headersList = headers[kHeadersListNode]
+  assert(headersList)
+
+  return headersList
+}
+
 module.exports = {
   isCTLExcludingHtab,
-  validateCookieName,
-  validateCookiePath,
-  validateCookieValue,
-  toIMFDate,
-  stringify
+  stringify,
+  getHeadersList
 }
 
 
@@ -32216,14 +32087,6 @@ const { isUint8Array, isArrayBuffer } = __nccwpck_require__(9830)
 const { File: UndiciFile } = __nccwpck_require__(8511)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(685)
 
-let random
-try {
-  const crypto = __nccwpck_require__(6005)
-  random = (max) => crypto.randomInt(0, max)
-} catch {
-  random = (max) => Math.floor(Math.random(max))
-}
-
 let ReadableStream = globalThis.ReadableStream
 
 /** @type {globalThis['File']} */
@@ -32309,7 +32172,7 @@ function extractBody (object, keepalive = false) {
     // Set source to a copy of the bytes held by object.
     source = new Uint8Array(object.buffer.slice(object.byteOffset, object.byteOffset + object.byteLength))
   } else if (util.isFormDataLike(object)) {
-    const boundary = `----formdata-undici-0${`${random(1e11)}`.padStart(11, '0')}`
+    const boundary = `----formdata-undici-0${`${Math.floor(Math.random() * 1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 
     /*! formdata-polyfill. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
@@ -34291,7 +34154,6 @@ const {
   isValidHeaderName,
   isValidHeaderValue
 } = __nccwpck_require__(2538)
-const util = __nccwpck_require__(3837)
 const { webidl } = __nccwpck_require__(1744)
 const assert = __nccwpck_require__(9491)
 
@@ -34845,9 +34707,6 @@ Object.defineProperties(Headers.prototype, {
   [Symbol.toStringTag]: {
     value: 'Headers',
     configurable: true
-  },
-  [util.inspect.custom]: {
-    enumerable: false
   }
 })
 
@@ -44024,20 +43883,6 @@ class Pool extends PoolBase {
       ? { ...options.interceptors }
       : undefined
     this[kFactory] = factory
-
-    this.on('connectionError', (origin, targets, error) => {
-      // If a connection error occurs, we remove the client from the pool,
-      // and emit a connectionError event. They will not be re-used.
-      // Fixes https://github.com/nodejs/undici/issues/3895
-      for (const target of targets) {
-        // Do not use kRemoveClient here, as it will close the client,
-        // but the client cannot be closed in this state.
-        const idx = this[kClients].indexOf(target)
-        if (idx !== -1) {
-          this[kClients].splice(idx, 1)
-        }
-      }
-    })
   }
 
   [kGetDispatcher] () {
@@ -46959,25 +46804,19 @@ function applyCondaConfiguration(inputs, options) {
             yield condaCommand(["config", "--add", "pkgs_dirs", pkgsDir], inputs, options);
         }
         // auto_activate_base was renamed to auto_activate in 25.5.0
-        core.info(`auto_activate: ${inputs.condaConfig.auto_activate_base}`);
+        core.info(`auto_activate: ${inputs.condaConfig.auto_activate}`);
         try {
             // 25.5.0+
-            yield condaCommand([
-                "config",
-                "--set",
-                "auto_activate",
-                inputs.condaConfig.auto_activate_base,
-            ], inputs, options);
+            yield condaCommand(["config", "--set", "auto_activate", inputs.condaConfig.auto_activate], inputs, options);
         }
         catch (err) {
             try {
                 // <25.5.0
-                core.warning("Using auto_activate_base is deprecated, please use auto_activate instead");
                 yield condaCommand([
                     "config",
                     "--set",
                     "auto_activate_base",
-                    inputs.condaConfig.auto_activate_base,
+                    inputs.condaConfig.auto_activate,
                 ], inputs, options);
             }
             catch (err2) {
@@ -46989,7 +46828,7 @@ function applyCondaConfiguration(inputs, options) {
             if (value.trim().length === 0 ||
                 key === "channels" ||
                 key === "pkgs_dirs" ||
-                key === "auto_activate_base") {
+                key === "auto_activate") {
                 continue;
             }
             core.info(`${key}: ${value}`);
@@ -47006,15 +46845,31 @@ function applyCondaConfiguration(inputs, options) {
     });
 }
 exports.applyCondaConfiguration = applyCondaConfiguration;
+/*
+ * Whether an environment is the default environment
+ */
+function isDefaultEnvironment(envName, inputs, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (envName === "") {
+            return false;
+        }
+        const configsOutput = (yield condaCommand(["config", "--show", "--json"], inputs, options, true));
+        const config = JSON.parse(configsOutput);
+        if (config.default_activation_env) {
+            return config.default_activation_env === envName;
+        }
+        return !utils.isBaseEnv(envName);
+    });
+}
 /**
  * Initialize Conda
  */
 function condaInit(inputs, options) {
     return __awaiter(this, void 0, void 0, function* () {
         let ownPath;
-        const isValidActivate = !utils.isBaseEnv(inputs.activateEnvironment);
-        const autoActivateBase = options.condaConfig["auto_activate_base"] === "true" ||
-            options.condaConfig["activate_environment"] === "base";
+        const isValidActivate = !(yield isDefaultEnvironment(inputs.activateEnvironment, inputs, options));
+        const autoActivateDefault = options.condaConfig.auto_activate === "true";
+        const installationDirectory = condaBasePath(inputs, options);
         // Fix ownership of folders
         if (options.useBundled) {
             if (constants.IS_MAC) {
@@ -47101,10 +46956,10 @@ function condaInit(inputs, options) {
         // Batch profiles
         let batchExtraText = `
   :: ---------------------------------------------------------------------------`;
-        if (autoActivateBase) {
+        if (autoActivateDefault) {
             batchExtraText += `
-  :: Conda Setup Action: Activate base
-  @CALL "%CONDA_BAT%" activate base`;
+  :: Conda Setup Action: Activate default environment
+  @CALL "%CONDA_BAT%" activate`;
         }
         if (isValidActivate) {
             batchExtraText += `
@@ -47116,7 +46971,6 @@ function condaInit(inputs, options) {
   @SETLOCAL EnableExtensions
   @SETLOCAL DisableDelayedExpansion
   :: ---------------------------------------------------------------------------`;
-        let extraShells;
         const shells = {
             "~/.bash_profile": bashExtraText,
             "~/.profile": bashExtraText,
@@ -47127,25 +46981,13 @@ function condaInit(inputs, options) {
             "~/.config/powershell/profile.ps1": powerExtraText,
             "~/Documents/PowerShell/profile.ps1": powerExtraText,
             "~/Documents/WindowsPowerShell/profile.ps1": powerExtraText,
+            [path.join(installationDirectory, "etc", "profile.d", "conda.sh")]: bashExtraText,
+            [path.join(installationDirectory, "etc", "fish", "conf.d", "conda.fish")]: bashExtraText,
+            [path.join(installationDirectory, "condabin", "conda_hook.bat")]: batchExtraText,
         };
-        if (options.useBundled) {
-            extraShells = {
-                "C:/Miniconda/etc/profile.d/conda.sh": bashExtraText,
-                "C:/Miniconda/etc/fish/conf.d/conda.fish": bashExtraText,
-                "C:/Miniconda/condabin/conda_hook.bat": batchExtraText,
-            };
-        }
-        else {
-            extraShells = {
-                "~/miniconda3/etc/profile.d/conda.sh": bashExtraText,
-                "~/miniconda3/etc/fish/conf.d/conda.fish": bashExtraText,
-                "~/miniconda3/condabin/conda_hook.bat": batchExtraText,
-            };
-        }
-        const allShells = Object.assign(Object.assign({}, shells), extraShells);
-        Object.keys(allShells).forEach((key) => {
+        Object.keys(shells).forEach((key) => {
             let filePath = key.replace("~", os.homedir());
-            const text = allShells[key];
+            const text = shells[key];
             if (fs.existsSync(filePath)) {
                 core.info(`Append to "${filePath}":\n ${text} \n`);
                 fs.appendFileSync(filePath, text);
@@ -47795,7 +47637,7 @@ const RULES = [
     (i, c) => !!(i.condaVersion && c.auto_update_conda === "true") &&
         `only one of 'conda-version: ${i.condaVersion}' or 'auto-update-conda: true' may be provided`,
     (i) => !!(i.pythonVersion && !i.activateEnvironment) &&
-        `'python-version: ${i.pythonVersion}' requires 'activate-environment: true'`,
+        `'python-version: ${i.pythonVersion}' requires 'activate-environment' to be set`,
     (i) => !!(i.minicondaVersion && i.miniforgeVersion) &&
         `only one of 'miniconda-version: ${i.minicondaVersion}' or 'miniforge-version: ${i.miniforgeVersion}' may be provided`,
     (i) => !!(i.installerUrl && i.minicondaVersion) &&
@@ -47821,6 +47663,9 @@ function parseInputs() {
             // https://github.com/conda-incubator/setup-miniconda/issues/385
             arch = "aarch64";
         }
+        if (core.getInput("auto-activate-base") !== "legacy-placeholder") {
+            core.warning("`auto-activate-base` is deprecated. Please use `auto-activate`.");
+        }
         const inputs = Object.freeze({
             activateEnvironment: core.getInput("activate-environment"),
             architecture: arch,
@@ -47842,11 +47687,14 @@ function parseInputs() {
                 add_anaconda_token: core.getInput("add-anaconda-token"),
                 add_pip_as_python_dependency: core.getInput("add-pip-as-python-dependency"),
                 allow_softlinks: core.getInput("allow-softlinks"),
-                auto_activate_base: core.getInput("auto-activate-base"),
+                auto_activate: core.getInput("auto-activate-base") === "legacy-placeholder"
+                    ? core.getInput("auto-activate")
+                    : core.getInput("auto-activate-base"),
                 auto_update_conda: core.getInput("auto-update-conda"),
                 channel_alias: core.getInput("channel-alias"),
                 channel_priority: core.getInput("channel-priority"),
                 channels: core.getInput("channels"),
+                default_activation_env: "", // Needed for type definition
                 show_channel_urls: core.getInput("show-channel-urls"),
                 use_only_tar_bz2: core.getInput("use-only-tar-bz2"),
                 solver: core.getInput("conda-solver"),
@@ -48885,14 +48733,6 @@ module.exports = require("https");
 
 "use strict";
 module.exports = require("net");
-
-/***/ }),
-
-/***/ 6005:
-/***/ ((module) => {
-
-"use strict";
-module.exports = require("node:crypto");
 
 /***/ }),
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -46858,7 +46858,7 @@ function isDefaultEnvironment(envName, inputs, options) {
         if (config.default_activation_env) {
             return config.default_activation_env === envName;
         }
-        return !utils.isBaseEnv(envName);
+        return utils.isBaseEnv(envName);
     });
 }
 /**

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -47819,10 +47819,15 @@ function parseInputs() {
             arch = "aarch64";
         }
         if (core.getInput("auto-activate-base") !== "legacy-placeholder") {
-            core.warning("`auto-activate-base` is deprecated. Please use `auto-activate`.");
+            core.warning("`auto-activate-base` is deprecated. Please use `auto-activate`. " +
+                "If your installer does not use the `base` environment as the default environment, " +
+                "also add `activate-environment: base`.");
         }
         const inputs = Object.freeze({
-            activateEnvironment: core.getInput("activate-environment"),
+            activateEnvironment: core.getInput("auto-activate-base") === "true" &&
+                core.getInput("activate-environment") === ""
+                ? "base"
+                : core.getInput("activate-environment"),
             architecture: arch,
             condaBuildVersion: core.getInput("conda-build-version"),
             condaConfigFile: core.getInput("condarc-file"),

--- a/etc/example-installers/default-environment/construct.yaml
+++ b/etc/example-installers/default-environment/construct.yaml
@@ -1,0 +1,20 @@
+{% set ext = os.environ.get("EXT", "sh") %}
+{% set add_default_activation_env = os.environ.get("ADD_ACTIVATION_ENV", "false") == "true" %}
+
+name: DefaultEnv
+installer_type: {{ ext }}
+version: 1.0.0
+channels:
+  - conda-forge
+specs:
+  - conda >=25.5.0
+extra_envs:
+  default:
+    specs:
+      - python
+condarc:
+  channels:
+    - conda-forge
+{% if add_default_activation_env %}
+  default_activation_env: default
+{% endif %}

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -311,7 +311,7 @@ async function isDefaultEnvironment(
   if (config.default_activation_env) {
     return config.default_activation_env === envName;
   }
-  return !utils.isBaseEnv(envName);
+  return utils.isBaseEnv(envName);
 }
 
 /**

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -241,31 +241,23 @@ export async function applyCondaConfiguration(
     );
   }
   // auto_activate_base was renamed to auto_activate in 25.5.0
-  core.info(`auto_activate: ${inputs.condaConfig.auto_activate_base}`);
+  core.info(`auto_activate: ${inputs.condaConfig.auto_activate}`);
   try {
     // 25.5.0+
     await condaCommand(
-      [
-        "config",
-        "--set",
-        "auto_activate",
-        inputs.condaConfig.auto_activate_base,
-      ],
+      ["config", "--set", "auto_activate", inputs.condaConfig.auto_activate],
       inputs,
       options,
     );
   } catch (err) {
     try {
       // <25.5.0
-      core.warning(
-        "Using auto_activate_base is deprecated, please use auto_activate instead",
-      );
       await condaCommand(
         [
           "config",
           "--set",
           "auto_activate_base",
-          inputs.condaConfig.auto_activate_base,
+          inputs.condaConfig.auto_activate,
         ],
         inputs,
         options,
@@ -281,7 +273,7 @@ export async function applyCondaConfiguration(
       value.trim().length === 0 ||
       key === "channels" ||
       key === "pkgs_dirs" ||
-      key === "auto_activate_base"
+      key === "auto_activate"
     ) {
       continue;
     }

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -308,8 +308,8 @@ export async function condaInit(
   let ownPath: string;
   const isValidActivate = !utils.isBaseEnv(inputs.activateEnvironment);
   const autoActivateBase: boolean =
-    options.condaConfig["auto_activate_base"] === "true" ||
-    options.condaConfig["activate_environment"] === "base";
+    options.condaConfig.auto_activate_base === "true" ||
+    inputs.activateEnvironment === "base";
 
   // Fix ownership of folders
   if (options.useBundled) {

--- a/src/input.ts
+++ b/src/input.ts
@@ -129,6 +129,7 @@ export async function parseInputs(): Promise<types.IActionInputs> {
       channel_alias: core.getInput("channel-alias"),
       channel_priority: core.getInput("channel-priority"),
       channels: core.getInput("channels"),
+      default_activation_env: "", // Needed for type definition
       show_channel_urls: core.getInput("show-channel-urls"),
       use_only_tar_bz2: core.getInput("use-only-tar-bz2"),
       solver: core.getInput("conda-solver"),

--- a/src/input.ts
+++ b/src/input.ts
@@ -95,11 +95,17 @@ export async function parseInputs(): Promise<types.IActionInputs> {
   }
   if (core.getInput("auto-activate-base") !== "legacy-placeholder") {
     core.warning(
-      "`auto-activate-base` is deprecated. Please use `auto-activate`.",
+      "`auto-activate-base` is deprecated. Please use `auto-activate`. " +
+        "If your installer does not use the `base` environment as the default environment, " +
+        "also add `activate-environment: base`.",
     );
   }
   const inputs: types.IActionInputs = Object.freeze({
-    activateEnvironment: core.getInput("activate-environment"),
+    activateEnvironment:
+      core.getInput("auto-activate-base") === "true" &&
+      core.getInput("activate-environment") === ""
+        ? "base"
+        : core.getInput("activate-environment"),
     architecture: arch,
     condaBuildVersion: core.getInput("conda-build-version"),
     condaConfigFile: core.getInput("condarc-file"),

--- a/src/input.ts
+++ b/src/input.ts
@@ -51,7 +51,7 @@ const RULES: IRule[] = [
     `only one of 'conda-version: ${i.condaVersion}' or 'auto-update-conda: true' may be provided`,
   (i) =>
     !!(i.pythonVersion && !i.activateEnvironment) &&
-    `'python-version: ${i.pythonVersion}' requires 'activate-environment: true'`,
+    `'python-version: ${i.pythonVersion}' requires 'activate-environment' to be set`,
   (i) =>
     !!(i.minicondaVersion && i.miniforgeVersion) &&
     `only one of 'miniconda-version: ${i.minicondaVersion}' or 'miniforge-version: ${i.miniforgeVersion}' may be provided`,
@@ -93,6 +93,11 @@ export async function parseInputs(): Promise<types.IActionInputs> {
     // https://github.com/conda-incubator/setup-miniconda/issues/385
     arch = "aarch64";
   }
+  if (core.getInput("auto-activate-base") !== "legacy-placeholder") {
+    core.warning(
+      "`auto-activate-base` is deprecated. Please use `auto-activate`.",
+    );
+  }
   const inputs: types.IActionInputs = Object.freeze({
     activateEnvironment: core.getInput("activate-environment"),
     architecture: arch,
@@ -116,7 +121,10 @@ export async function parseInputs(): Promise<types.IActionInputs> {
         "add-pip-as-python-dependency",
       ),
       allow_softlinks: core.getInput("allow-softlinks"),
-      auto_activate_base: core.getInput("auto-activate-base"),
+      auto_activate:
+        core.getInput("auto-activate-base") === "legacy-placeholder"
+          ? core.getInput("auto-activate")
+          : core.getInput("auto-activate-base"),
       auto_update_conda: core.getInput("auto-update-conda"),
       channel_alias: core.getInput("channel-alias"),
       channel_priority: core.getInput("channel-priority"),

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export interface ICondaConfig {
   channel_alias: string;
   channel_priority: string;
   channels: string;
+  default_activation_env: string;
   show_channel_urls: string;
   use_only_tar_bz2: string;
   always_yes: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,7 @@ export interface ICondaConfig {
   add_anaconda_token: string;
   add_pip_as_python_dependency: string;
   allow_softlinks: string;
-  auto_activate_base: string;
+  auto_activate: string;
   auto_update_conda: string;
   channel_alias: string;
   channel_priority: string;


### PR DESCRIPTION
`conda` has replaced `auto_activate_base` with `auto_activate` to allow for setting default environments to different environments than the `base` environment.

On Windows, however, the `base` environment is hard-coded as the primary activation environment, overriding default environment settings. Additionally, other environments are only activated when they are not the `base` environment, which would make it impossible to activate the `base` environment if a default environment is set in a `.condarc` file.

The action's input options also still reflect the old language in `conda`. `auto-update-base` should be deprecated in favor of `auto-update`.

## Summary of changes

* Deprecate `auto-activate-base` input parameter and replace with `auto-activate`.
* Remove warnings for using `auto_activate_base` the option depends on the `conda` version and is thus not actionable by the user.
* Activate the default environment on Windows instead of the `base` environment.
* `isValidActivate` now checks if the target environment is the default environment.
* Replace hard-coded paths to Miniconda for Windows shell scripts with the actual path to the `base` environment.