### PR TITLE
Add channels parsing utility and add url validation

### DIFF
--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -33751,6 +33751,21 @@ const RULES = [
         `only one of 'installer-url: ${i.installerUrl}' or 'miniconda-version: ${i.minicondaVersion}' may be provided`,
     (i) => !!(i.installerUrl && i.miniforgeVersion) &&
         `only one of 'installer-url: ${i.installerUrl}' or 'miniforge-version: ${i.miniforgeVersion}' may be provided`,
+    (i) => {
+        if (!i.installerUrl)
+            return false;
+        const ALLOWED_PROTOCOLS = ["https:", "http:", "file:"];
+        try {
+            const protocol = new URL(i.installerUrl).protocol;
+            if (!ALLOWED_PROTOCOLS.includes(protocol)) {
+                return `'installer-url' protocol '${protocol}' is not allowed. Must be one of: ${ALLOWED_PROTOCOLS.join(", ")}`;
+            }
+        }
+        catch (_a) {
+            return `'installer-url: ${i.installerUrl}' is not a valid URL`;
+        }
+        return false;
+    },
     (i) => !!(i.installerUrl &&
         !KNOWN_EXTENSIONS.includes(urlExt(i.installerUrl))) &&
         `'installer-url' extension '${urlExt(i.installerUrl)}' must be one of: ${KNOWN_EXTENSIONS}`,
@@ -33868,15 +33883,19 @@ var utils_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _ar
 
 
 
-/** The folder to use as the conda package cache */
-function parsePkgsDirs(configuredPkgsDirs) {
-    // Package directories are also comma-separated, like channels
-    // We're also setting the appropriate conda config env var, to be safe
-    const pkgsDirs = configuredPkgsDirs
+/**
+ * Split a comma-separated string into trimmed, non-empty entries.
+ */
+function parseCommaSeparated(value) {
+    return value
         .trim()
         .split(/,/)
-        .map((p) => p.trim())
-        .filter((p) => p.length);
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+}
+/** The folder to use as the conda package cache */
+function parsePkgsDirs(configuredPkgsDirs) {
+    const pkgsDirs = parseCommaSeparated(configuredPkgsDirs);
     // Falling back to our default package directories value
     if (pkgsDirs.length) {
         return pkgsDirs;

--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -33886,6 +33886,12 @@ var utils_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _ar
 /**
  * Split a comma-separated string into trimmed, non-empty entries.
  */
+/**
+ * Split a comma-separated string into trimmed, non-empty entries.
+ *
+ * @param value - Comma-separated string to split.
+ * @returns An array of trimmed, non-empty string entries.
+ */
 function parseCommaSeparated(value) {
     return value
         .trim()
@@ -33894,6 +33900,13 @@ function parseCommaSeparated(value) {
         .filter((s) => s.length > 0);
 }
 /** The folder to use as the conda package cache */
+/**
+ * Parse the configured `pkgs_dirs` into a list of directories, falling
+ * back to a default under the user home if none are configured.
+ *
+ * @param configuredPkgsDirs - Comma-separated string of package directory paths.
+ * @returns An array of resolved package directory paths.
+ */
 function parsePkgsDirs(configuredPkgsDirs) {
     const pkgsDirs = parseCommaSeparated(configuredPkgsDirs);
     // Falling back to our default package directories value

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -53574,6 +53574,21 @@ const RULES = [
         `only one of 'installer-url: ${i.installerUrl}' or 'miniconda-version: ${i.minicondaVersion}' may be provided`,
     (i) => !!(i.installerUrl && i.miniforgeVersion) &&
         `only one of 'installer-url: ${i.installerUrl}' or 'miniforge-version: ${i.miniforgeVersion}' may be provided`,
+    (i) => {
+        if (!i.installerUrl)
+            return false;
+        const ALLOWED_PROTOCOLS = ["https:", "http:", "file:"];
+        try {
+            const protocol = new URL(i.installerUrl).protocol;
+            if (!ALLOWED_PROTOCOLS.includes(protocol)) {
+                return `'installer-url' protocol '${protocol}' is not allowed. Must be one of: ${ALLOWED_PROTOCOLS.join(", ")}`;
+            }
+        }
+        catch (_a) {
+            return `'installer-url: ${i.installerUrl}' is not a valid URL`;
+        }
+        return false;
+    },
     (i) => !!(i.installerUrl &&
         !KNOWN_EXTENSIONS.includes(urlExt(i.installerUrl))) &&
         `'installer-url' extension '${urlExt(i.installerUrl)}' must be one of: ${KNOWN_EXTENSIONS}`,
@@ -53691,15 +53706,19 @@ var utils_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _ar
 
 
 
-/** The folder to use as the conda package cache */
-function parsePkgsDirs(configuredPkgsDirs) {
-    // Package directories are also comma-separated, like channels
-    // We're also setting the appropriate conda config env var, to be safe
-    const pkgsDirs = configuredPkgsDirs
+/**
+ * Split a comma-separated string into trimmed, non-empty entries.
+ */
+function parseCommaSeparated(value) {
+    return value
         .trim()
         .split(/,/)
-        .map((p) => p.trim())
-        .filter((p) => p.length);
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+}
+/** The folder to use as the conda package cache */
+function parsePkgsDirs(configuredPkgsDirs) {
+    const pkgsDirs = parseCommaSeparated(configuredPkgsDirs);
     // Falling back to our default package directories value
     if (pkgsDirs.length) {
         return pkgsDirs;
@@ -53909,11 +53928,7 @@ function applyCondaConfiguration(inputs, options, reapply = false) {
         if (!reapply) {
             // Channels are special: if specified as an action input, these take priority
             // over what is found in (at present) a YAML-based environment
-            let channels = inputs.condaConfig.channels
-                .trim()
-                .split(/,/)
-                .map((c) => c.trim())
-                .filter((c) => c.length);
+            let channels = parseCommaSeparated(inputs.condaConfig.channels);
             if (!channels.length && ((_c = (_b = (_a = options.envSpec) === null || _a === void 0 ? void 0 : _a.yaml) === null || _b === void 0 ? void 0 : _b.channels) === null || _c === void 0 ? void 0 : _c.length)) {
                 channels = options.envSpec.yaml.channels;
             }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -53709,6 +53709,12 @@ var utils_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _ar
 /**
  * Split a comma-separated string into trimmed, non-empty entries.
  */
+/**
+ * Split a comma-separated string into trimmed, non-empty entries.
+ *
+ * @param value - Comma-separated string to split.
+ * @returns An array of trimmed, non-empty string entries.
+ */
 function parseCommaSeparated(value) {
     return value
         .trim()
@@ -53717,6 +53723,13 @@ function parseCommaSeparated(value) {
         .filter((s) => s.length > 0);
 }
 /** The folder to use as the conda package cache */
+/**
+ * Parse the configured `pkgs_dirs` into a list of directories, falling
+ * back to a default under the user home if none are configured.
+ *
+ * @param configuredPkgsDirs - Comma-separated string of package directory paths.
+ * @returns An array of resolved package directory paths.
+ */
 function parsePkgsDirs(configuredPkgsDirs) {
     const pkgsDirs = parseCommaSeparated(configuredPkgsDirs);
     // Falling back to our default package directories value

--- a/src/__tests__/conda.test.ts
+++ b/src/__tests__/conda.test.ts
@@ -40,6 +40,13 @@ vi.mock("../utils", () => ({
     }
     return "";
   }),
+  parseCommaSeparated: vi.fn((value: string) =>
+    value
+      .trim()
+      .split(/,/)
+      .map((s: string) => s.trim())
+      .filter((s: string) => s.length > 0),
+  ),
   parsePkgsDirs: vi.fn(() => ["/mock/pkgs"]),
   isBaseEnv: vi.fn(() => false),
 }));

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -170,11 +170,7 @@ export async function applyCondaConfiguration(
   if (!reapply) {
     // Channels are special: if specified as an action input, these take priority
     // over what is found in (at present) a YAML-based environment
-    let channels = inputs.condaConfig.channels
-      .trim()
-      .split(/,/)
-      .map((c) => c.trim())
-      .filter((c) => c.length);
+    let channels = utils.parseCommaSeparated(inputs.condaConfig.channels);
 
     if (!channels.length && options.envSpec?.yaml?.channels?.length) {
       channels = options.envSpec.yaml.channels;

--- a/src/input.ts
+++ b/src/input.ts
@@ -61,6 +61,21 @@ const RULES: IRule[] = [
   (i) =>
     !!(i.installerUrl && i.miniforgeVersion) &&
     `only one of 'installer-url: ${i.installerUrl}' or 'miniforge-version: ${i.miniforgeVersion}' may be provided`,
+  (i) => {
+    if (!i.installerUrl) return false;
+    const ALLOWED_PROTOCOLS = ["https:", "http:", "file:"];
+    try {
+      const protocol = new URL(i.installerUrl).protocol;
+      if (!ALLOWED_PROTOCOLS.includes(protocol)) {
+        return `'installer-url' protocol '${protocol}' is not allowed. Must be one of: ${ALLOWED_PROTOCOLS.join(
+          ", ",
+        )}`;
+      }
+    } catch {
+      return `'installer-url: ${i.installerUrl}' is not a valid URL`;
+    }
+    return false;
+  },
   (i) =>
     !!(
       i.installerUrl &&

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,9 +1,8 @@
 declare module "get-hrefs" {
-  import type { Options as NormalizeUrlOptions } from "normalize-url";
   export interface IAllowedProtocols {
     [key: string]: boolean;
   }
-  export interface IOptions extends NormalizeUrlOptions {
+  export interface IOptions {
     baseUrl?: string;
     allowedProtocols?: IAllowedProtocols;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,12 @@ import * as constants from "./constants";
 /**
  * Split a comma-separated string into trimmed, non-empty entries.
  */
+/**
+ * Split a comma-separated string into trimmed, non-empty entries.
+ *
+ * @param value - Comma-separated string to split.
+ * @returns An array of trimmed, non-empty string entries.
+ */
 export function parseCommaSeparated(value: string): string[] {
   return value
     .trim()
@@ -18,6 +24,13 @@ export function parseCommaSeparated(value: string): string[] {
 }
 
 /** The folder to use as the conda package cache */
+/**
+ * Parse the configured `pkgs_dirs` into a list of directories, falling
+ * back to a default under the user home if none are configured.
+ *
+ * @param configuredPkgsDirs - Comma-separated string of package directory paths.
+ * @returns An array of resolved package directory paths.
+ */
 export function parsePkgsDirs(configuredPkgsDirs: string) {
   const pkgsDirs = parseCommaSeparated(configuredPkgsDirs);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,15 +6,20 @@ import * as exec from "@actions/exec";
 import * as core from "@actions/core";
 import * as constants from "./constants";
 
-/** The folder to use as the conda package cache */
-export function parsePkgsDirs(configuredPkgsDirs: string) {
-  // Package directories are also comma-separated, like channels
-  // We're also setting the appropriate conda config env var, to be safe
-  const pkgsDirs = configuredPkgsDirs
+/**
+ * Split a comma-separated string into trimmed, non-empty entries.
+ */
+export function parseCommaSeparated(value: string): string[] {
+  return value
     .trim()
     .split(/,/)
-    .map((p) => p.trim())
-    .filter((p) => p.length);
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** The folder to use as the conda package cache */
+export function parsePkgsDirs(configuredPkgsDirs: string) {
+  const pkgsDirs = parseCommaSeparated(configuredPkgsDirs);
 
   // Falling back to our default package directories value
   if (pkgsDirs.length) {


### PR DESCRIPTION
### Summary

- Extract `parseCommaSeparated()` utility from `parsePkgsDirs()` to deduplicate comma-separated string parsing (used for both channels and package directories).
- Add URL protocol validation for `installer-url` input — only `https:`, `http:`, and `file:` protocols are allowed.
- Simplify `get-hrefs` type declarations by removing the `normalize-url` dependency from `typings.d.ts`.

### Tasks and Maintenance

- Refactor: shared parsing logic consolidated into a single utility function.
- Input validation: prevents unexpected protocols in installer URLs.