### PR TITLE
Fix MultipleKeysError when user condarc declares auto_activate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## [v4.0.1] (2026-04-24)
+
+### Fixes
+
+- Fix `MultipleKeysError` on conda 25.11+ when a user-supplied `condarc-file`
+  already declares `auto_activate`: now only one of `auto_activate` /
+  `auto_activate_base` is written to `.condarc`, preferring whichever key the
+  user's existing condarc uses.
+- Add `auto_activate` to the boolean coercion set so its value is serialized as
+  a YAML boolean when it is the chosen canonical key.
+- Add `local_repodata_ttl` to `KNOWN_CONDARC_KEYS` to silence a spurious
+  "Unrecognized condarc key" warning for a valid conda key.
+
+[v4.0.1]: https://github.com/conda-incubator/setup-miniconda/releases/tag/v4.0.1
+
 ## [v4.0.0] (2026-04-23)
 
 ### Breaking Changes

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -38107,6 +38107,7 @@ const BOOLEAN_CONDARC_KEYS = new Set([
     "add_anaconda_token",
     "add_pip_as_python_dependency",
     "allow_softlinks",
+    "auto_activate",
     "auto_activate_base",
     "auto_update_conda",
     "show_channel_urls",
@@ -38132,6 +38133,7 @@ const KNOWN_CONDARC_KEYS = new Set([
     "override_channels_enabled",
     "pkgs_dirs",
     "proxy_servers",
+    "local_repodata_ttl",
     "repodata_threads",
     "restore_free_channel",
     "safety_checks",
@@ -38247,12 +38249,18 @@ function writeCondaConfig(inputs, options) {
         for (const pkgsDir of mergedPkgsDirs) {
             info(`pkgs_dir: '${pkgsDir}'`);
         }
-        // --- auto_activate_base ---
-        // Write auto_activate_base for broad compatibility. Conda 25.5.0+ also
-        // accepts auto_activate as the canonical name, but older versions only
-        // recognize auto_activate_base.
-        config["auto_activate_base"] = coerceConfigValue("auto_activate_base", inputs.condaConfig.auto_activate);
-        info(`auto_activate_base: ${config["auto_activate_base"]}`);
+        // --- auto_activate / auto_activate_base ---
+        // conda 25.11+ raises MultipleKeysError if both aliases coexist in the same
+        // .condarc. Prefer whichever key the user already set (via condarc-file or
+        // an existing .condarc); fall back to auto_activate_base for compatibility
+        // with conda versions older than 25.5.0.
+        const autoActivateKey = "auto_activate" in config && !("auto_activate_base" in config)
+            ? "auto_activate"
+            : "auto_activate_base";
+        delete config["auto_activate"];
+        delete config["auto_activate_base"];
+        config[autoActivateKey] = coerceConfigValue(autoActivateKey, inputs.condaConfig.auto_activate);
+        info(`${autoActivateKey}: ${config[autoActivateKey]}`);
         // --- All other config entries ---
         const SKIP_KEYS = new Set([
             "channels",

--- a/src/__tests__/conda.test.ts
+++ b/src/__tests__/conda.test.ts
@@ -261,7 +261,7 @@ describe("writeCondaConfig", () => {
     expect(config["pkgs_dirs"]).toContain("/mock/pkgs");
   });
 
-  it("sets auto_activate_base from input", async () => {
+  it("sets auto_activate_base from input when no alias is in existing condarc", async () => {
     const { writeCondaConfig } = await import("../conda");
     const inputs = makeInputs({ channels: "conda-forge" });
 
@@ -271,6 +271,38 @@ describe("writeCondaConfig", () => {
 
     const config = getWrittenConfig();
     expect(config["auto_activate_base"]).toBe(false);
+    expect(config).not.toHaveProperty("auto_activate");
+  });
+
+  it("prefers auto_activate key when user condarc already contains it (avoids MultipleKeysError on conda 25.11+)", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "conda-forge" });
+
+    // Simulate a user condarc that uses the new canonical key name
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ auto_activate: true }),
+    );
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config).not.toHaveProperty("auto_activate_base");
+    expect(config["auto_activate"]).toBe(false);
+  });
+
+  it("uses auto_activate_base when user condarc has auto_activate_base (avoids MultipleKeysError on conda 25.11+)", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ channels: "conda-forge" });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ auto_activate_base: false }),
+    );
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["auto_activate_base"]).toBe(false);
+    expect(config).not.toHaveProperty("auto_activate");
   });
 
   it("sets notify_outdated_conda to false", async () => {

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -197,6 +197,7 @@ const BOOLEAN_CONDARC_KEYS = new Set([
   "add_anaconda_token",
   "add_pip_as_python_dependency",
   "allow_softlinks",
+  "auto_activate",
   "auto_activate_base",
   "auto_update_conda",
   "show_channel_urls",
@@ -223,6 +224,7 @@ const KNOWN_CONDARC_KEYS = new Set([
   "override_channels_enabled",
   "pkgs_dirs",
   "proxy_servers",
+  "local_repodata_ttl",
   "repodata_threads",
   "restore_free_channel",
   "safety_checks",
@@ -363,15 +365,22 @@ export async function writeCondaConfig(
     core.info(`pkgs_dir: '${pkgsDir}'`);
   }
 
-  // --- auto_activate_base ---
-  // Write auto_activate_base for broad compatibility. Conda 25.5.0+ also
-  // accepts auto_activate as the canonical name, but older versions only
-  // recognize auto_activate_base.
-  config["auto_activate_base"] = coerceConfigValue(
-    "auto_activate_base",
+  // --- auto_activate / auto_activate_base ---
+  // conda 25.11+ raises MultipleKeysError if both aliases coexist in the same
+  // .condarc. Prefer whichever key the user already set (via condarc-file or
+  // an existing .condarc); fall back to auto_activate_base for compatibility
+  // with conda versions older than 25.5.0.
+  const autoActivateKey =
+    "auto_activate" in config && !("auto_activate_base" in config)
+      ? "auto_activate"
+      : "auto_activate_base";
+  delete config["auto_activate"];
+  delete config["auto_activate_base"];
+  config[autoActivateKey] = coerceConfigValue(
+    autoActivateKey,
     inputs.condaConfig.auto_activate,
   );
-  core.info(`auto_activate_base: ${config["auto_activate_base"]}`);
+  core.info(`${autoActivateKey}: ${config[autoActivateKey]}`);
 
   // --- All other config entries ---
   const SKIP_KEYS = new Set([


### PR DESCRIPTION
### Summary

conda 25.11+ raises a hard error (`MultipleKeysError`) if both `auto_activate` and `auto_activate_base` appear in the same `.condarc`. `writeCondaConfig` was merging the user's `condarc-file` first (which may already declare `auto_activate`), then unconditionally writing `auto_activate_base` on top. Both keys ended up in the final `.condarc` and conda 25.11+ refused to start.

Observed in conda/conda-build [run 24878641904](https://github.com/conda/conda-build/actions/runs/24878641904/job/72841275348?pr=5957): their `.github/condarc` sets `auto_activate: True`, which triggered the bug on every job.

### What changed

- `writeCondaConfig` now detects which alias is already present in the merged config and writes only that one. Defaults to `auto_activate_base` when neither is set (backward compat with conda < 25.5.0). The other alias is explicitly deleted before writing.
- `auto_activate` added to `BOOLEAN_CONDARC_KEYS` so it gets coerced to a YAML boolean when used as the canonical key (same as `auto_activate_base`).
- `local_repodata_ttl` added to `KNOWN_CONDARC_KEYS` -- it is a valid conda key that was missing from the allow-list, causing a spurious warning.
- Regression tests added for all three cases: default (neither alias present), user condarc has `auto_activate`, user condarc has `auto_activate_base`.