### PR TITLE
fix: remove accidental indentation from shell config template strings

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -48174,45 +48174,42 @@ function condaInit(inputs, options) {
             }
         }
         // PowerShell profiles
-        let powerExtraText = `
-  # ----------------------------------------------------------------------------`;
+        // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+        const powerLines = [
+            "",
+            "# ----------------------------------------------------------------------------",
+        ];
         if (isValidActivate) {
-            powerExtraText += `
-  # Conda Setup Action: Custom activation
-  conda activate "${inputs.activateEnvironment}"`;
+            powerLines.push("# Conda Setup Action: Custom activation", `conda activate "${inputs.activateEnvironment}"`);
         }
-        powerExtraText += `
-  # ----------------------------------------------------------------------------`;
+        powerLines.push("# ----------------------------------------------------------------------------");
+        const powerExtraText = powerLines.join("\n");
         // Bash profiles
-        let bashExtraText = `
-  # ----------------------------------------------------------------------------
-  # Conda Setup Action: Basic configuration
-  set -eo pipefail`;
+        // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+        const bashLines = [
+            "",
+            "# ----------------------------------------------------------------------------",
+            "# Conda Setup Action: Basic configuration",
+            "set -eo pipefail",
+        ];
         if (isValidActivate) {
-            bashExtraText += `
-  # Conda Setup Action: Custom activation
-  conda activate "${inputs.activateEnvironment}"`;
-            bashExtraText += `
-  # ----------------------------------------------------------------------------`;
+            bashLines.push("# Conda Setup Action: Custom activation", `conda activate "${inputs.activateEnvironment}"`, "# ----------------------------------------------------------------------------");
         }
+        const bashExtraText = bashLines.join("\n");
         // Batch profiles
-        let batchExtraText = `
-  :: ---------------------------------------------------------------------------`;
+        // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+        const batchLines = [
+            "",
+            ":: ---------------------------------------------------------------------------",
+        ];
         if (autoActivateDefault) {
-            batchExtraText += `
-  :: Conda Setup Action: Activate default environment
-  @CALL "%CONDA_BAT%" activate`;
+            batchLines.push(":: Conda Setup Action: Activate default environment", '@CALL "%CONDA_BAT%" activate');
         }
         if (isValidActivate) {
-            batchExtraText += `
-  :: Conda Setup Action: Custom activation
-  @CALL "%CONDA_BAT%" activate "${inputs.activateEnvironment}"`;
+            batchLines.push(":: Conda Setup Action: Custom activation", `@CALL "%CONDA_BAT%" activate "${inputs.activateEnvironment}"`);
         }
-        batchExtraText += `
-  :: Conda Setup Action: Basic configuration
-  @SETLOCAL EnableExtensions
-  @SETLOCAL DisableDelayedExpansion
-  :: ---------------------------------------------------------------------------`;
+        batchLines.push(":: Conda Setup Action: Basic configuration", "@SETLOCAL EnableExtensions", "@SETLOCAL DisableDelayedExpansion", ":: ---------------------------------------------------------------------------");
+        const batchExtraText = batchLines.join("\n");
         const shells = {
             "~/.bash_profile": bashExtraText,
             "~/.profile": bashExtraText,

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,6 +302,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.12.0.tgz",
       "integrity": "sha512-s8/jNFPKPNRmXEnNXfuo1gemBdVmpQsK1pcu+QIvuNJuhFzGrpD7WjOcvDc/+uEdfzSYpNu7U/+MmbScjoQ6vg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.12.0",
         "@typescript-eslint/types": "6.12.0",
@@ -471,6 +472,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -912,6 +914,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.54.0.tgz",
       "integrity": "sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2349,6 +2352,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
       "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -430,7 +430,9 @@ export async function condaInit(
       `conda activate "${inputs.activateEnvironment}"`,
     );
   }
-  powerLines.push("# ----------------------------------------------------------------------------");
+  powerLines.push(
+    "# ----------------------------------------------------------------------------",
+  );
   const powerExtraText = powerLines.join("\n");
 
   // Bash profiles

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -419,47 +419,62 @@ export async function condaInit(
   }
 
   // PowerShell profiles
-  let powerExtraText = `
-  # ----------------------------------------------------------------------------`;
+  // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+  const powerLines: string[] = [
+    "",
+    "# ----------------------------------------------------------------------------",
+  ];
   if (isValidActivate) {
-    powerExtraText += `
-  # Conda Setup Action: Custom activation
-  conda activate "${inputs.activateEnvironment}"`;
+    powerLines.push(
+      "# Conda Setup Action: Custom activation",
+      `conda activate "${inputs.activateEnvironment}"`,
+    );
   }
-  powerExtraText += `
-  # ----------------------------------------------------------------------------`;
+  powerLines.push("# ----------------------------------------------------------------------------");
+  const powerExtraText = powerLines.join("\n");
 
   // Bash profiles
-  let bashExtraText: string = `
-  # ----------------------------------------------------------------------------
-  # Conda Setup Action: Basic configuration
-  set -eo pipefail`;
+  // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+  const bashLines: string[] = [
+    "",
+    "# ----------------------------------------------------------------------------",
+    "# Conda Setup Action: Basic configuration",
+    "set -eo pipefail",
+  ];
   if (isValidActivate) {
-    bashExtraText += `
-  # Conda Setup Action: Custom activation
-  conda activate "${inputs.activateEnvironment}"`;
-    bashExtraText += `
-  # ----------------------------------------------------------------------------`;
+    bashLines.push(
+      "# Conda Setup Action: Custom activation",
+      `conda activate "${inputs.activateEnvironment}"`,
+      "# ----------------------------------------------------------------------------",
+    );
   }
+  const bashExtraText = bashLines.join("\n");
 
   // Batch profiles
-  let batchExtraText = `
-  :: ---------------------------------------------------------------------------`;
+  // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+  const batchLines: string[] = [
+    "",
+    ":: ---------------------------------------------------------------------------",
+  ];
   if (autoActivateDefault) {
-    batchExtraText += `
-  :: Conda Setup Action: Activate default environment
-  @CALL "%CONDA_BAT%" activate`;
+    batchLines.push(
+      ":: Conda Setup Action: Activate default environment",
+      '@CALL "%CONDA_BAT%" activate',
+    );
   }
   if (isValidActivate) {
-    batchExtraText += `
-  :: Conda Setup Action: Custom activation
-  @CALL "%CONDA_BAT%" activate "${inputs.activateEnvironment}"`;
+    batchLines.push(
+      ":: Conda Setup Action: Custom activation",
+      `@CALL "%CONDA_BAT%" activate "${inputs.activateEnvironment}"`,
+    );
   }
-  batchExtraText += `
-  :: Conda Setup Action: Basic configuration
-  @SETLOCAL EnableExtensions
-  @SETLOCAL DisableDelayedExpansion
-  :: ---------------------------------------------------------------------------`;
+  batchLines.push(
+    ":: Conda Setup Action: Basic configuration",
+    "@SETLOCAL EnableExtensions",
+    "@SETLOCAL DisableDelayedExpansion",
+    ":: ---------------------------------------------------------------------------",
+  );
+  const batchExtraText = batchLines.join("\n");
 
   const shells: types.IShells = {
     "~/.bash_profile": bashExtraText,


### PR DESCRIPTION
Fixes #422

The template strings (bashExtraText, powerExtraText, batchExtraText) had 2-space indentation inherited from TypeScript code formatting. This indentation was written to shell config files like .xonshrc, breaking xonsh's Python-based syntax.

Refactored to use array.join() pattern which is immune to auto-formatter indentation changes.