### PR TITLE
Update README to include information on activation for restricted envs

### DIFF
--- a/.github/workflows/example-17.yml
+++ b/.github/workflows/example-17.yml
@@ -109,17 +109,17 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          conda info -n test
+          conda.bat info
       - name: Conda list (pwsh)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          conda list -n test
+          conda.bat list -n test
       - name: Conda info (cmd)
         if: runner.os == 'Windows'
         shell: cmd /C CALL {0}
         run: |
-          conda.bat info -n test
+          conda.bat info
       - name: Conda list (cmd)
         if: runner.os == 'Windows'
         shell: cmd /C CALL {0}

--- a/.github/workflows/example-17.yml
+++ b/.github/workflows/example-17.yml
@@ -1,0 +1,51 @@
+name: "Example 17: Restricted environments (no profile modifications)"
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "develop"
+      - "main"
+      - "master"
+  schedule:
+    # Note that cronjobs run on master/main by default
+    - cron: "0 0 * * *"
+
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  example-17:
+    # prevent cronjobs from running on forks
+    if:
+      (github.event_name == 'schedule' && github.repository ==
+      'conda-incubator/setup-miniconda') || (github.event_name != 'schedule')
+    name: Ex17 (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: ./
+        with:
+          activate-environment: test
+          remove-profiles: "false"
+      - name: Conda info
+        shell: bash
+        run: |
+          source "$CONDA/etc/profile.d/conda.sh"
+          conda activate test
+          conda info
+      - name: Conda list
+        shell: bash
+        run: |
+          source "$CONDA/etc/profile.d/conda.sh"
+          conda activate test
+          conda list

--- a/.github/workflows/example-17.yml
+++ b/.github/workflows/example-17.yml
@@ -9,9 +9,6 @@ on:
       - "develop"
       - "main"
       - "master"
-  schedule:
-    # Note that cronjobs run on master/main by default
-    - cron: "0 0 * * *"
 
 concurrency:
   group:
@@ -33,19 +30,98 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6.0.2
+      - name: Save profile checksums (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          md5sum ~/.profile ~/.bashrc 2>/dev/null > /tmp/profile_checksums_before.txt || true
+          cat /tmp/profile_checksums_before.txt
+      - name: Save profile checksums (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $files = @(
+            "$HOME\Documents\PowerShell\profile.ps1",
+            "$HOME\Documents\WindowsPowerShell\profile.ps1"
+          )
+          $hashes = @()
+          foreach ($f in $files) {
+            if (Test-Path $f) {
+              $hashes += Get-FileHash $f -Algorithm MD5 | Select-Object Hash, Path
+            } else {
+              $hashes += [PSCustomObject]@{Hash="MISSING"; Path=$f}
+            }
+          }
+          $hashes | ConvertTo-Json | Out-File "$env:TEMP\profile_checksums_before.json"
+          $hashes | Format-Table -AutoSize
       - uses: ./
         with:
           activate-environment: test
           remove-profiles: "false"
-      - name: Conda info
+          run-init: "false"
+      - name: Verify profiles unchanged (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          md5sum ~/.profile ~/.bashrc 2>/dev/null > /tmp/profile_checksums_after.txt || true
+          cat /tmp/profile_checksums_after.txt
+          diff /tmp/profile_checksums_before.txt /tmp/profile_checksums_after.txt
+          echo "Profiles unchanged - OK (run-init=false)"
+      - name: Verify profiles unchanged (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $files = @(
+            "$HOME\Documents\PowerShell\profile.ps1",
+            "$HOME\Documents\WindowsPowerShell\profile.ps1"
+          )
+          $hashes = @()
+          foreach ($f in $files) {
+            if (Test-Path $f) {
+              $hashes += Get-FileHash $f -Algorithm MD5 | Select-Object Hash, Path
+            } else {
+              $hashes += [PSCustomObject]@{Hash="MISSING"; Path=$f}
+            }
+          }
+          $hashes | Format-Table -AutoSize
+          $before = Get-Content "$env:TEMP\profile_checksums_before.json" | ConvertFrom-Json
+          $after = $hashes
+          for ($i = 0; $i -lt $before.Count; $i++) {
+            if ($before[$i].Hash -ne $after[$i].Hash) {
+              Write-Error "Profile changed: $($before[$i].Path) ($($before[$i].Hash) -> $($after[$i].Hash))"
+              exit 1
+            }
+          }
+          Write-Host "Profiles unchanged - OK (run-init=false)"
+      - name: Conda info (bash)
         shell: bash
         run: |
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate test
           conda info
-      - name: Conda list
+      - name: Conda list (bash)
         shell: bash
         run: |
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate test
           conda list
+      - name: Conda info (pwsh)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          conda info -n test
+      - name: Conda list (pwsh)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          conda list -n test
+      - name: Conda info (cmd)
+        if: runner.os == 'Windows'
+        shell: cmd /C CALL {0}
+        run: |
+          conda.bat info -n test
+      - name: Conda list (cmd)
+        if: runner.os == 'Windows'
+        shell: cmd /C CALL {0}
+        run: |
+          conda.bat list -n test

--- a/README.md
+++ b/README.md
@@ -851,6 +851,32 @@ jobs:
       - run: conda config --show
 ```
 
+### Restricted environments (no profile modifications)
+
+If your environment does not allow modifications to `~/.profile` or `~/.bashrc`
+(e.g. corporate self-hosted runners with restricted home directories), set
+`remove-profiles: "false"` and source conda manually on each step:
+
+```yaml
+jobs:
+  restricted-env:
+    name: Restricted environment
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: myenv
+          environment-file: environment.yml
+          remove-profiles: "false"
+      - name: Run with conda
+        shell: bash
+        run: |
+          source "$CONDA/etc/profile.d/conda.sh"
+          conda activate myenv
+          python my_script.py
+```
+
 ## IMPORTANT
 
 - Conda activation does not correctly work on `sh`. Please use `bash`.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ possibility of automatically activating the `test` environment on all shells.
 | [Remove defaults](#example-14-remove-defaults-channel)             | [![Remove defaults][ex14-badge]][ex14]                          |
 | [Linux ARM](#example-15-linux-arm)                                 | [![Linux ARM][ex15-badge]][ex15]                                |
 | Default environments                                               | [![Default environments][ex16-badge]][ex16]                     |
+| [Restricted environments](#example-17-restricted-environments)     | [![Restricted environments][ex17-badge]][ex17]                  |
 
 [ex1]:
   https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-1.yml
@@ -127,6 +128,10 @@ possibility of automatically activating the `test` environment on all shells.
   https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-16.yml
 [ex16-badge]:
   https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-16.yml/badge.svg?branch=main
+[ex17]:
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-17.yml
+[ex17-badge]:
+  https://github.com/conda-incubator/setup-miniconda/actions/workflows/example-17.yml/badge.svg?branch=main
 
 ## Other Workflows
 
@@ -851,7 +856,7 @@ jobs:
       - run: conda config --show
 ```
 
-### Restricted environments (no profile modifications)
+### Example 17: Restricted environments
 
 If your environment does not allow modifications to `~/.profile` or `~/.bashrc`
 (e.g. corporate self-hosted runners with restricted home directories), set

--- a/README.md
+++ b/README.md
@@ -860,7 +860,8 @@ jobs:
 
 If your environment does not allow modifications to `~/.profile` or `~/.bashrc`
 (e.g. corporate self-hosted runners with restricted home directories), set
-`remove-profiles: "false"` and source conda manually on each step:
+`run-init: "false"` and `remove-profiles: "false"` to prevent any profile
+modifications. You must then manually source conda in each step:
 
 ```yaml
 jobs:
@@ -874,6 +875,7 @@ jobs:
           activate-environment: myenv
           environment-file: environment.yml
           remove-profiles: "false"
+          run-init: "false"
       - name: Run with conda
         shell: bash
         run: |

--- a/action.yml
+++ b/action.yml
@@ -250,6 +250,14 @@ inputs:
       removed from the runner. Default is "true".'
     required: false
     default: "true"
+  run-init:
+    description:
+      'Advanced. Whether to run "conda init" and modify shell profiles. Set to
+      "false" to prevent any modifications to ~/.profile, ~/.bashrc, and other
+      shell profiles. When disabled, you must manually source conda in each
+      step. Default is "true".'
+    required: false
+    default: "true"
   mamba-version:
     description:
       'Use mamba (https://github.com/QuantStack/mamba) as a faster drop-in

--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -33795,6 +33795,7 @@ function parseInputs() {
             condaRemoveDefaults: getInput("conda-remove-defaults"),
             pythonVersion: getInput("python-version"),
             removeProfiles: getInput("remove-profiles"),
+            runInit: getInput("run-init"),
             condaConfig: Object.freeze({
                 add_anaconda_token: getInput("add-anaconda-token"),
                 add_pip_as_python_dependency: getInput("add-pip-as-python-dependency"),

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -53618,6 +53618,7 @@ function parseInputs() {
             condaRemoveDefaults: getInput("conda-remove-defaults"),
             pythonVersion: getInput("python-version"),
             removeProfiles: getInput("remove-profiles"),
+            runInit: getInput("run-init"),
             condaConfig: Object.freeze({
                 add_anaconda_token: getInput("add-anaconda-token"),
                 add_pip_as_python_dependency: getInput("add-pip-as-python-dependency"),
@@ -54059,116 +54060,122 @@ function condaInit(inputs, options) {
                 }
             }
         }
-        // Remove profile files
-        if (inputs.removeProfiles == "true") {
-            for (let rc of PROFILES) {
-                try {
-                    let file = external_path_namespaceObject.join(external_os_namespaceObject.homedir(), rc);
-                    if (external_fs_namespaceObject.existsSync(file)) {
-                        info(`Removing "${file}"`);
-                        yield rmRF(file);
+        // Skip conda init and all profile modifications if run-init is false
+        if (inputs.runInit == "false") {
+            info("Skipping conda init and profile modifications (run-init=false)");
+        }
+        else {
+            // Remove profile files
+            if (inputs.removeProfiles == "true") {
+                for (let rc of PROFILES) {
+                    try {
+                        let file = external_path_namespaceObject.join(external_os_namespaceObject.homedir(), rc);
+                        if (external_fs_namespaceObject.existsSync(file)) {
+                            info(`Removing "${file}"`);
+                            yield rmRF(file);
+                        }
+                    }
+                    catch (err) {
+                        warning(err);
                     }
                 }
-                catch (err) {
-                    warning(err);
+            }
+            // Run conda init
+            for (let cmd of ["--all"]) {
+                yield condaCommand(["init", cmd], inputs, options);
+            }
+            if (inputs.removeProfiles == "true") {
+                // Rename files
+                if (IS_LINUX) {
+                    let source = "~/.bashrc".replace("~", external_os_namespaceObject.homedir());
+                    let dest = "~/.profile".replace("~", external_os_namespaceObject.homedir());
+                    if (external_fs_namespaceObject.existsSync(source)) {
+                        info(`Renaming "${source}" to "${dest}"\n`);
+                        yield mv(source, dest);
+                    }
+                }
+                else if (IS_MAC) {
+                    let source = "~/.bash_profile".replace("~", external_os_namespaceObject.homedir());
+                    let dest = "~/.profile".replace("~", external_os_namespaceObject.homedir());
+                    if (external_fs_namespaceObject.existsSync(source)) {
+                        info(`Renaming "${source}" to "${dest}"\n`);
+                        yield mv(source, dest);
+                    }
                 }
             }
-        }
-        // Run conda init
-        for (let cmd of ["--all"]) {
-            yield condaCommand(["init", cmd], inputs, options);
-        }
-        if (inputs.removeProfiles == "true") {
-            // Rename files
-            if (IS_LINUX) {
-                let source = "~/.bashrc".replace("~", external_os_namespaceObject.homedir());
-                let dest = "~/.profile".replace("~", external_os_namespaceObject.homedir());
-                if (external_fs_namespaceObject.existsSync(source)) {
-                    info(`Renaming "${source}" to "${dest}"\n`);
-                    yield mv(source, dest);
+            // PowerShell profiles
+            // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+            const powerLines = [
+                "",
+                "# ----------------------------------------------------------------------------",
+            ];
+            if (isValidActivate) {
+                powerLines.push("# Conda Setup Action: Custom activation", `conda activate "${inputs.activateEnvironment}"`);
+            }
+            powerLines.push("# ----------------------------------------------------------------------------");
+            const powerExtraText = powerLines.join("\n");
+            // Bash profiles
+            // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+            const bashLines = [
+                "",
+                "# ----------------------------------------------------------------------------",
+                "# Conda Setup Action: Basic configuration",
+                "set -eo pipefail",
+            ];
+            if (isValidActivate) {
+                bashLines.push("# Conda Setup Action: Custom activation", `conda activate "${inputs.activateEnvironment}"`, "# ----------------------------------------------------------------------------");
+            }
+            const bashExtraText = bashLines.join("\n");
+            // Xonsh profiles
+            // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+            const xonshLines = [
+                "",
+                "# ----------------------------------------------------------------------------",
+                "# Conda Setup Action: Basic configuration",
+                "$RAISE_SUBPROC_ERROR = True", // equivalent to: set -e
+                "$XONSH_PIPEFAIL = True", // equivalent to: set -o pipefail
+            ];
+            if (isValidActivate) {
+                xonshLines.push("# Conda Setup Action: Custom activation", `conda activate "${inputs.activateEnvironment}"`, "# ----------------------------------------------------------------------------");
+            }
+            const xonshExtraText = xonshLines.join("\n");
+            // Batch profiles
+            // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+            const batchLines = [
+                "",
+                ":: ---------------------------------------------------------------------------",
+            ];
+            if (autoActivateDefault) {
+                batchLines.push(":: Conda Setup Action: Activate default environment", '@CALL "%CONDA_BAT%" activate');
+            }
+            if (isValidActivate) {
+                batchLines.push(":: Conda Setup Action: Custom activation", `@CALL "%CONDA_BAT%" activate "${inputs.activateEnvironment}"`);
+            }
+            batchLines.push(":: Conda Setup Action: Basic configuration", "@SETLOCAL EnableExtensions", "@SETLOCAL DisableDelayedExpansion", ":: ---------------------------------------------------------------------------");
+            const batchExtraText = batchLines.join("\n");
+            const shells = {
+                "~/.bash_profile": bashExtraText,
+                "~/.profile": bashExtraText,
+                "~/.zshrc": bashExtraText,
+                "~/.config/fish/config.fish": bashExtraText,
+                "~/.tcshrc": bashExtraText,
+                "~/.xonshrc": xonshExtraText,
+                "~/.config/powershell/profile.ps1": powerExtraText,
+                "~/Documents/PowerShell/profile.ps1": powerExtraText,
+                "~/Documents/WindowsPowerShell/profile.ps1": powerExtraText,
+                [external_path_namespaceObject.join(installationDirectory, "etc", "profile.d", "conda.sh")]: bashExtraText,
+                [external_path_namespaceObject.join(installationDirectory, "etc", "fish", "conf.d", "conda.fish")]: bashExtraText,
+                [external_path_namespaceObject.join(installationDirectory, "condabin", "conda_hook.bat")]: batchExtraText,
+            };
+            Object.keys(shells).forEach((key) => {
+                let filePath = key.replace("~", external_os_namespaceObject.homedir());
+                const text = shells[key];
+                if (external_fs_namespaceObject.existsSync(filePath)) {
+                    info(`Append to "${filePath}":\n ${text} \n`);
+                    external_fs_namespaceObject.appendFileSync(filePath, text);
                 }
-            }
-            else if (IS_MAC) {
-                let source = "~/.bash_profile".replace("~", external_os_namespaceObject.homedir());
-                let dest = "~/.profile".replace("~", external_os_namespaceObject.homedir());
-                if (external_fs_namespaceObject.existsSync(source)) {
-                    info(`Renaming "${source}" to "${dest}"\n`);
-                    yield mv(source, dest);
-                }
-            }
+            });
         }
-        // PowerShell profiles
-        // NOTE: Using array.join() to prevent auto-formatters from adding indentation
-        const powerLines = [
-            "",
-            "# ----------------------------------------------------------------------------",
-        ];
-        if (isValidActivate) {
-            powerLines.push("# Conda Setup Action: Custom activation", `conda activate "${inputs.activateEnvironment}"`);
-        }
-        powerLines.push("# ----------------------------------------------------------------------------");
-        const powerExtraText = powerLines.join("\n");
-        // Bash profiles
-        // NOTE: Using array.join() to prevent auto-formatters from adding indentation
-        const bashLines = [
-            "",
-            "# ----------------------------------------------------------------------------",
-            "# Conda Setup Action: Basic configuration",
-            "set -eo pipefail",
-        ];
-        if (isValidActivate) {
-            bashLines.push("# Conda Setup Action: Custom activation", `conda activate "${inputs.activateEnvironment}"`, "# ----------------------------------------------------------------------------");
-        }
-        const bashExtraText = bashLines.join("\n");
-        // Xonsh profiles
-        // NOTE: Using array.join() to prevent auto-formatters from adding indentation
-        const xonshLines = [
-            "",
-            "# ----------------------------------------------------------------------------",
-            "# Conda Setup Action: Basic configuration",
-            "$RAISE_SUBPROC_ERROR = True", // equivalent to: set -e
-            "$XONSH_PIPEFAIL = True", // equivalent to: set -o pipefail
-        ];
-        if (isValidActivate) {
-            xonshLines.push("# Conda Setup Action: Custom activation", `conda activate "${inputs.activateEnvironment}"`, "# ----------------------------------------------------------------------------");
-        }
-        const xonshExtraText = xonshLines.join("\n");
-        // Batch profiles
-        // NOTE: Using array.join() to prevent auto-formatters from adding indentation
-        const batchLines = [
-            "",
-            ":: ---------------------------------------------------------------------------",
-        ];
-        if (autoActivateDefault) {
-            batchLines.push(":: Conda Setup Action: Activate default environment", '@CALL "%CONDA_BAT%" activate');
-        }
-        if (isValidActivate) {
-            batchLines.push(":: Conda Setup Action: Custom activation", `@CALL "%CONDA_BAT%" activate "${inputs.activateEnvironment}"`);
-        }
-        batchLines.push(":: Conda Setup Action: Basic configuration", "@SETLOCAL EnableExtensions", "@SETLOCAL DisableDelayedExpansion", ":: ---------------------------------------------------------------------------");
-        const batchExtraText = batchLines.join("\n");
-        const shells = {
-            "~/.bash_profile": bashExtraText,
-            "~/.profile": bashExtraText,
-            "~/.zshrc": bashExtraText,
-            "~/.config/fish/config.fish": bashExtraText,
-            "~/.tcshrc": bashExtraText,
-            "~/.xonshrc": xonshExtraText,
-            "~/.config/powershell/profile.ps1": powerExtraText,
-            "~/Documents/PowerShell/profile.ps1": powerExtraText,
-            "~/Documents/WindowsPowerShell/profile.ps1": powerExtraText,
-            [external_path_namespaceObject.join(installationDirectory, "etc", "profile.d", "conda.sh")]: bashExtraText,
-            [external_path_namespaceObject.join(installationDirectory, "etc", "fish", "conf.d", "conda.fish")]: bashExtraText,
-            [external_path_namespaceObject.join(installationDirectory, "condabin", "conda_hook.bat")]: batchExtraText,
-        };
-        Object.keys(shells).forEach((key) => {
-            let filePath = key.replace("~", external_os_namespaceObject.homedir());
-            const text = shells[key];
-            if (external_fs_namespaceObject.existsSync(filePath)) {
-                info(`Append to "${filePath}":\n ${text} \n`);
-                external_fs_namespaceObject.appendFileSync(filePath, text);
-            }
-        });
     });
 }
 

--- a/src/__tests__/conda.test.ts
+++ b/src/__tests__/conda.test.ts
@@ -11,6 +11,8 @@ vi.mock("@actions/core", () => ({
 // Mock @actions/io
 vi.mock("@actions/io", () => ({
   cp: vi.fn(),
+  rmRF: vi.fn(),
+  mv: vi.fn(),
 }));
 
 // Mock fs so condaExecutable finds a "conda" binary
@@ -19,6 +21,7 @@ vi.mock("fs", async (importOriginal) => {
   return {
     ...actual,
     existsSync: vi.fn(() => true),
+    appendFileSync: vi.fn(),
   };
 });
 
@@ -48,6 +51,8 @@ function makeInputs(
   overrides: Partial<{
     channels: string;
     condaRemoveDefaults: string;
+    runInit: string;
+    removeProfiles: string;
   }> = {},
 ): types.IActionInputs {
   return Object.freeze({
@@ -65,8 +70,8 @@ function makeInputs(
     miniforgeVersion: "",
     condaRemoveDefaults: overrides.condaRemoveDefaults ?? "false",
     pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
+    removeProfiles: overrides.removeProfiles ?? "true",
+    runInit: overrides.runInit ?? "true",
     useMamba: "",
     cleanPatchedEnvironmentFile: "true",
     runPost: "true",
@@ -161,5 +166,31 @@ describe("applyCondaConfiguration", () => {
     const args = getCondaArgs();
     const setCalls = args.filter((a) => a.includes("--set"));
     expect(setCalls.length).toBeGreaterThan(0);
+  });
+});
+
+describe("condaInit", () => {
+  beforeEach(() => {
+    executeCalls.length = 0;
+  });
+
+  it("skips conda init when runInit is false", async () => {
+    const { condaInit } = await import("../conda");
+    const inputs = makeInputs({ runInit: "false" });
+
+    await condaInit(inputs, makeOptions());
+
+    const initCalls = executeCalls.filter((c) => c.command.includes("init"));
+    expect(initCalls).toEqual([]);
+  });
+
+  it("runs conda init when runInit is true", async () => {
+    const { condaInit } = await import("../conda");
+    const inputs = makeInputs({ runInit: "true" });
+
+    await condaInit(inputs, makeOptions());
+
+    const initCalls = executeCalls.filter((c) => c.command.includes("init"));
+    expect(initCalls.length).toBeGreaterThan(0);
   });
 });

--- a/src/__tests__/conda.test.ts
+++ b/src/__tests__/conda.test.ts
@@ -66,6 +66,7 @@ function makeInputs(
     condaRemoveDefaults: overrides.condaRemoveDefaults ?? "false",
     pythonVersion: "",
     removeProfiles: "true",
+    runInit: "true",
     useMamba: "",
     cleanPatchedEnvironmentFile: "true",
     runPost: "true",

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -391,146 +391,151 @@ export async function condaInit(
     }
   }
 
-  // Remove profile files
-  if (inputs.removeProfiles == "true") {
-    for (let rc of constants.PROFILES) {
-      try {
-        let file: string = path.join(os.homedir(), rc);
-        if (fs.existsSync(file)) {
-          core.info(`Removing "${file}"`);
-          await io.rmRF(file);
+  // Skip conda init and all profile modifications if run-init is false
+  if (inputs.runInit == "false") {
+    core.info("Skipping conda init and profile modifications (run-init=false)");
+  } else {
+    // Remove profile files
+    if (inputs.removeProfiles == "true") {
+      for (let rc of constants.PROFILES) {
+        try {
+          let file: string = path.join(os.homedir(), rc);
+          if (fs.existsSync(file)) {
+            core.info(`Removing "${file}"`);
+            await io.rmRF(file);
+          }
+        } catch (err) {
+          core.warning(err as Error);
         }
-      } catch (err) {
-        core.warning(err as Error);
       }
     }
-  }
 
-  // Run conda init
-  for (let cmd of ["--all"]) {
-    await condaCommand(["init", cmd], inputs, options);
-  }
+    // Run conda init
+    for (let cmd of ["--all"]) {
+      await condaCommand(["init", cmd], inputs, options);
+    }
 
-  if (inputs.removeProfiles == "true") {
-    // Rename files
-    if (constants.IS_LINUX) {
-      let source: string = "~/.bashrc".replace("~", os.homedir());
-      let dest: string = "~/.profile".replace("~", os.homedir());
-      if (fs.existsSync(source)) {
-        core.info(`Renaming "${source}" to "${dest}"\n`);
-        await io.mv(source, dest);
-      }
-    } else if (constants.IS_MAC) {
-      let source: string = "~/.bash_profile".replace("~", os.homedir());
-      let dest: string = "~/.profile".replace("~", os.homedir());
-      if (fs.existsSync(source)) {
-        core.info(`Renaming "${source}" to "${dest}"\n`);
-        await io.mv(source, dest);
+    if (inputs.removeProfiles == "true") {
+      // Rename files
+      if (constants.IS_LINUX) {
+        let source: string = "~/.bashrc".replace("~", os.homedir());
+        let dest: string = "~/.profile".replace("~", os.homedir());
+        if (fs.existsSync(source)) {
+          core.info(`Renaming "${source}" to "${dest}"\n`);
+          await io.mv(source, dest);
+        }
+      } else if (constants.IS_MAC) {
+        let source: string = "~/.bash_profile".replace("~", os.homedir());
+        let dest: string = "~/.profile".replace("~", os.homedir());
+        if (fs.existsSync(source)) {
+          core.info(`Renaming "${source}" to "${dest}"\n`);
+          await io.mv(source, dest);
+        }
       }
     }
-  }
 
-  // PowerShell profiles
-  // NOTE: Using array.join() to prevent auto-formatters from adding indentation
-  const powerLines: string[] = [
-    "",
-    "# ----------------------------------------------------------------------------",
-  ];
-  if (isValidActivate) {
+    // PowerShell profiles
+    // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+    const powerLines: string[] = [
+      "",
+      "# ----------------------------------------------------------------------------",
+    ];
+    if (isValidActivate) {
+      powerLines.push(
+        "# Conda Setup Action: Custom activation",
+        `conda activate "${inputs.activateEnvironment}"`,
+      );
+    }
     powerLines.push(
-      "# Conda Setup Action: Custom activation",
-      `conda activate "${inputs.activateEnvironment}"`,
-    );
-  }
-  powerLines.push(
-    "# ----------------------------------------------------------------------------",
-  );
-  const powerExtraText = powerLines.join("\n");
-
-  // Bash profiles
-  // NOTE: Using array.join() to prevent auto-formatters from adding indentation
-  const bashLines: string[] = [
-    "",
-    "# ----------------------------------------------------------------------------",
-    "# Conda Setup Action: Basic configuration",
-    "set -eo pipefail",
-  ];
-  if (isValidActivate) {
-    bashLines.push(
-      "# Conda Setup Action: Custom activation",
-      `conda activate "${inputs.activateEnvironment}"`,
       "# ----------------------------------------------------------------------------",
     );
-  }
-  const bashExtraText = bashLines.join("\n");
+    const powerExtraText = powerLines.join("\n");
 
-  // Xonsh profiles
-  // NOTE: Using array.join() to prevent auto-formatters from adding indentation
-  const xonshLines: string[] = [
-    "",
-    "# ----------------------------------------------------------------------------",
-    "# Conda Setup Action: Basic configuration",
-    "$RAISE_SUBPROC_ERROR = True", // equivalent to: set -e
-    "$XONSH_PIPEFAIL = True", // equivalent to: set -o pipefail
-  ];
-  if (isValidActivate) {
-    xonshLines.push(
-      "# Conda Setup Action: Custom activation",
-      `conda activate "${inputs.activateEnvironment}"`,
+    // Bash profiles
+    // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+    const bashLines: string[] = [
+      "",
       "# ----------------------------------------------------------------------------",
-    );
-  }
-  const xonshExtraText = xonshLines.join("\n");
-
-  // Batch profiles
-  // NOTE: Using array.join() to prevent auto-formatters from adding indentation
-  const batchLines: string[] = [
-    "",
-    ":: ---------------------------------------------------------------------------",
-  ];
-  if (autoActivateDefault) {
-    batchLines.push(
-      ":: Conda Setup Action: Activate default environment",
-      '@CALL "%CONDA_BAT%" activate',
-    );
-  }
-  if (isValidActivate) {
-    batchLines.push(
-      ":: Conda Setup Action: Custom activation",
-      `@CALL "%CONDA_BAT%" activate "${inputs.activateEnvironment}"`,
-    );
-  }
-  batchLines.push(
-    ":: Conda Setup Action: Basic configuration",
-    "@SETLOCAL EnableExtensions",
-    "@SETLOCAL DisableDelayedExpansion",
-    ":: ---------------------------------------------------------------------------",
-  );
-  const batchExtraText = batchLines.join("\n");
-
-  const shells: types.IShells = {
-    "~/.bash_profile": bashExtraText,
-    "~/.profile": bashExtraText,
-    "~/.zshrc": bashExtraText,
-    "~/.config/fish/config.fish": bashExtraText,
-    "~/.tcshrc": bashExtraText,
-    "~/.xonshrc": xonshExtraText,
-    "~/.config/powershell/profile.ps1": powerExtraText,
-    "~/Documents/PowerShell/profile.ps1": powerExtraText,
-    "~/Documents/WindowsPowerShell/profile.ps1": powerExtraText,
-    [path.join(installationDirectory, "etc", "profile.d", "conda.sh")]:
-      bashExtraText,
-    [path.join(installationDirectory, "etc", "fish", "conf.d", "conda.fish")]:
-      bashExtraText,
-    [path.join(installationDirectory, "condabin", "conda_hook.bat")]:
-      batchExtraText,
-  };
-  Object.keys(shells).forEach((key) => {
-    let filePath: string = key.replace("~", os.homedir());
-    const text = shells[key];
-    if (fs.existsSync(filePath)) {
-      core.info(`Append to "${filePath}":\n ${text} \n`);
-      fs.appendFileSync(filePath, text);
+      "# Conda Setup Action: Basic configuration",
+      "set -eo pipefail",
+    ];
+    if (isValidActivate) {
+      bashLines.push(
+        "# Conda Setup Action: Custom activation",
+        `conda activate "${inputs.activateEnvironment}"`,
+        "# ----------------------------------------------------------------------------",
+      );
     }
-  });
+    const bashExtraText = bashLines.join("\n");
+
+    // Xonsh profiles
+    // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+    const xonshLines: string[] = [
+      "",
+      "# ----------------------------------------------------------------------------",
+      "# Conda Setup Action: Basic configuration",
+      "$RAISE_SUBPROC_ERROR = True", // equivalent to: set -e
+      "$XONSH_PIPEFAIL = True", // equivalent to: set -o pipefail
+    ];
+    if (isValidActivate) {
+      xonshLines.push(
+        "# Conda Setup Action: Custom activation",
+        `conda activate "${inputs.activateEnvironment}"`,
+        "# ----------------------------------------------------------------------------",
+      );
+    }
+    const xonshExtraText = xonshLines.join("\n");
+
+    // Batch profiles
+    // NOTE: Using array.join() to prevent auto-formatters from adding indentation
+    const batchLines: string[] = [
+      "",
+      ":: ---------------------------------------------------------------------------",
+    ];
+    if (autoActivateDefault) {
+      batchLines.push(
+        ":: Conda Setup Action: Activate default environment",
+        '@CALL "%CONDA_BAT%" activate',
+      );
+    }
+    if (isValidActivate) {
+      batchLines.push(
+        ":: Conda Setup Action: Custom activation",
+        `@CALL "%CONDA_BAT%" activate "${inputs.activateEnvironment}"`,
+      );
+    }
+    batchLines.push(
+      ":: Conda Setup Action: Basic configuration",
+      "@SETLOCAL EnableExtensions",
+      "@SETLOCAL DisableDelayedExpansion",
+      ":: ---------------------------------------------------------------------------",
+    );
+    const batchExtraText = batchLines.join("\n");
+
+    const shells: types.IShells = {
+      "~/.bash_profile": bashExtraText,
+      "~/.profile": bashExtraText,
+      "~/.zshrc": bashExtraText,
+      "~/.config/fish/config.fish": bashExtraText,
+      "~/.tcshrc": bashExtraText,
+      "~/.xonshrc": xonshExtraText,
+      "~/.config/powershell/profile.ps1": powerExtraText,
+      "~/Documents/PowerShell/profile.ps1": powerExtraText,
+      "~/Documents/WindowsPowerShell/profile.ps1": powerExtraText,
+      [path.join(installationDirectory, "etc", "profile.d", "conda.sh")]:
+        bashExtraText,
+      [path.join(installationDirectory, "etc", "fish", "conf.d", "conda.fish")]:
+        bashExtraText,
+      [path.join(installationDirectory, "condabin", "conda_hook.bat")]:
+        batchExtraText,
+    };
+    Object.keys(shells).forEach((key) => {
+      let filePath: string = key.replace("~", os.homedir());
+      const text = shells[key];
+      if (fs.existsSync(filePath)) {
+        core.info(`Append to "${filePath}":\n ${text} \n`);
+        fs.appendFileSync(filePath, text);
+      }
+    });
+  }
 }

--- a/src/input.ts
+++ b/src/input.ts
@@ -121,6 +121,7 @@ export async function parseInputs(): Promise<types.IActionInputs> {
     condaRemoveDefaults: core.getInput("conda-remove-defaults"),
     pythonVersion: core.getInput("python-version"),
     removeProfiles: core.getInput("remove-profiles"),
+    runInit: core.getInput("run-init"),
     condaConfig: Object.freeze({
       add_anaconda_token: core.getInput("add-anaconda-token"),
       add_pip_as_python_dependency: core.getInput(

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ export interface IActionInputs {
   readonly condaRemoveDefaults: string;
   readonly pythonVersion: string;
   readonly removeProfiles: string;
+  readonly runInit: string;
   readonly useMamba: string;
   readonly cleanPatchedEnvironmentFile: string;
   readonly runPost: string;


### PR DESCRIPTION
Fixes #376

### Restricted environments (no profile modifications)

If your environment does not allow modifications to `~/.profile` or `~/.bashrc`
(e.g. corporate self-hosted runners with restricted home directories), set
`remove-profiles: "false"` and source conda manually on each step:

```yaml
jobs:
  restricted-env:
    name: Restricted environment
    runs-on: "ubuntu-latest"
    steps:
      - uses: actions/checkout@v5
      - uses: conda-incubator/setup-miniconda@v3
        with:
          activate-environment: myenv
          environment-file: environment.yml
          run-init: "false"
          remove-profiles: "false"
      - name: Run with conda
        shell: bash
        run: |
          source "$CONDA/etc/profile.d/conda.sh"
          conda activate myenv
          python my_script.py
```