### PR TITLE
Suppress 'nodefaults' warning when conda-remove-defaults is set

### DIFF
--- a/src/conda.ts
+++ b/src/conda.ts
@@ -313,12 +313,14 @@ export async function writeCondaConfig(
   const filteredChannels: string[] = [];
   for (const channel of channels) {
     if (channel === "nodefaults") {
-      core.warning(
-        "'nodefaults' channel detected: will remove 'defaults' if added implicitly. " +
-          "In the future, 'nodefaults' to remove 'defaults' won't be supported. " +
-          "Please set 'conda-remove-defaults' = 'true' in setup-miniconda to remove this warning.",
-      );
-      removeDefaults = true;
+      if (!removeDefaults) {
+        core.warning(
+          "'nodefaults' channel detected: will remove 'defaults' if added implicitly. " +
+            "In the future, 'nodefaults' to remove 'defaults' won't be supported. " +
+            "Please set 'conda-remove-defaults' = 'true' in setup-miniconda to remove this warning.",
+        );
+        removeDefaults = true;
+      }
       continue;
     }
     filteredChannels.push(channel);


### PR DESCRIPTION
Currently, if it detects a 'nodefaults' channel then it emits the warning:

> 'nodefaults' channel detected: will remove 'defaults' if added implicitly.  
> In the future, 'nodefaults' to remove 'defaults' won't be supported.
> Please set 'conda-remove-defaults' = 'true' in setup-miniconda to remove this warning.

But even if the user does what asked, it does not remove the warning, which can make the user
think they have not done it correctly.

With this change, if they _have_ set conda-remove-defaults' = 'true' correctly, then the warning is removed (as promised).

I considered just rewording the warning, but since `nodefaults` is still an an officially documented method to suppress the defaults channel in Anaconda, I think we should just remove the warning if users do both 'conda-remove-defaults' _and_ include `nodefaults`.