### PR TITLE
ci(docs): skip Netlify preview for Dependabot PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,8 +52,8 @@ jobs:
         id: pages
         uses: actions/deploy-pages@v5
 
-      # Netlify preview — only on PRs
-      - if: github.event_name == 'pull_request'
+      # Netlify preview — only on PRs (excluding Dependabot, which has no secrets access)
+      - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         name: Deploy to Netlify
         id: netlify
         env:
@@ -69,7 +69,7 @@ jobs:
           DEPLOY_URL=$(jq -r '.deploy_url' deploy_output.json)
           echo "deploy_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
 
-      - if: github.event_name == 'pull_request'
+      - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,9 @@ jobs:
         uses: actions/deploy-pages@v5
 
       # Netlify preview — only on PRs (excluding Dependabot, which has no secrets access)
-      - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      - if:
+          github.event_name == 'pull_request' && github.actor !=
+          'dependabot[bot]'
         name: Deploy to Netlify
         id: netlify
         env:
@@ -69,7 +71,9 @@ jobs:
           DEPLOY_URL=$(jq -r '.deploy_url' deploy_output.json)
           echo "deploy_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
 
-      - if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+      - if:
+          github.event_name == 'pull_request' && github.actor !=
+          'dependabot[bot]'
         name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v3
         with:


### PR DESCRIPTION
Dependabot PRs run without access to repository secrets, so the Netlify deploy and sticky comment steps fail. Guard both steps on github.actor != 'dependabot[bot]'.

See also https://github.com/dependabot/dependabot-core/issues/3253