### PR TITLE
Replace conda config subprocesses with direct .condarc YAML write

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -38103,125 +38103,210 @@ function bootstrapConfig() {
         yield external_fs_namespaceObject.promises.writeFile(CONDARC_PATH, BOOTSTRAP_CONDARC);
     });
 }
+const BOOLEAN_CONDARC_KEYS = new Set([
+    "add_anaconda_token",
+    "add_pip_as_python_dependency",
+    "allow_softlinks",
+    "auto_activate_base",
+    "auto_update_conda",
+    "show_channel_urls",
+    "use_only_tar_bz2",
+    "always_yes",
+    "changeps1",
+    "notify_outdated_conda",
+]);
+const KNOWN_CONDARC_KEYS = new Set([
+    ...BOOLEAN_CONDARC_KEYS,
+    "channels",
+    "channel_alias",
+    "channel_priority",
+    "channel_settings",
+    "custom_channels",
+    "custom_multichannels",
+    "default_channels",
+    "default_activation_env",
+    "denylist_channels",
+    "allowlist_channels",
+    "create_default_packages",
+    "envs_dirs",
+    "override_channels_enabled",
+    "pkgs_dirs",
+    "proxy_servers",
+    "repodata_threads",
+    "restore_free_channel",
+    "safety_checks",
+    "solver",
+    "ssl_verify",
+    "auto_activate",
+]);
+const TRUTHY_VALUES = new Set(["true", "yes", "on", "y", "1"]);
+const FALSY_VALUES = new Set(["false", "no", "off", "n", "0"]);
 /**
- * Copy a user-provided `.condarc` file from the workspace into `~/.condarc`.
+ * Coerce a string value to its appropriate YAML type for a given condarc key.
+ * Handles all YAML 1.1 boolean literals (true/false/yes/no/on/off/y/n/1/0).
  *
- * @param inputs - The parsed action inputs containing the condarc file path.
+ * @param key - The condarc configuration key name.
+ * @param value - The raw string value from the action input.
+ * @returns The coerced boolean or original string value.
  */
-function copyConfig(inputs) {
-    return conda_awaiter(this, void 0, void 0, function* () {
-        const sourcePath = external_path_namespaceObject.join(process.env["GITHUB_WORKSPACE"] || "", inputs.condaConfigFile);
-        info(`Copying "${sourcePath}" to "${CONDARC_PATH}..."`);
-        yield io_cp(sourcePath, CONDARC_PATH);
-    });
+function coerceConfigValue(key, value) {
+    if (BOOLEAN_CONDARC_KEYS.has(key)) {
+        const lower = value.toLowerCase();
+        if (TRUTHY_VALUES.has(lower))
+            return true;
+        if (FALSY_VALUES.has(lower))
+            return false;
+    }
+    return value;
 }
 /**
- * Apply all conda configuration from the action inputs, including channels,
- * package directories, auto-activation, and arbitrary config keys.
+ * Build the complete conda configuration and write it directly to ~/.condarc.
+ *
+ * This replaces the old approach of spawning N `conda config --set/--add`
+ * subprocesses (each taking 2-5s for Python/conda startup overhead).
  *
  * @param inputs - The parsed action inputs.
  * @param options - The current dynamic options.
- * @param reapply - When `true`, skip channels and `pkgs_dirs` that persist from the first call.
  */
-function applyCondaConfiguration(inputs_1, options_1) {
-    return conda_awaiter(this, arguments, void 0, function* (inputs, options, reapply = false) {
-        var _a, _b, _c, _d;
-        const configEntries = Object.entries(inputs.condaConfig);
-        // Skip channels and pkgs_dirs on reapply — they persist in .condarc from the
-        // first call and re-adding them produces spurious warnings (see #57)
-        if (!reapply) {
-            // Channels are special: if specified as an action input, these take priority
-            // over what is found in (at present) a YAML-based environment
-            let channels = parseCommaSeparated(inputs.condaConfig.channels);
-            if (!channels.length && ((_c = (_b = (_a = options.envSpec) === null || _a === void 0 ? void 0 : _a.yaml) === null || _b === void 0 ? void 0 : _b.channels) === null || _c === void 0 ? void 0 : _c.length)) {
-                channels = options.envSpec.yaml.channels;
-            }
-            // This can be enabled via conda-remove-defaults and channels = nodefaults
-            let removeDefaults = inputs.condaRemoveDefaults === "true";
-            // LIFO: reverse order to preserve higher priority as listed in the option
-            // .slice ensures working against a copy
-            for (const channel of channels.slice().reverse()) {
-                if (channel === "nodefaults") {
-                    warning("'nodefaults' channel detected: will remove 'defaults' if added implicitly. " +
-                        "In the future, 'nodefaults' to remove 'defaults' won't be supported. " +
-                        "Please set 'conda-remove-defaults' = 'true' in setup-miniconda to remove this warning.");
-                    removeDefaults = true;
-                    continue;
-                }
-                info(`Adding channel '${channel}'`);
-                yield condaCommand(["config", "--add", "channels", channel], inputs, options);
-            }
-            if (!channels.includes("defaults")) {
-                if (removeDefaults) {
-                    info("Removing implicitly added 'defaults' channel");
-                    const configsOutput = (yield condaCommand(["config", "--show-sources", "--json"], inputs, options, true));
-                    const configs = JSON.parse(configsOutput);
-                    for (const fileName in configs) {
-                        const fileConfig = configs[fileName];
-                        if ((_d = fileConfig === null || fileConfig === void 0 ? void 0 : fileConfig.channels) === null || _d === void 0 ? void 0 : _d.includes("defaults")) {
-                            yield condaCommand([
-                                "config",
-                                "--remove",
-                                "channels",
-                                "defaults",
-                                "--file",
-                                fileName,
-                            ], inputs, options);
-                        }
-                    }
-                }
-                else {
-                    warning("The 'defaults' channel might have been added implicitly. " +
-                        "If this is intentional, add 'defaults' to the 'channels' list. " +
-                        "Otherwise, consider setting 'conda-remove-defaults' to 'true'.");
-                }
-            }
-            // Package directories are also comma-separated, like channels
-            const pkgsDirs = parsePkgsDirs(inputs.condaConfig.pkgs_dirs);
-            for (const pkgsDir of pkgsDirs) {
-                info(`Adding pkgs_dir '${pkgsDir}'`);
-                yield condaCommand(["config", "--add", "pkgs_dirs", pkgsDir], inputs, options);
+function writeCondaConfig(inputs, options) {
+    return conda_awaiter(this, void 0, void 0, function* () {
+        var _a, _b, _c;
+        let config = {};
+        if (external_fs_namespaceObject.existsSync(CONDARC_PATH)) {
+            const existingConfig = load(external_fs_namespaceObject.readFileSync(CONDARC_PATH, "utf8"));
+            if (existingConfig) {
+                config = Object.assign({}, existingConfig);
+                info(`Read existing condarc from ${CONDARC_PATH} as base config`);
             }
         }
-        // auto_activate_base was renamed to auto_activate in 25.5.0
-        info(`auto_activate: ${inputs.condaConfig.auto_activate}`);
-        try {
-            // 25.5.0+
-            yield condaCommand(["config", "--set", "auto_activate", inputs.condaConfig.auto_activate], inputs, options);
-        }
-        catch (_e) {
-            try {
-                // <25.5.0
-                yield condaCommand([
-                    "config",
-                    "--set",
-                    "auto_activate_base",
-                    inputs.condaConfig.auto_activate,
-                ], inputs, options);
-            }
-            catch (err2) {
-                warning(err2);
+        if (inputs.condaConfigFile) {
+            const sourcePath = external_path_namespaceObject.join(process.env["GITHUB_WORKSPACE"] || "", inputs.condaConfigFile);
+            info(`Reading user condarc from "${sourcePath}"...`);
+            const userConfig = load(external_fs_namespaceObject.readFileSync(sourcePath, "utf8"));
+            if (userConfig) {
+                config = Object.assign(Object.assign({}, config), userConfig);
             }
         }
-        // All other options are just passed as their string representations
-        for (const [key, value] of configEntries) {
-            if (value.trim().length === 0 ||
-                key === "channels" ||
-                key === "pkgs_dirs" ||
-                key === "auto_activate") {
+        config["notify_outdated_conda"] = false;
+        // --- Channels ---
+        let channels = inputs.condaConfig.channels
+            .trim()
+            .split(/,/)
+            .map((c) => c.trim())
+            .filter((c) => c.length);
+        if (!channels.length && ((_c = (_b = (_a = options.envSpec) === null || _a === void 0 ? void 0 : _a.yaml) === null || _b === void 0 ? void 0 : _b.channels) === null || _c === void 0 ? void 0 : _c.length)) {
+            channels = options.envSpec.yaml.channels;
+        }
+        let removeDefaults = inputs.condaRemoveDefaults === "true";
+        const filteredChannels = [];
+        for (const channel of channels) {
+            if (channel === "nodefaults") {
+                warning("'nodefaults' channel detected: will remove 'defaults' if added implicitly. " +
+                    "In the future, 'nodefaults' to remove 'defaults' won't be supported. " +
+                    "Please set 'conda-remove-defaults' = 'true' in setup-miniconda to remove this warning.");
+                removeDefaults = true;
                 continue;
             }
-            info(`${key}: ${value}`);
-            try {
-                yield condaCommand(["config", "--set", key, value], inputs, options);
+            filteredChannels.push(channel);
+        }
+        const existingChannels = config["channels"] || [];
+        const userExplicitlyAddedDefaults = filteredChannels.includes("defaults");
+        if (filteredChannels.length) {
+            const merged = [
+                ...filteredChannels,
+                ...existingChannels.filter((c) => !filteredChannels.includes(c)),
+            ];
+            if (removeDefaults && !userExplicitlyAddedDefaults) {
+                config["channels"] = merged.filter((c) => c !== "defaults");
+                info("Removing implicitly added 'defaults' channel");
             }
-            catch (err) {
-                warning(err);
+            else {
+                config["channels"] = merged;
             }
         }
-        // Log all configuration information
-        yield condaCommand(["config", "--show-sources"], inputs, options);
-        yield condaCommand(["config", "--show"], inputs, options);
+        else if (removeDefaults) {
+            config["channels"] = existingChannels.filter((c) => c !== "defaults");
+            info("Removing implicitly added 'defaults' channel");
+        }
+        else if (!existingChannels.length) {
+            warning("The 'defaults' channel might have been added implicitly. " +
+                "If this is intentional, add 'defaults' to the 'channels' list. " +
+                "Otherwise, consider setting 'conda-remove-defaults' to 'true'.");
+        }
+        for (const ch of config["channels"] || []) {
+            info(`Channel: '${ch}'`);
+        }
+        // --- Package directories ---
+        const inputPkgsDirs = parsePkgsDirs(inputs.condaConfig.pkgs_dirs);
+        const existingPkgsDirs = config["pkgs_dirs"] || [];
+        const mergedPkgsDirs = [
+            ...inputPkgsDirs,
+            ...existingPkgsDirs.filter((d) => !inputPkgsDirs.includes(d)),
+        ];
+        config["pkgs_dirs"] = mergedPkgsDirs;
+        for (const pkgsDir of mergedPkgsDirs) {
+            info(`pkgs_dir: '${pkgsDir}'`);
+        }
+        // --- auto_activate_base ---
+        // Write auto_activate_base for broad compatibility. Conda 25.5.0+ also
+        // accepts auto_activate as the canonical name, but older versions only
+        // recognize auto_activate_base.
+        config["auto_activate_base"] = coerceConfigValue("auto_activate_base", inputs.condaConfig.auto_activate);
+        info(`auto_activate_base: ${config["auto_activate_base"]}`);
+        // --- All other config entries ---
+        const SKIP_KEYS = new Set([
+            "channels",
+            "pkgs_dirs",
+            "auto_activate",
+            "default_activation_env",
+        ]);
+        const configEntries = Object.entries(inputs.condaConfig);
+        for (const [key, value] of configEntries) {
+            if (SKIP_KEYS.has(key) || value.trim().length === 0) {
+                continue;
+            }
+            const coerced = coerceConfigValue(key, value);
+            config[key] = coerced;
+            info(`${key}: ${coerced}`);
+        }
+        // Strip 'defaults' from prefix-level condarc files too
+        if (removeDefaults && !userExplicitlyAddedDefaults) {
+            const basePath = condaBasePath(inputs, options);
+            const prefixCondarcPaths = [
+                external_path_namespaceObject.join(basePath, ".condarc"),
+                external_path_namespaceObject.join(basePath, "condarc"),
+            ];
+            for (const condarcPath of prefixCondarcPaths) {
+                if (!external_fs_namespaceObject.existsSync(condarcPath))
+                    continue;
+                try {
+                    const prefixConfig = load(external_fs_namespaceObject.readFileSync(condarcPath, "utf8"));
+                    if ((prefixConfig === null || prefixConfig === void 0 ? void 0 : prefixConfig["channels"]) &&
+                        Array.isArray(prefixConfig["channels"]) &&
+                        prefixConfig["channels"].includes("defaults")) {
+                        prefixConfig["channels"] = prefixConfig["channels"].filter((c) => c !== "defaults");
+                        const updatedYaml = dump(prefixConfig, { lineWidth: -1 });
+                        external_fs_namespaceObject.writeFileSync(condarcPath, updatedYaml, "utf8");
+                        info(`Removed 'defaults' channel from prefix condarc at ${condarcPath}`);
+                    }
+                }
+                catch (err) {
+                    warning(`Failed to process prefix condarc at ${condarcPath}: ${err}`);
+                }
+            }
+        }
+        for (const key of Object.keys(config)) {
+            if (!KNOWN_CONDARC_KEYS.has(key)) {
+                warning(`Unrecognized condarc key '${key}'. This may be a typo or a ` +
+                    `key from a newer conda version. conda will ignore unknown keys.`);
+            }
+        }
+        const configYaml = dump(config, { lineWidth: -1 });
+        info(`Writing condarc to ${CONDARC_PATH}:\n${configYaml}`);
+        external_fs_namespaceObject.writeFileSync(CONDARC_PATH, configYaml, "utf8");
+        if (isDebug()) {
+            yield condaCommand(["config", "--show"], inputs, options);
+        }
     });
 }
 /**
@@ -38272,9 +38357,9 @@ function isDefaultEnvironment(envName, inputs, options) {
         if (!external_fs_namespaceObject.existsSync(condarcPath))
             continue;
         try {
-            const config = load(external_fs_namespaceObject.readFileSync(condarcPath, "utf8"));
-            if (config === null || config === void 0 ? void 0 : config["default_activation_env"]) {
-                const defaultEnv = _getFullEnvironmentPath(config["default_activation_env"], inputs, options);
+            const condarcConfig = load(external_fs_namespaceObject.readFileSync(condarcPath, "utf8"));
+            if (condarcConfig === null || condarcConfig === void 0 ? void 0 : condarcConfig["default_activation_env"]) {
+                const defaultEnv = _getFullEnvironmentPath(condarcConfig["default_activation_env"], inputs, options);
                 const activationEnv = _getFullEnvironmentPath(envName, inputs, options);
                 return defaultEnv === activationEnv;
             }
@@ -40320,10 +40405,6 @@ function installBaseTools(inputs, options) {
         }
         if (tools.length) {
             yield condaCommand(["install", "--name", "base", ...tools], inputs, options);
-            // *Now* use the new options, as we may have a new conda/mamba with more supported
-            // options that previously failed. Pass reapply=true to skip channels/pkgs_dirs
-            // which already persist in .condarc from the first call (#57)
-            yield applyCondaConfiguration(inputs, postInstallOptions, true);
         }
         else {
             info("No tools were installed in 'base' env.");
@@ -40399,12 +40480,9 @@ function setupMiniconda(inputs) {
                 "respectively, to the parameters for this action.");
         }
         yield group("Setup environment variables...", () => setPathVariables(inputs, options));
-        if (inputs.condaConfigFile) {
-            yield group("Copying condarc file...", () => copyConfig(inputs));
-        }
         // For potential 'channels' that may alter configuration
         options.envSpec = yield group("Parsing environment...", () => getEnvSpec(inputs));
-        yield group("Applying initial configuration...", () => applyCondaConfiguration(inputs, options));
+        yield group("Writing conda configuration...", () => writeCondaConfig(inputs, options));
         yield group("Initializing conda shell integration...", () => condaInit(inputs, options));
         // New base tools may change options
         options = yield group("Adding tools to 'base' env...", () => installBaseTools(inputs, options));

--- a/src/__tests__/base-tools/index.test.ts
+++ b/src/__tests__/base-tools/index.test.ts
@@ -5,13 +5,12 @@ import type * as types from "../../types";
 // Mock @actions/core
 const mockInfo = vi.fn();
 vi.mock("@actions/core", () => ({
-  info: (...args: any[]) => mockInfo(...args),
+  info: (...args: unknown[]) => mockInfo(...args),
   warning: vi.fn(),
 }));
 
 // Mock conda
 const mockCondaCommand = vi.fn(async () => {});
-const mockApplyCondaConfiguration = vi.fn(async () => {});
 
 // Mock utils
 vi.mock("../../utils", () => ({
@@ -46,9 +45,7 @@ vi.mock("../../constants", () => ({
 
 // Mock conda functions used by update-mamba's postInstall
 vi.mock("../../conda", async () => ({
-  condaCommand: (...args: any[]) => mockCondaCommand(...args),
-  applyCondaConfiguration: (...args: any[]) =>
-    mockApplyCondaConfiguration(...args),
+  condaCommand: (...args: unknown[]) => mockCondaCommand(...args),
   condaExecutable: vi.fn(() => "/opt/conda/bin/mamba"),
   condaBasePath: vi.fn(() => "/opt/conda"),
 }));
@@ -118,7 +115,6 @@ describe("installBaseTools", () => {
   beforeEach(async () => {
     vi.resetModules();
     mockCondaCommand.mockReset();
-    mockApplyCondaConfiguration.mockReset();
     mockInfo.mockReset();
     const mod = await import("../../base-tools/index");
     installBaseTools = mod.installBaseTools;
@@ -131,7 +127,6 @@ describe("installBaseTools", () => {
     await installBaseTools(inputs, options);
 
     expect(mockCondaCommand).not.toHaveBeenCalled();
-    expect(mockApplyCondaConfiguration).not.toHaveBeenCalled();
     expect(mockInfo).toHaveBeenCalledWith(
       "No tools were installed in 'base' env.",
     );
@@ -151,18 +146,13 @@ describe("installBaseTools", () => {
     );
   });
 
-  it("calls applyCondaConfiguration with reapply=true after install", async () => {
+  it("does not call applyCondaConfiguration (config is written upfront)", async () => {
     const inputs = makeInputs({ condaVersion: "23.1.0" });
     const options = makeOptions();
 
     await installBaseTools(inputs, options);
 
-    expect(mockApplyCondaConfiguration).toHaveBeenCalledTimes(1);
-    expect(mockApplyCondaConfiguration).toHaveBeenCalledWith(
-      inputs,
-      expect.any(Object),
-      true,
-    );
+    expect(mockCondaCommand).toHaveBeenCalledTimes(1);
   });
 
   it("installs multiple tools in a single conda command", async () => {

--- a/src/__tests__/conda.test.ts
+++ b/src/__tests__/conda.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as yaml from "js-yaml";
 
 import type * as types from "../types";
 
@@ -6,6 +7,7 @@ import type * as types from "../types";
 vi.mock("@actions/core", () => ({
   info: vi.fn(),
   warning: vi.fn(),
+  isDebug: vi.fn(() => false),
 }));
 
 // Mock @actions/io
@@ -22,6 +24,8 @@ vi.mock("fs", async (importOriginal) => {
     ...actual,
     existsSync: vi.fn(() => true),
     appendFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn(() => ""),
   };
 });
 
@@ -123,74 +127,276 @@ function makeOptions(): types.IDynamicOptions {
   };
 }
 
-/**
- * Extract the conda subcommand args from execute calls.
- * execute() is called with [condaExePath, ...args], so args start at index 1.
- */
-function getCondaArgs(): string[][] {
-  return executeCalls.map((c) => c.command.slice(1));
-}
+describe("writeCondaConfig", () => {
+  let fsMod: typeof import("fs");
 
-describe("applyCondaConfiguration", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     executeCalls.length = 0;
+    fsMod = await import("fs");
+    vi.mocked(fsMod.existsSync).mockReturnValue(true);
+    vi.mocked(fsMod.writeFileSync).mockClear();
+    vi.mocked(fsMod.readFileSync).mockReturnValue("");
   });
 
-  it("adds channels on first call (reapply=false)", async () => {
-    const { applyCondaConfiguration } = await import("../conda");
+  function getWrittenConfig(): Record<string, unknown> {
+    const calls = vi.mocked(fsMod.writeFileSync).mock.calls;
+    const lastCall = calls[calls.length - 1];
+    return yaml.load(lastCall[1] as string) as Record<string, unknown>;
+  }
+
+  it("writes channels from input to condarc", async () => {
+    const { writeCondaConfig } = await import("../conda");
     const inputs = makeInputs({ channels: "conda-forge" });
 
-    await applyCondaConfiguration(inputs, makeOptions(), false);
-
-    const args = getCondaArgs();
-    const addChannelCalls = args.filter(
-      (a) => a.includes("--add") && a.includes("channels"),
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ channels: ["defaults"] }),
     );
-    expect(addChannelCalls.length).toBeGreaterThan(0);
-    expect(addChannelCalls[0]).toContain("conda-forge");
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["channels"]).toContain("conda-forge");
   });
 
-  it("skips channels on reapply=true (#57)", async () => {
-    const { applyCondaConfiguration } = await import("../conda");
-    const inputs = makeInputs({ channels: "conda-forge" });
+  it("uses channels from envSpec.yaml when input channels are empty", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "" });
+    const options: types.IDynamicOptions = {
+      ...makeOptions(),
+      envSpec: {
+        yaml: { channels: ["bioconda", "defaults"] },
+      },
+    };
 
-    await applyCondaConfiguration(inputs, makeOptions(), true);
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
 
-    const args = getCondaArgs();
-    const addChannelCalls = args.filter(
-      (a) => a.includes("--add") && a.includes("channels"),
+    await writeCondaConfig(inputs, options);
+
+    const config = getWrittenConfig();
+    expect(config["channels"]).toContain("bioconda");
+    expect(config["channels"]).toContain("defaults");
+  });
+
+  it("handles nodefaults channel by removing defaults", async () => {
+    const core = await import("@actions/core");
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "nodefaults,conda-forge" });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ channels: ["defaults"] }),
     );
-    expect(addChannelCalls).toEqual([]);
-  });
 
-  it("skips pkgs_dirs on reapply=true (#57)", async () => {
-    const { applyCondaConfiguration } = await import("../conda");
-    const inputs = makeInputs({ channels: "conda-forge" });
+    await writeCondaConfig(inputs, makeOptions());
 
-    await applyCondaConfiguration(inputs, makeOptions(), true);
-
-    const args = getCondaArgs();
-    const addPkgsDirCalls = args.filter(
-      (a) => a.includes("--add") && a.includes("pkgs_dirs"),
+    const config = getWrittenConfig();
+    expect(config["channels"]).not.toContain("defaults");
+    expect(config["channels"]).toContain("conda-forge");
+    expect(vi.mocked(core.warning)).toHaveBeenCalledWith(
+      expect.stringContaining("nodefaults"),
     );
-    expect(addPkgsDirCalls).toEqual([]);
   });
 
-  it("still applies --set options on reapply=true", async () => {
-    const { applyCondaConfiguration } = await import("../conda");
+  it("removes defaults when condaRemoveDefaults is true", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({
+      channels: "conda-forge",
+      condaRemoveDefaults: "true",
+    });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ channels: ["defaults"] }),
+    );
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["channels"]).not.toContain("defaults");
+    expect(config["channels"]).toContain("conda-forge");
+  });
+
+  it("keeps defaults when user explicitly adds it", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({
+      channels: "defaults,conda-forge",
+      condaRemoveDefaults: "true",
+    });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["channels"]).toContain("defaults");
+  });
+
+  it("warns about implicitly added defaults when removeDefaults is false and no channels exist", async () => {
+    const core = await import("@actions/core");
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({
+      channels: "",
+      condaRemoveDefaults: "false",
+    });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, {
+      ...makeOptions(),
+      envSpec: undefined,
+    });
+
+    expect(vi.mocked(core.warning)).toHaveBeenCalledWith(
+      expect.stringContaining("defaults"),
+    );
+  });
+
+  it("merges pkgs_dirs from input", async () => {
+    const { writeCondaConfig } = await import("../conda");
     const inputs = makeInputs({ channels: "conda-forge" });
 
-    await applyCondaConfiguration(inputs, makeOptions(), true);
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
 
-    const args = getCondaArgs();
-    const setCalls = args.filter((a) => a.includes("--set"));
-    expect(setCalls.length).toBeGreaterThan(0);
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["pkgs_dirs"]).toContain("/mock/pkgs");
+  });
+
+  it("sets auto_activate_base from input", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "conda-forge" });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["auto_activate_base"]).toBe(false);
+  });
+
+  it("sets notify_outdated_conda to false", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "conda-forge" });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["notify_outdated_conda"]).toBe(false);
+  });
+
+  it("writes config entries and skips empty values", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "conda-forge" });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["always_yes"]).toBe(true);
+    expect(config["changeps1"]).toBe(false);
+    expect(config).not.toHaveProperty("channel_alias");
+  });
+
+  it("warns on unrecognized condarc keys", async () => {
+    const core = await import("@actions/core");
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "conda-forge" });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ unknown_key: "value" }),
+    );
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    expect(vi.mocked(core.warning)).toHaveBeenCalledWith(
+      expect.stringContaining("unknown_key"),
+    );
+  });
+
+  it("writes YAML to CONDARC_PATH", async () => {
+    const constants = await import("../constants");
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "conda-forge" });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    expect(vi.mocked(fsMod.writeFileSync)).toHaveBeenCalledWith(
+      constants.CONDARC_PATH,
+      expect.any(String),
+      "utf8",
+    );
+  });
+
+  it("reads existing condarc and merges it", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "conda-forge" });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ solver: "libmamba" }),
+    );
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["solver"]).toBe("libmamba");
+    expect(config["channels"]).toContain("conda-forge");
+  });
+
+  it("reads condaConfigFile and merges it over existing condarc", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = {
+      ...makeInputs({ channels: "conda-forge" }),
+      condaConfigFile: "my-condarc.yml",
+    } as types.IActionInputs;
+
+    const originalWorkspace = process.env["GITHUB_WORKSPACE"];
+    process.env["GITHUB_WORKSPACE"] = "/workspace";
+
+    vi.mocked(fsMod.readFileSync).mockImplementation((p: unknown) => {
+      const pStr = p as string;
+      if (pStr.includes("my-condarc.yml")) {
+        return yaml.dump({ solver: "classic", channel_priority: "strict" });
+      }
+      return yaml.dump({ solver: "libmamba" });
+    });
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["solver"]).toBe("classic");
+    expect(config["channel_priority"]).toBe("strict");
+
+    if (originalWorkspace !== undefined) {
+      process.env["GITHUB_WORKSPACE"] = originalWorkspace;
+    } else {
+      delete process.env["GITHUB_WORKSPACE"];
+    }
+  });
+
+  it("handles missing existing condarc gracefully", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "conda-forge" });
+
+    vi.mocked(fsMod.existsSync).mockReturnValue(false);
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["channels"]).toContain("conda-forge");
   });
 });
 
 describe("condaInit", () => {
-  beforeEach(() => {
+  let fsMod: typeof import("fs");
+
+  beforeEach(async () => {
     executeCalls.length = 0;
+    fsMod = await import("fs");
+    vi.mocked(fsMod.existsSync).mockReturnValue(true);
   });
 
   it("skips conda init when runInit is false", async () => {
@@ -470,12 +676,18 @@ describe("bootstrapConfig", () => {
   });
 });
 
-describe("copyConfig", () => {
-  it("copies the condaConfigFile to CONDARC_PATH when set", async () => {
-    const io = await import("@actions/io");
-    const path = await import("path");
-    const constants = await import("../constants");
-    const { copyConfig } = await import("../conda");
+describe("writeCondaConfig with condaConfigFile", () => {
+  let fsMod: typeof import("fs");
+
+  beforeEach(async () => {
+    fsMod = await import("fs");
+    vi.mocked(fsMod.existsSync).mockReturnValue(true);
+    vi.mocked(fsMod.writeFileSync).mockClear();
+  });
+
+  it("reads the condaConfigFile from GITHUB_WORKSPACE and merges it", async () => {
+    const pathMod = await import("path");
+    const { writeCondaConfig } = await import("../conda");
 
     const inputs = {
       ...makeInputs(),
@@ -485,14 +697,27 @@ describe("copyConfig", () => {
     const originalWorkspace = process.env["GITHUB_WORKSPACE"];
     process.env["GITHUB_WORKSPACE"] = "/workspace";
 
-    await copyConfig(inputs);
+    vi.mocked(fsMod.readFileSync).mockImplementation((p: unknown) => {
+      const pStr = p as string;
+      if (pStr === pathMod.join("/workspace", "my-condarc.yml")) {
+        return yaml.dump({ solver: "libmamba" });
+      }
+      return yaml.dump({});
+    });
 
-    expect(vi.mocked(io.cp)).toHaveBeenCalledWith(
-      path.join("/workspace", "my-condarc.yml"),
-      constants.CONDARC_PATH,
-    );
+    await writeCondaConfig(inputs, makeOptions());
 
-    // Restore
+    const calls = vi.mocked(fsMod.readFileSync).mock.calls;
+    const readPaths = calls.map((c) => c[0] as string);
+    expect(readPaths).toContain(pathMod.join("/workspace", "my-condarc.yml"));
+
+    const lastWriteCall = vi.mocked(fsMod.writeFileSync).mock.calls.at(-1);
+    const config = yaml.load(lastWriteCall![1] as string) as Record<
+      string,
+      unknown
+    >;
+    expect(config["solver"]).toBe("libmamba");
+
     if (originalWorkspace !== undefined) {
       process.env["GITHUB_WORKSPACE"] = originalWorkspace;
     } else {
@@ -684,6 +909,7 @@ describe("condaInitActivation", () => {
 
 // ---------------------------------------------------------------------------
 // _getFullEnvironmentPath (exercised via condaInitActivation → isDefaultEnvironment)
+// isDefaultEnvironment now reads condarc files directly via fs.readFileSync
 // ---------------------------------------------------------------------------
 describe("_getFullEnvironmentPath coverage", () => {
   let fsMod: typeof import("fs");
@@ -693,53 +919,26 @@ describe("_getFullEnvironmentPath coverage", () => {
     fsMod = await import("fs");
     vi.mocked(fsMod.existsSync).mockReturnValue(true);
     vi.mocked(fsMod.appendFileSync).mockClear();
+    vi.mocked(fsMod.readFileSync).mockReturnValue("");
   });
-
-  /**
-   * Override the execute mock to return a specific default_activation_env
-   * for --show --json calls. Uses vi.mocked to override the existing mock.
-   */
-  async function mockDefaultActivationEnv(envValue: string) {
-    const utils = await import("../utils");
-    vi.mocked(utils.execute).mockImplementation(async (command: string[]) => {
-      executeCalls.push({ command });
-      if (command.includes("--show") && command.includes("--json")) {
-        return JSON.stringify({ default_activation_env: envValue });
-      }
-      if (command.includes("--show-sources") && command.includes("--json")) {
-        return "{}";
-      }
-      return "";
-    });
-  }
 
   afterEach(async () => {
-    // Restore the default execute mock behavior
-    const utils = await import("../utils");
-    vi.mocked(utils.execute).mockImplementation(async (command: string[]) => {
-      executeCalls.push({ command });
-      if (command.includes("--show") && command.includes("--json")) {
-        return '{"default_activation_env": ""}';
-      }
-      if (command.includes("--show-sources") && command.includes("--json")) {
-        return "{}";
-      }
-      return "";
-    });
+    vi.mocked(fsMod.readFileSync).mockReturnValue("");
   });
 
+  function mockCondarcWithDefaultEnv(envValue: string) {
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ default_activation_env: envValue }),
+    );
+  }
+
   it("resolves a simple env name to installDir/envs/name when default_activation_env is set", async () => {
-    // default_activation_env = "mydefault" (a simple name, not base)
-    // activateEnvironment = "test" (also a simple name, not base)
-    // Both go through the name branch: installDir/envs/<name>
-    // They differ, so isValidActivate = true, profiles get activate commands
-    await mockDefaultActivationEnv("mydefault");
+    mockCondarcWithDefaultEnv("mydefault");
     const { condaInitActivation } = await import("../conda");
     const inputs = makeInputs({ runInit: "true" });
 
     await condaInitActivation(inputs, makeOptions());
 
-    // activateEnvironment="test" != "mydefault", so conda activate should appear
     const appendCalls = vi.mocked(fsMod.appendFileSync).mock.calls;
     const hasActivate = appendCalls.some(
       (call) =>
@@ -750,15 +949,11 @@ describe("_getFullEnvironmentPath coverage", () => {
   });
 
   it("resolves base env name to installDir when default_activation_env is base", async () => {
-    // default_activation_env = "base"
-    // activateEnvironment = "base"
-    // Both resolve via isBaseEnv to path.resolve(installDir)
-    // They match, so isValidActivate = false, no activate commands
     const utils = await import("../utils");
     vi.mocked(utils.isBaseEnv).mockImplementation(
       (name) => name === "base" || name === "root" || name === "",
     );
-    await mockDefaultActivationEnv("base");
+    mockCondarcWithDefaultEnv("base");
     const { condaInitActivation } = await import("../conda");
     const inputs = {
       ...makeInputs({ runInit: "true" }),
@@ -767,7 +962,6 @@ describe("_getFullEnvironmentPath coverage", () => {
 
     await condaInitActivation(inputs, makeOptions());
 
-    // Both resolve to the same path → isValidActivate = false → no activate
     const appendCalls = vi.mocked(fsMod.appendFileSync).mock.calls;
     const hasActivate = appendCalls.some(
       (call) =>
@@ -775,15 +969,11 @@ describe("_getFullEnvironmentPath coverage", () => {
         call[1].includes('conda activate "base"'),
     );
     expect(hasActivate).toBe(false);
-    // Restore isBaseEnv default
     vi.mocked(utils.isBaseEnv).mockImplementation(() => false);
   });
 
   it("resolves ~/ paths via os.homedir when default_activation_env starts with ~/", async () => {
-    // default_activation_env = "~/myenvs/default" → homedir path
-    // activateEnvironment = "test" → installDir/envs/test
-    // Different paths → isValidActivate = true
-    await mockDefaultActivationEnv("~/myenvs/default");
+    mockCondarcWithDefaultEnv("~/myenvs/default");
     const { condaInitActivation } = await import("../conda");
     const inputs = makeInputs({ runInit: "true" });
 
@@ -799,10 +989,7 @@ describe("_getFullEnvironmentPath coverage", () => {
   });
 
   it("resolves absolute paths directly when default_activation_env is absolute", async () => {
-    // default_activation_env = "/opt/envs/production" → absolute path
-    // activateEnvironment = "test" → installDir/envs/test
-    // Different → isValidActivate = true
-    await mockDefaultActivationEnv("/opt/envs/production");
+    mockCondarcWithDefaultEnv("/opt/envs/production");
     const { condaInitActivation } = await import("../conda");
     const inputs = makeInputs({ runInit: "true" });
 
@@ -818,9 +1005,7 @@ describe("_getFullEnvironmentPath coverage", () => {
   });
 
   it("treats activateEnvironment with / as an absolute path", async () => {
-    // activateEnvironment = "/custom/path/myenv" (contains /)
-    // Goes through the absolute path branch of _getFullEnvironmentPath
-    await mockDefaultActivationEnv("someother");
+    mockCondarcWithDefaultEnv("someother");
     const { condaInitActivation } = await import("../conda");
     const inputs = {
       ...makeInputs({ runInit: "true" }),
@@ -914,284 +1099,136 @@ describe("condaCommand captureOutput", () => {
 });
 
 // ---------------------------------------------------------------------------
-// applyCondaConfiguration — additional branches
+// writeCondaConfig — additional branches
 // ---------------------------------------------------------------------------
-describe("applyCondaConfiguration additional branches", () => {
+describe("writeCondaConfig additional branches", () => {
   let fsMod: typeof import("fs");
 
   beforeEach(async () => {
     executeCalls.length = 0;
     fsMod = await import("fs");
     vi.mocked(fsMod.existsSync).mockReturnValue(true);
+    vi.mocked(fsMod.writeFileSync).mockClear();
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
   });
 
-  it("uses channels from envSpec.yaml when input channels are empty", async () => {
-    const { applyCondaConfiguration } = await import("../conda");
-    const inputs = makeInputs({ channels: "" });
-    const options: types.IDynamicOptions = {
-      ...makeOptions(),
-      envSpec: {
-        yaml: { channels: ["bioconda", "defaults"] },
-      },
-    };
+  function getWrittenConfig(): Record<string, unknown> {
+    const calls = vi.mocked(fsMod.writeFileSync).mock.calls;
+    const lastCall = calls[calls.length - 1];
+    return yaml.load(lastCall[1] as string) as Record<string, unknown>;
+  }
 
-    await applyCondaConfiguration(inputs, options, false);
-
-    const args = getCondaArgs();
-    const addChannelCalls = args.filter(
-      (a) => a.includes("--add") && a.includes("channels"),
-    );
-    // Should have added bioconda and defaults from envSpec
-    expect(addChannelCalls.length).toBeGreaterThanOrEqual(2);
-  });
-
-  it("handles nodefaults channel by setting removeDefaults", async () => {
+  it("strips defaults from prefix-level condarc when removeDefaults is set", async () => {
     const core = await import("@actions/core");
-    const utils = await import("../utils");
-    const { applyCondaConfiguration } = await import("../conda");
-
-    // Return a config where "defaults" is present in a file's channels
-    vi.mocked(utils.execute).mockImplementation(async (command: string[]) => {
-      executeCalls.push({ command });
-      if (command.includes("--show-sources") && command.includes("--json")) {
-        return JSON.stringify({
-          "/home/.condarc": { channels: ["defaults", "conda-forge"] },
-        });
-      }
-      if (command.includes("--show") && command.includes("--json")) {
-        return '{"default_activation_env": ""}';
-      }
-      return "";
-    });
-
-    const inputs = makeInputs({ channels: "nodefaults,conda-forge" });
-    await applyCondaConfiguration(inputs, makeOptions(), false);
-
-    // Should have warned about nodefaults
-    expect(vi.mocked(core.warning)).toHaveBeenCalledWith(
-      expect.stringContaining("nodefaults"),
-    );
-
-    // Should have called --remove channels defaults
-    const args = getCondaArgs();
-    const removeCalls = args.filter(
-      (a) =>
-        a.includes("--remove") &&
-        a.includes("channels") &&
-        a.includes("defaults"),
-    );
-    expect(removeCalls.length).toBeGreaterThan(0);
-
-    // Restore the mock
-    vi.mocked(utils.execute).mockImplementation(async (command: string[]) => {
-      executeCalls.push({ command });
-      if (command.includes("--show-sources") && command.includes("--json")) {
-        return "{}";
-      }
-      if (command.includes("--show") && command.includes("--json")) {
-        return '{"default_activation_env": ""}';
-      }
-      return "";
-    });
-  });
-
-  it("removes defaults when condaRemoveDefaults is true and defaults not in channels", async () => {
-    const utils = await import("../utils");
-    const { applyCondaConfiguration } = await import("../conda");
-
-    vi.mocked(utils.execute).mockImplementation(async (command: string[]) => {
-      executeCalls.push({ command });
-      if (command.includes("--show-sources") && command.includes("--json")) {
-        return JSON.stringify({
-          "/home/.condarc": { channels: ["defaults", "conda-forge"] },
-        });
-      }
-      if (command.includes("--show") && command.includes("--json")) {
-        return '{"default_activation_env": ""}';
-      }
-      return "";
-    });
-
+    const { writeCondaConfig } = await import("../conda");
     const inputs = makeInputs({
       channels: "conda-forge",
       condaRemoveDefaults: "true",
     });
-    await applyCondaConfiguration(inputs, makeOptions(), false);
 
-    const args = getCondaArgs();
-    const removeCalls = args.filter(
-      (a) =>
-        a.includes("--remove") &&
-        a.includes("channels") &&
-        a.includes("defaults"),
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ channels: ["defaults", "conda-forge"] }),
     );
-    expect(removeCalls.length).toBeGreaterThan(0);
 
-    // Restore mock
-    vi.mocked(utils.execute).mockImplementation(async (command: string[]) => {
-      executeCalls.push({ command });
-      if (command.includes("--show-sources") && command.includes("--json")) {
-        return "{}";
-      }
-      if (command.includes("--show") && command.includes("--json")) {
-        return '{"default_activation_env": ""}';
-      }
-      return "";
-    });
-  });
+    await writeCondaConfig(inputs, makeOptions());
 
-  it("warns about implicitly added defaults when removeDefaults is false", async () => {
-    const core = await import("@actions/core");
-    const { applyCondaConfiguration } = await import("../conda");
-    // channels does NOT include "defaults" and condaRemoveDefaults is false
-    const inputs = makeInputs({
-      channels: "conda-forge",
-      condaRemoveDefaults: "false",
-    });
-
-    await applyCondaConfiguration(inputs, makeOptions(), false);
-
-    expect(vi.mocked(core.warning)).toHaveBeenCalledWith(
-      expect.stringContaining("defaults"),
+    const writeCalls = vi.mocked(fsMod.writeFileSync).mock.calls;
+    expect(writeCalls.length).toBeGreaterThan(0);
+    expect(vi.mocked(core.info)).toHaveBeenCalledWith(
+      expect.stringContaining("Removing implicitly added 'defaults' channel"),
     );
   });
 
-  it("adds pkgs_dirs on first call", async () => {
-    const { applyCondaConfiguration } = await import("../conda");
+  it("coerces boolean config values correctly", async () => {
+    const { writeCondaConfig } = await import("../conda");
     const inputs = makeInputs({ channels: "conda-forge" });
 
-    await applyCondaConfiguration(inputs, makeOptions(), false);
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
 
-    const args = getCondaArgs();
-    const pkgsDirCalls = args.filter(
-      (a) => a.includes("--add") && a.includes("pkgs_dirs"),
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["auto_update_conda"]).toBe(false);
+    expect(config["always_yes"]).toBe(true);
+    expect(config["changeps1"]).toBe(false);
+  });
+
+  it("preserves existing pkgs_dirs while merging input", async () => {
+    const utils = await import("../utils");
+    const { writeCondaConfig } = await import("../conda");
+
+    vi.mocked(utils.parsePkgsDirs).mockReturnValue(["/custom/pkgs"]);
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ pkgs_dirs: ["/existing/pkgs"] }),
     );
-    // parsePkgsDirs mock returns ["/mock/pkgs"]
-    expect(pkgsDirCalls.length).toBe(1);
-    expect(pkgsDirCalls[0]).toContain("/mock/pkgs");
+
+    const inputs = makeInputs({ channels: "conda-forge" });
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    const pkgsDirs = config["pkgs_dirs"] as string[];
+    expect(pkgsDirs).toContain("/custom/pkgs");
+    expect(pkgsDirs).toContain("/existing/pkgs");
+
+    vi.mocked(utils.parsePkgsDirs).mockReturnValue(["/mock/pkgs"]);
   });
 
-  it("falls back to auto_activate_base when auto_activate config --set fails", async () => {
-    const utils = await import("../utils");
-    const { applyCondaConfiguration } = await import("../conda");
+  it("merges channels preserving order (user channels first)", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "conda-forge,bioconda" });
 
-    vi.mocked(utils.execute).mockImplementation(async (command: string[]) => {
-      executeCalls.push({ command });
-      if (command.includes("--show-sources") && command.includes("--json")) {
-        return "{}";
-      }
-      if (command.includes("--show") && command.includes("--json")) {
-        return '{"default_activation_env": ""}';
-      }
-      // Make --set auto_activate fail to trigger fallback
-      if (command.includes("--set") && command.includes("auto_activate")) {
-        throw new Error("Unknown config key: auto_activate");
-      }
-      return "";
-    });
-
-    const inputs = makeInputs({ channels: "defaults" });
-    await applyCondaConfiguration(inputs, makeOptions(), false);
-
-    const args = getCondaArgs();
-    const autoActivateBaseCalls = args.filter(
-      (a) => a.includes("--set") && a.includes("auto_activate_base"),
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ channels: ["defaults"] }),
     );
-    expect(autoActivateBaseCalls.length).toBe(1);
 
-    // Restore mock
-    vi.mocked(utils.execute).mockImplementation(async (command: string[]) => {
-      executeCalls.push({ command });
-      if (command.includes("--show-sources") && command.includes("--json")) {
-        return "{}";
-      }
-      if (command.includes("--show") && command.includes("--json")) {
-        return '{"default_activation_env": ""}';
-      }
-      return "";
-    });
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    const channels = config["channels"] as string[];
+    expect(channels.indexOf("conda-forge")).toBeLessThan(
+      channels.indexOf("bioconda"),
+    );
+    expect(channels.indexOf("bioconda")).toBeLessThan(
+      channels.indexOf("defaults"),
+    );
   });
 
-  it("warns and continues when a generic --set config option fails", async () => {
-    const core = await import("@actions/core");
-    const utils = await import("../utils");
-    const { applyCondaConfiguration } = await import("../conda");
-
-    vi.mocked(utils.execute).mockImplementation(async (command: string[]) => {
-      executeCalls.push({ command });
-      if (command.includes("--show-sources") && command.includes("--json")) {
-        return "{}";
-      }
-      if (command.includes("--show") && command.includes("--json")) {
-        return '{"default_activation_env": ""}';
-      }
-      // Make --set auto_update_conda fail
-      if (command.includes("--set") && command.includes("auto_update_conda")) {
-        throw new Error("config set failed");
-      }
-      return "";
+  it("removes defaults from existing channels when removeDefaults is true and no input channels", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({
+      channels: "",
+      condaRemoveDefaults: "true",
     });
 
-    const inputs = makeInputs({ channels: "defaults" });
-    await applyCondaConfiguration(inputs, makeOptions(), false);
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ channels: ["defaults", "conda-forge"] }),
+    );
 
-    // Should have called core.warning with the error
-    expect(vi.mocked(core.warning)).toHaveBeenCalledWith(expect.any(Error));
-
-    // Restore mock
-    vi.mocked(utils.execute).mockImplementation(async (command: string[]) => {
-      executeCalls.push({ command });
-      if (command.includes("--show-sources") && command.includes("--json")) {
-        return "{}";
-      }
-      if (command.includes("--show") && command.includes("--json")) {
-        return '{"default_activation_env": ""}';
-      }
-      return "";
+    await writeCondaConfig(inputs, {
+      ...makeOptions(),
+      envSpec: undefined,
     });
+
+    const config = getWrittenConfig();
+    const channels = config["channels"] as string[];
+    expect(channels).not.toContain("defaults");
+    expect(channels).toContain("conda-forge");
   });
 
-  it("warns when both auto_activate and auto_activate_base fail", async () => {
-    const core = await import("@actions/core");
-    const utils = await import("../utils");
-    const { applyCondaConfiguration } = await import("../conda");
+  it("does not duplicate channels already present in existing config", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "conda-forge" });
 
-    vi.mocked(utils.execute).mockImplementation(async (command: string[]) => {
-      executeCalls.push({ command });
-      if (command.includes("--show-sources") && command.includes("--json")) {
-        return "{}";
-      }
-      if (command.includes("--show") && command.includes("--json")) {
-        return '{"default_activation_env": ""}';
-      }
-      // Fail both auto_activate and auto_activate_base
-      if (
-        command.includes("--set") &&
-        (command.includes("auto_activate") ||
-          command.includes("auto_activate_base"))
-      ) {
-        throw new Error("config set failed");
-      }
-      return "";
-    });
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ channels: ["conda-forge", "defaults"] }),
+    );
 
-    const inputs = makeInputs({ channels: "defaults" });
-    await applyCondaConfiguration(inputs, makeOptions(), false);
+    await writeCondaConfig(inputs, makeOptions());
 
-    // core.warning should have been called with the second error
-    expect(vi.mocked(core.warning)).toHaveBeenCalledWith(expect.any(Error));
-
-    // Restore mock
-    vi.mocked(utils.execute).mockImplementation(async (command: string[]) => {
-      executeCalls.push({ command });
-      if (command.includes("--show-sources") && command.includes("--json")) {
-        return "{}";
-      }
-      if (command.includes("--show") && command.includes("--json")) {
-        return '{"default_activation_env": ""}';
-      }
-      return "";
-    });
+    const config = getWrittenConfig();
+    const channels = config["channels"] as string[];
+    const condaForgeCount = channels.filter((c) => c === "conda-forge").length;
+    expect(condaForgeCount).toBe(1);
   });
 });
 

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -54,15 +54,13 @@ vi.mock("../installer", () => ({
 // ./conda
 const mockBootstrapConfig = vi.fn();
 const mockCondaBasePath = vi.fn(() => "/mock/conda");
-const mockCopyConfig = vi.fn();
-const mockApplyCondaConfiguration = vi.fn();
+const mockWriteCondaConfig = vi.fn();
 const mockCondaInit = vi.fn();
 const mockCondaInitActivation = vi.fn();
 vi.mock("../conda", () => ({
   bootstrapConfig: mockBootstrapConfig,
   condaBasePath: mockCondaBasePath,
-  copyConfig: mockCopyConfig,
-  applyCondaConfiguration: mockApplyCondaConfiguration,
+  writeCondaConfig: mockWriteCondaConfig,
   condaInit: mockCondaInit,
   condaInitActivation: mockCondaInitActivation,
 }));
@@ -188,7 +186,7 @@ describe("run", () => {
     expect(mockGetLocalInstallerPath).toHaveBeenCalledOnce();
     expect(mockSetPathVariables).toHaveBeenCalledOnce();
     expect(mockGetEnvSpec).toHaveBeenCalledOnce();
-    expect(mockApplyCondaConfiguration).toHaveBeenCalledOnce();
+    expect(mockWriteCondaConfig).toHaveBeenCalledOnce();
     expect(mockCondaInit).toHaveBeenCalledOnce();
     expect(mockInstallBaseTools).toHaveBeenCalledOnce();
     expect(mockCondaInitActivation).toHaveBeenCalledOnce();
@@ -321,21 +319,15 @@ describe("run", () => {
     );
   });
 
-  it("copies condarc when condaConfigFile is set", async () => {
+  it("passes condaConfigFile through to writeCondaConfig", async () => {
     mockParseInputs.mockResolvedValue(
       makeInputs({ condaConfigFile: "/path/to/.condarc" }),
     );
 
     await importAndRun();
 
-    expect(mockCopyConfig).toHaveBeenCalledOnce();
-  });
-
-  it("skips copying condarc when condaConfigFile is empty", async () => {
-    mockParseInputs.mockResolvedValue(makeInputs({ condaConfigFile: "" }));
-
-    await importAndRun();
-
-    expect(mockCopyConfig).not.toHaveBeenCalled();
+    expect(mockWriteCondaConfig).toHaveBeenCalledOnce();
+    const callArgs = mockWriteCondaConfig.mock.calls[0];
+    expect(callArgs[0].condaConfigFile).toBe("/path/to/.condarc");
   });
 });

--- a/src/base-tools/index.ts
+++ b/src/base-tools/index.ts
@@ -72,11 +72,6 @@ export async function installBaseTools(
       inputs,
       options,
     );
-
-    // *Now* use the new options, as we may have a new conda/mamba with more supported
-    // options that previously failed. Pass reapply=true to skip channels/pkgs_dirs
-    // which already persist in .condarc from the first call (#57)
-    await conda.applyCondaConfiguration(inputs, postInstallOptions, true);
   } else {
     core.info("No tools were installed in 'base' env.");
   }

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -193,170 +193,258 @@ export async function bootstrapConfig(): Promise<void> {
   );
 }
 
+const BOOLEAN_CONDARC_KEYS = new Set([
+  "add_anaconda_token",
+  "add_pip_as_python_dependency",
+  "allow_softlinks",
+  "auto_activate_base",
+  "auto_update_conda",
+  "show_channel_urls",
+  "use_only_tar_bz2",
+  "always_yes",
+  "changeps1",
+  "notify_outdated_conda",
+]);
+
+const KNOWN_CONDARC_KEYS = new Set([
+  ...BOOLEAN_CONDARC_KEYS,
+  "channels",
+  "channel_alias",
+  "channel_priority",
+  "channel_settings",
+  "custom_channels",
+  "custom_multichannels",
+  "default_channels",
+  "default_activation_env",
+  "denylist_channels",
+  "allowlist_channels",
+  "create_default_packages",
+  "envs_dirs",
+  "override_channels_enabled",
+  "pkgs_dirs",
+  "proxy_servers",
+  "repodata_threads",
+  "restore_free_channel",
+  "safety_checks",
+  "solver",
+  "ssl_verify",
+  "auto_activate",
+]);
+
+const TRUTHY_VALUES = new Set(["true", "yes", "on", "y", "1"]);
+const FALSY_VALUES = new Set(["false", "no", "off", "n", "0"]);
+
 /**
- * Copy a user-provided `.condarc` file from the workspace into `~/.condarc`.
+ * Coerce a string value to its appropriate YAML type for a given condarc key.
+ * Handles all YAML 1.1 boolean literals (true/false/yes/no/on/off/y/n/1/0).
  *
- * @param inputs - The parsed action inputs containing the condarc file path.
+ * @param key - The condarc configuration key name.
+ * @param value - The raw string value from the action input.
+ * @returns The coerced boolean or original string value.
  */
-export async function copyConfig(inputs: types.IActionInputs) {
-  const sourcePath: string = path.join(
-    process.env["GITHUB_WORKSPACE"] || "",
-    inputs.condaConfigFile,
-  );
-  core.info(`Copying "${sourcePath}" to "${constants.CONDARC_PATH}..."`);
-  await io.cp(sourcePath, constants.CONDARC_PATH);
+function coerceConfigValue(key: string, value: string): boolean | string {
+  if (BOOLEAN_CONDARC_KEYS.has(key)) {
+    const lower = value.toLowerCase();
+    if (TRUTHY_VALUES.has(lower)) return true;
+    if (FALSY_VALUES.has(lower)) return false;
+  }
+  return value;
 }
 
 /**
- * Apply all conda configuration from the action inputs, including channels,
- * package directories, auto-activation, and arbitrary config keys.
+ * Build the complete conda configuration and write it directly to ~/.condarc.
+ *
+ * This replaces the old approach of spawning N `conda config --set/--add`
+ * subprocesses (each taking 2-5s for Python/conda startup overhead).
  *
  * @param inputs - The parsed action inputs.
  * @param options - The current dynamic options.
- * @param reapply - When `true`, skip channels and `pkgs_dirs` that persist from the first call.
  */
-export async function applyCondaConfiguration(
+export async function writeCondaConfig(
   inputs: types.IActionInputs,
   options: types.IDynamicOptions,
-  reapply: boolean = false,
 ): Promise<void> {
+  let config: Record<string, unknown> = {};
+
+  if (fs.existsSync(constants.CONDARC_PATH)) {
+    const existingConfig = yaml.load(
+      fs.readFileSync(constants.CONDARC_PATH, "utf8"),
+    ) as Record<string, unknown> | null;
+    if (existingConfig) {
+      config = { ...existingConfig };
+      core.info(
+        `Read existing condarc from ${constants.CONDARC_PATH} as base config`,
+      );
+    }
+  }
+
+  if (inputs.condaConfigFile) {
+    const sourcePath = path.join(
+      process.env["GITHUB_WORKSPACE"] || "",
+      inputs.condaConfigFile,
+    );
+    core.info(`Reading user condarc from "${sourcePath}"...`);
+    const userConfig = yaml.load(fs.readFileSync(sourcePath, "utf8")) as Record<
+      string,
+      unknown
+    > | null;
+    if (userConfig) {
+      config = { ...config, ...userConfig };
+    }
+  }
+
+  config["notify_outdated_conda"] = false;
+
+  // --- Channels ---
+  let channels = inputs.condaConfig.channels
+    .trim()
+    .split(/,/)
+    .map((c) => c.trim())
+    .filter((c) => c.length);
+
+  if (!channels.length && options.envSpec?.yaml?.channels?.length) {
+    channels = options.envSpec.yaml.channels;
+  }
+
+  let removeDefaults: boolean = inputs.condaRemoveDefaults === "true";
+
+  const filteredChannels: string[] = [];
+  for (const channel of channels) {
+    if (channel === "nodefaults") {
+      core.warning(
+        "'nodefaults' channel detected: will remove 'defaults' if added implicitly. " +
+          "In the future, 'nodefaults' to remove 'defaults' won't be supported. " +
+          "Please set 'conda-remove-defaults' = 'true' in setup-miniconda to remove this warning.",
+      );
+      removeDefaults = true;
+      continue;
+    }
+    filteredChannels.push(channel);
+  }
+
+  const existingChannels = (config["channels"] as string[]) || [];
+  const userExplicitlyAddedDefaults = filteredChannels.includes("defaults");
+
+  if (filteredChannels.length) {
+    const merged = [
+      ...filteredChannels,
+      ...existingChannels.filter((c) => !filteredChannels.includes(c)),
+    ];
+    if (removeDefaults && !userExplicitlyAddedDefaults) {
+      config["channels"] = merged.filter((c) => c !== "defaults");
+      core.info("Removing implicitly added 'defaults' channel");
+    } else {
+      config["channels"] = merged;
+    }
+  } else if (removeDefaults) {
+    config["channels"] = existingChannels.filter((c) => c !== "defaults");
+    core.info("Removing implicitly added 'defaults' channel");
+  } else if (!existingChannels.length) {
+    core.warning(
+      "The 'defaults' channel might have been added implicitly. " +
+        "If this is intentional, add 'defaults' to the 'channels' list. " +
+        "Otherwise, consider setting 'conda-remove-defaults' to 'true'.",
+    );
+  }
+
+  for (const ch of (config["channels"] as string[]) || []) {
+    core.info(`Channel: '${ch}'`);
+  }
+
+  // --- Package directories ---
+  const inputPkgsDirs = utils.parsePkgsDirs(inputs.condaConfig.pkgs_dirs);
+  const existingPkgsDirs = (config["pkgs_dirs"] as string[]) || [];
+  const mergedPkgsDirs = [
+    ...inputPkgsDirs,
+    ...existingPkgsDirs.filter((d) => !inputPkgsDirs.includes(d)),
+  ];
+  config["pkgs_dirs"] = mergedPkgsDirs;
+  for (const pkgsDir of mergedPkgsDirs) {
+    core.info(`pkgs_dir: '${pkgsDir}'`);
+  }
+
+  // --- auto_activate_base ---
+  // Write auto_activate_base for broad compatibility. Conda 25.5.0+ also
+  // accepts auto_activate as the canonical name, but older versions only
+  // recognize auto_activate_base.
+  config["auto_activate_base"] = coerceConfigValue(
+    "auto_activate_base",
+    inputs.condaConfig.auto_activate,
+  );
+  core.info(`auto_activate_base: ${config["auto_activate_base"]}`);
+
+  // --- All other config entries ---
+  const SKIP_KEYS = new Set([
+    "channels",
+    "pkgs_dirs",
+    "auto_activate",
+    "default_activation_env",
+  ]);
   const configEntries = Object.entries(inputs.condaConfig) as [
     keyof types.ICondaConfig,
     string,
   ][];
 
-  // Skip channels and pkgs_dirs on reapply — they persist in .condarc from the
-  // first call and re-adding them produces spurious warnings (see #57)
-  if (!reapply) {
-    // Channels are special: if specified as an action input, these take priority
-    // over what is found in (at present) a YAML-based environment
-    let channels = utils.parseCommaSeparated(inputs.condaConfig.channels);
-
-    if (!channels.length && options.envSpec?.yaml?.channels?.length) {
-      channels = options.envSpec.yaml.channels;
-    }
-
-    // This can be enabled via conda-remove-defaults and channels = nodefaults
-    let removeDefaults: boolean = inputs.condaRemoveDefaults === "true";
-
-    // LIFO: reverse order to preserve higher priority as listed in the option
-    // .slice ensures working against a copy
-    for (const channel of channels.slice().reverse()) {
-      if (channel === "nodefaults") {
-        core.warning(
-          "'nodefaults' channel detected: will remove 'defaults' if added implicitly. " +
-            "In the future, 'nodefaults' to remove 'defaults' won't be supported. " +
-            "Please set 'conda-remove-defaults' = 'true' in setup-miniconda to remove this warning.",
-        );
-        removeDefaults = true;
-        continue;
-      }
-      core.info(`Adding channel '${channel}'`);
-      await condaCommand(
-        ["config", "--add", "channels", channel],
-        inputs,
-        options,
-      );
-    }
-
-    if (!channels.includes("defaults")) {
-      if (removeDefaults) {
-        core.info("Removing implicitly added 'defaults' channel");
-        const configsOutput = (await condaCommand(
-          ["config", "--show-sources", "--json"],
-          inputs,
-          options,
-          true,
-        )) as string;
-        const configs = JSON.parse(configsOutput) as Record<
-          string,
-          types.ICondaConfig
-        >;
-        for (const fileName in configs) {
-          const fileConfig = configs[fileName];
-          if (fileConfig?.channels?.includes("defaults")) {
-            await condaCommand(
-              [
-                "config",
-                "--remove",
-                "channels",
-                "defaults",
-                "--file",
-                fileName,
-              ],
-              inputs,
-              options,
-            );
-          }
-        }
-      } else {
-        core.warning(
-          "The 'defaults' channel might have been added implicitly. " +
-            "If this is intentional, add 'defaults' to the 'channels' list. " +
-            "Otherwise, consider setting 'conda-remove-defaults' to 'true'.",
-        );
-      }
-    }
-
-    // Package directories are also comma-separated, like channels
-    const pkgsDirs = utils.parsePkgsDirs(inputs.condaConfig.pkgs_dirs);
-    for (const pkgsDir of pkgsDirs) {
-      core.info(`Adding pkgs_dir '${pkgsDir}'`);
-      await condaCommand(
-        ["config", "--add", "pkgs_dirs", pkgsDir],
-        inputs,
-        options,
-      );
-    }
-  }
-  // auto_activate_base was renamed to auto_activate in 25.5.0
-  core.info(`auto_activate: ${inputs.condaConfig.auto_activate}`);
-  try {
-    // 25.5.0+
-    await condaCommand(
-      ["config", "--set", "auto_activate", inputs.condaConfig.auto_activate],
-      inputs,
-      options,
-    );
-  } catch {
-    try {
-      // <25.5.0
-      await condaCommand(
-        [
-          "config",
-          "--set",
-          "auto_activate_base",
-          inputs.condaConfig.auto_activate,
-        ],
-        inputs,
-        options,
-      );
-    } catch (err2) {
-      core.warning(err2 as Error);
-    }
-  }
-
-  // All other options are just passed as their string representations
   for (const [key, value] of configEntries) {
-    if (
-      value.trim().length === 0 ||
-      key === "channels" ||
-      key === "pkgs_dirs" ||
-      key === "auto_activate"
-    ) {
+    if (SKIP_KEYS.has(key) || value.trim().length === 0) {
       continue;
     }
-    core.info(`${key}: ${value}`);
-    try {
-      await condaCommand(["config", "--set", key, value], inputs, options);
-    } catch (err) {
-      core.warning(err as Error);
+    const coerced = coerceConfigValue(key, value);
+    config[key] = coerced;
+    core.info(`${key}: ${coerced}`);
+  }
+
+  // Strip 'defaults' from prefix-level condarc files too
+  if (removeDefaults && !userExplicitlyAddedDefaults) {
+    const basePath = condaBasePath(inputs, options);
+    const prefixCondarcPaths = [
+      path.join(basePath, ".condarc"),
+      path.join(basePath, "condarc"),
+    ];
+    for (const condarcPath of prefixCondarcPaths) {
+      if (!fs.existsSync(condarcPath)) continue;
+      try {
+        const prefixConfig = yaml.load(
+          fs.readFileSync(condarcPath, "utf8"),
+        ) as Record<string, unknown> | null;
+        if (
+          prefixConfig?.["channels"] &&
+          Array.isArray(prefixConfig["channels"]) &&
+          (prefixConfig["channels"] as string[]).includes("defaults")
+        ) {
+          prefixConfig["channels"] = (
+            prefixConfig["channels"] as string[]
+          ).filter((c: string) => c !== "defaults");
+          const updatedYaml = yaml.dump(prefixConfig, { lineWidth: -1 });
+          fs.writeFileSync(condarcPath, updatedYaml, "utf8");
+          core.info(
+            `Removed 'defaults' channel from prefix condarc at ${condarcPath}`,
+          );
+        }
+      } catch (err) {
+        core.warning(
+          `Failed to process prefix condarc at ${condarcPath}: ${err}`,
+        );
+      }
     }
   }
 
-  // Log all configuration information
-  await condaCommand(["config", "--show-sources"], inputs, options);
-  await condaCommand(["config", "--show"], inputs, options);
+  for (const key of Object.keys(config)) {
+    if (!KNOWN_CONDARC_KEYS.has(key)) {
+      core.warning(
+        `Unrecognized condarc key '${key}'. This may be a typo or a ` +
+          `key from a newer conda version. conda will ignore unknown keys.`,
+      );
+    }
+  }
+
+  const configYaml = yaml.dump(config, { lineWidth: -1 });
+  core.info(`Writing condarc to ${constants.CONDARC_PATH}:\n${configYaml}`);
+  fs.writeFileSync(constants.CONDARC_PATH, configYaml, "utf8");
+
+  if (core.isDebug()) {
+    await condaCommand(["config", "--show"], inputs, options);
+  }
 }
 
 /**
@@ -417,13 +505,12 @@ function isDefaultEnvironment(
   for (const condarcPath of condarcLocations) {
     if (!fs.existsSync(condarcPath)) continue;
     try {
-      const config = yaml.load(fs.readFileSync(condarcPath, "utf8")) as Record<
-        string,
-        unknown
-      > | null;
-      if (config?.["default_activation_env"]) {
+      const condarcConfig = yaml.load(
+        fs.readFileSync(condarcPath, "utf8"),
+      ) as Record<string, unknown> | null;
+      if (condarcConfig?.["default_activation_env"]) {
         const defaultEnv = _getFullEnvironmentPath(
-          config["default_activation_env"] as string,
+          condarcConfig["default_activation_env"] as string,
           inputs,
           options,
         );

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -75,17 +75,13 @@ async function setupMiniconda(inputs: types.IActionInputs): Promise<void> {
     outputs.setPathVariables(inputs, options),
   );
 
-  if (inputs.condaConfigFile) {
-    await core.group("Copying condarc file...", () => conda.copyConfig(inputs));
-  }
-
   // For potential 'channels' that may alter configuration
   options.envSpec = await core.group("Parsing environment...", () =>
     env.getEnvSpec(inputs),
   );
 
-  await core.group("Applying initial configuration...", () =>
-    conda.applyCondaConfiguration(inputs, options),
+  await core.group("Writing conda configuration...", () =>
+    conda.writeCondaConfig(inputs, options),
   );
 
   await core.group("Initializing conda shell integration...", () =>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,9 +11,9 @@ export default defineConfig({
         // Some branches are platform-specific (Windows/Linux paths
         // unreachable on macOS) so 100% is only achievable in CI
         // with a multi-OS matrix. These thresholds are the floor.
-        lines: 93,
+        lines: 94,
         branches: 88,
-        functions: 97,
+        functions: 98,
         statements: 93,
       },
     },


### PR DESCRIPTION
### Summary

Replace `applyCondaConfiguration()` (which spawned ~13 sequential `conda config` subprocesses per run, each paying 2-5s of Python startup) with `writeCondaConfig()` that builds the complete `.condarc` in memory and writes it once via `fs.writeFileSync`.

Remove `copyConfig()` -- user condarc files are now merged in memory rather than copied to `~/.condarc` before configuration runs.

Remove the redundant second `applyCondaConfiguration` call after base tool installation. Since the config is written to `.condarc` upfront, there is no need to re-apply it after installing tools into the base env.

### What changed

- `writeCondaConfig()` replaces both `applyCondaConfiguration()` and `copyConfig()`. It reads the existing installer-written `~/.condarc` as a base, merges the user condarc file (if provided), then applies all action inputs on top and writes once.
- Channel merging is now done in memory: user-specified channels come first, then any channels from the existing config that weren't already listed.
- `removeDefaults` now also strips `defaults` from prefix-level condarc files (`.condarc`/`condarc` inside the conda prefix), not just the user-level one.
- Boolean config values handle all YAML 1.1 literals (`on`/`off`/`y`/`n`/`1`/`0`) via a coercion helper.
- Uses `auto_activate_base` for backward compatibility with all conda versions. The rename to `auto_activate` and minimum version bump are deferred to a future v4 PR.
- `conda config --show` is now only run when `ACTIONS_STEP_DEBUG` is enabled, avoiding another subprocess in the default path.

### Limitations

The unrecognized-key warning uses a hardcoded `KNOWN_CONDARC_KEYS` set. If upstream conda adds new config keys, users who adopt them will see a spurious (but non-fatal) warning until the set is updated here. The warning text already notes this possibility. Conda config key additions are infrequent enough that periodic manual updates should be fine.

This is the core performance optimization extracted from #453.