### PR TITLE
Use setup-conda-standalone to set up example 16

### DIFF
--- a/.github/workflows/example-16.yml
+++ b/.github/workflows/example-16.yml
@@ -29,17 +29,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Miniconda for installer builds
-        uses: ./
+      - name: Download conda-standalone
+        id: download-conda-standalone
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4  # v0.1.0
         with:
-          activate-environment: ""
-          auto-activate: false
+          channel: main
+          destination-directory: ${{ runner.temp }}/conda_standalone
+          set-env: false
 
       - name: Create installer
         uses: conda-incubator/installer@2d2df0b03c6795f70e128c56403c7d084cca4fb8 # v0.1.0
         id: create-installer
         with:
-          conda-root: ${{ env.CONDA }}
           environment-yaml-string: |
             channels:
               - conda-forge
@@ -49,6 +50,7 @@ jobs:
               ADD_ACTIVATION_ENV: '${{ matrix.add-activation-env }}'
               EXT: ${{ matrix.os == 'windows' && 'exe' || 'sh' }}
           input-directory: etc/example-installers/default-environment/
+          standalone-location: ${{ steps.download-conda-standalone.outputs.conda-standalone-path }}
 
       - name: Upload installer to Github artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/example-16.yml
+++ b/.github/workflows/example-16.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Download conda-standalone
         id: download-conda-standalone
-        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4  # v0.1.0
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
         with:
           channel: main
           destination-directory: ${{ runner.temp }}/conda_standalone
@@ -50,7 +50,8 @@ jobs:
               ADD_ACTIVATION_ENV: '${{ matrix.add-activation-env }}'
               EXT: ${{ matrix.os == 'windows' && 'exe' || 'sh' }}
           input-directory: etc/example-installers/default-environment/
-          standalone-location: ${{ steps.download-conda-standalone.outputs.conda-standalone-path }}
+          standalone-location:
+            ${{ steps.download-conda-standalone.outputs.conda-standalone-path }}
 
       - name: Upload installer to Github artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
Currently, `example-16.yml` uses `setup-miniconda` to create the installer build environment for the test installer. Replace this with [setup-conda-standalone](https://github.com/conda-incubator/setup-conda-standalone) for a faster environment setup and to avoid interference between multiple installations.