### PR TITLE
Parallelize Windows takeown calls

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -54197,7 +54197,6 @@ function isDefaultEnvironment(envName, inputs, options) {
  */
 function condaInit(inputs, options) {
     return conda_awaiter(this, void 0, void 0, function* () {
-        let ownPath;
         // Fix ownership of folders
         if (options.useBundled) {
             if (IS_MAC) {
@@ -54212,13 +54211,16 @@ function condaInit(inputs, options) {
                 ]);
             }
             else if (constants_IS_WINDOWS) {
-                for (const folder of WIN_PERMS_FOLDERS) {
-                    ownPath = external_path_namespaceObject.join(condaBasePath(inputs, options), folder);
+                const basePath = condaBasePath(inputs, options);
+                const takeownPromises = WIN_PERMS_FOLDERS.map((folder) => {
+                    const ownPath = external_path_namespaceObject.join(basePath, folder);
                     if (external_fs_namespaceObject.existsSync(ownPath)) {
                         info(`Fixing ${folder} ownership`);
-                        yield execute(["takeown", "/f", ownPath, "/r", "/d", "y"]);
+                        return execute(["takeown", "/f", ownPath, "/r", "/d", "y"]);
                     }
-                }
+                    return undefined;
+                }).filter(Boolean);
+                yield Promise.all(takeownPromises);
             }
         }
         // Skip conda init and all profile modifications if run-init is false

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -429,8 +429,6 @@ export async function condaInit(
   inputs: types.IActionInputs,
   options: types.IDynamicOptions,
 ): Promise<void> {
-  let ownPath: string;
-
   // Fix ownership of folders
   if (options.useBundled) {
     if (constants.IS_MAC) {
@@ -444,13 +442,16 @@ export async function condaInit(
         condaBasePath(inputs, options),
       ]);
     } else if (constants.IS_WINDOWS) {
-      for (const folder of constants.WIN_PERMS_FOLDERS) {
-        ownPath = path.join(condaBasePath(inputs, options), folder);
+      const basePath = condaBasePath(inputs, options);
+      const takeownPromises = constants.WIN_PERMS_FOLDERS.map((folder) => {
+        const ownPath = path.join(basePath, folder);
         if (fs.existsSync(ownPath)) {
           core.info(`Fixing ${folder} ownership`);
-          await utils.execute(["takeown", "/f", ownPath, "/r", "/d", "y"]);
+          return utils.execute(["takeown", "/f", ownPath, "/r", "/d", "y"]);
         }
-      }
+        return undefined;
+      }).filter(Boolean) as Promise<void | string>[];
+      await Promise.all(takeownPromises);
     }
   }
 


### PR DESCRIPTION
### Summary

- Run `takeown` commands for all Windows permission folders concurrently using `Promise.all` instead of sequentially.
- Remove unused outer `ownPath` variable.

Each `takeown` call is independent, so there's no reason to wait for one to complete before starting the next.

This is a non-breaking change extracted from #453.