### PR TITLE
ci: harden GitHub Actions workflows and add zizmor scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,18 @@ updates:
     target-branch: "main"
     schedule:
       interval: "weekly"
+    cooldown:
+      # Let new releases settle before opening update PRs, giving a
+      # compromised release time to be caught. Security updates are exempt
+      # from cooldown and still open immediately.
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/"
     target-branch: "main"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     versioning-strategy: "increase"
     allow:
       - dependency-type: "production"

--- a/.github/workflows/caching-envs-example.yml
+++ b/.github/workflows/caching-envs-example.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   caching-example:
     name: Caching-Env
@@ -34,7 +37,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Miniforge
         uses: ./
@@ -49,7 +54,7 @@ jobs:
         shell: bash
 
       - name: Cache Conda env
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.CONDA }}/envs
           key:

--- a/.github/workflows/caching-example.yml
+++ b/.github/workflows/caching-example.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   caching-ubuntu:
     # prevent cronjobs from running on forks
@@ -28,9 +31,11 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Cache conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           # Increase this value to reset cache if etc/example-environment.yml has not changed
           CACHE_NUMBER: 3
@@ -56,9 +61,11 @@ jobs:
     runs-on: "windows-latest"
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Cache conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           # Increase this value to reset cache if etc/example-environment.yml has not changed
           CACHE_NUMBER: 3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,8 +35,10 @@ jobs:
       url:
         ${{ steps.pages.outputs.page_url || steps.netlify.outputs.deploy_url }}
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
       - run: |
@@ -45,12 +47,12 @@ jobs:
 
       # GitHub Pages — only on push to main
       - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/api
       - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: pages
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
       # Netlify preview — only on PRs (excluding Dependabot, which has no secrets access)
       - if:
@@ -75,7 +77,7 @@ jobs:
           github.event_name == 'pull_request' && github.actor !=
           'dependabot[bot]'
         name: Comment on PR
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3.0.3
         with:
           header: netlify-preview
           message: |

--- a/.github/workflows/example-1.yml
+++ b/.github/workflows/example-1.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-1:
     # prevent cronjobs from running on forks
@@ -33,7 +36,9 @@ jobs:
         python-version: ["3.8", "3.11"]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           auto-update-conda: true

--- a/.github/workflows/example-10.yml
+++ b/.github/workflows/example-10.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-10-miniforge:
     # prevent cronjobs from running on forks
@@ -34,7 +37,9 @@ jobs:
       matrix:
         os: ["ubuntu", "macos", "windows"]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         id: setup-miniconda
         with:
@@ -61,7 +66,9 @@ jobs:
       matrix:
         os: ["ubuntu", "macos", "windows"]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         id: setup-miniconda
         with:

--- a/.github/workflows/example-11.yml
+++ b/.github/workflows/example-11.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-11:
     # prevent cronjobs from running on forks
@@ -36,7 +39,9 @@ jobs:
         miniconda-version: ["latest"]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         id: setup-miniconda
         continue-on-error: true

--- a/.github/workflows/example-12.yml
+++ b/.github/workflows/example-12.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-12:
     # prevent cronjobs from running on forks
@@ -32,7 +35,9 @@ jobs:
         solver: ["classic", "libmamba"]
         os: ["ubuntu-latest", "windows-latest"]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         id: setup-miniconda
         continue-on-error: true

--- a/.github/workflows/example-13.yml
+++ b/.github/workflows/example-13.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-13:
     # prevent cronjobs from running on forks
@@ -36,7 +39,9 @@ jobs:
           - os: macos-15-intel
             variant: empty-with
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         if: matrix.variant == 'Miniforge3'
         id: setup-miniforge

--- a/.github/workflows/example-14.yml
+++ b/.github/workflows/example-14.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-14:
     # prevent cronjobs from running on forks
@@ -41,7 +44,9 @@ jobs:
           ]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         id: setup-miniconda
         continue-on-error: true

--- a/.github/workflows/example-15.yml
+++ b/.github/workflows/example-15.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-15:
     # prevent cronjobs from running on forks
@@ -32,7 +35,9 @@ jobs:
         os: ["ubuntu-24.04-arm"]
         variant: ["Miniforge3", "Miniconda", "no-variant", "empty-with"]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         if: matrix.variant == 'Miniforge3'
         id: setup-miniforge

--- a/.github/workflows/example-16.yml
+++ b/.github/workflows/example-16.yml
@@ -14,6 +14,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-16-build:
     # prevent cronjobs from running on forks
@@ -30,7 +33,7 @@ jobs:
         add-activation-env: ["false", "true"]
         os: ["ubuntu", "windows"]
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -77,7 +80,7 @@ jobs:
         add-activation-env: ["false", "true"]
         os: ["ubuntu", "windows"]
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/example-17.yml
+++ b/.github/workflows/example-17.yml
@@ -15,6 +15,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-17:
     # prevent cronjobs from running on forks
@@ -29,7 +32,9 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Save profile checksums (Unix)
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/example-2.yml
+++ b/.github/workflows/example-2.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-2-linux:
     # prevent cronjobs from running on forks
@@ -28,7 +31,9 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           miniconda-version: "latest"
@@ -51,7 +56,9 @@ jobs:
     runs-on: "macos-latest"
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           miniconda-version: "latest"
@@ -80,7 +87,9 @@ jobs:
     runs-on: "windows-latest"
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           auto-update-conda: true

--- a/.github/workflows/example-3.yml
+++ b/.github/workflows/example-3.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-3:
     # prevent cronjobs from running on forks
@@ -31,7 +34,9 @@ jobs:
         shell: bash -el {0}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           activate-environment: anaconda-client-env
@@ -59,7 +64,9 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           activate-environment: test-python-pinned
@@ -80,7 +87,9 @@ jobs:
         shell: bash -el {0}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           activate-environment: anaconda-client-env

--- a/.github/workflows/example-4.yml
+++ b/.github/workflows/example-4.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-4:
     # prevent cronjobs from running on forks
@@ -31,7 +34,9 @@ jobs:
         shell: bash -el {0}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           activate-environment: foo

--- a/.github/workflows/example-5.yml
+++ b/.github/workflows/example-5.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-5-linux:
     # prevent cronjobs from running on forks
@@ -33,7 +36,9 @@ jobs:
         shell: bash -el {0}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: |
           curl -L ${MINIFORGE_URL} > /tmp/some-built-installer-${{ github.run_number }}.sh
       - uses: ./
@@ -58,7 +63,9 @@ jobs:
         shell: bash -el {0}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           installer-url: https://github.com/conda-forge/miniforge/releases/download/4.11.0-0/Miniforge-pypy3-4.11.0-0-MacOSX-x86_64.sh?foo=bar&baz
@@ -77,7 +84,9 @@ jobs:
     runs-on: "windows-latest"
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           installer-url:

--- a/.github/workflows/example-6.yml
+++ b/.github/workflows/example-6.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-6:
     # prevent cronjobs from running on forks
@@ -58,7 +61,9 @@ jobs:
         shell: bash -el {0}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           miniforge-variant: Miniforge3

--- a/.github/workflows/example-7.yml
+++ b/.github/workflows/example-7.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-7:
     # prevent cronjobs from running on forks
@@ -35,7 +38,9 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           auto-update-conda: false

--- a/.github/workflows/example-8.yml
+++ b/.github/workflows/example-8.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-8:
     # prevent cronjobs from running on forks
@@ -33,7 +36,9 @@ jobs:
         python-version: ["3.8", "3.11"]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         id: setup-miniconda
         continue-on-error: true

--- a/.github/workflows/example-9.yml
+++ b/.github/workflows/example-9.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   example-9:
     # prevent cronjobs from running on forks
@@ -33,7 +36,9 @@ jobs:
         python-version: ["3.8", "3.11"]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         id: setup-miniconda
         continue-on-error: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,14 +15,19 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
     runs-on: "ubuntu-latest"
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
       - run: |
@@ -35,8 +40,10 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
       - name: Build

--- a/.github/workflows/regression-checks.yml
+++ b/.github/workflows/regression-checks.yml
@@ -18,6 +18,9 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   issue-114:
     # prevent cronjobs from running on forks
@@ -36,7 +39,9 @@ jobs:
         python-version: ["3.9"]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         id: setup-miniconda
         with:
@@ -58,7 +63,9 @@ jobs:
     runs-on: windows-latest
     name: Issue 324
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           activate-environment: test-env
@@ -97,7 +104,9 @@ jobs:
         python-version: ["3.12"]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         id: setup-miniconda
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,18 +29,20 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
       - run: npm ci
       - run: npm run test:coverage
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: coverage/coverage-final.json
           flags: ${{ matrix.os }}
           fail_ci_if_error: false
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: coverage-${{ matrix.os }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,7 +3,7 @@ name: "Zizmor"
 on:
   pull_request:
     branches:
-      - "*"
+      - "**"
   push:
     branches:
       - "develop"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,32 @@
+name: "Zizmor"
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "develop"
+      - "main"
+      - "master"
+
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Analyze workflows
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write # upload SARIF results to code scanning
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,14 @@
+# Configuration for zizmor — GitHub Actions static analysis.
+# https://docs.zizmor.sh/configuration/
+rules:
+  misfeature:
+    ignore:
+      # setup-miniconda intentionally supports and demonstrates conda activation
+      # in the Windows `cmd` shell — a core feature of the action. The
+      # `shell: cmd /C CALL {0}` steps below are deliberate, so zizmor's
+      # suggestion to switch to bash/pwsh is a false positive here.
+      - example-2.yml
+      - example-6.yml
+      - example-16.yml
+      - example-17.yml
+      - regression-checks.yml

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 npm run format && npm run check && npm run build && npm run docs || exit 1
 
 # Lint GitHub Actions workflows with zizmor when any workflow/config is staged.
-if git diff --cached --name-only --diff-filter=ACM | grep -qE '^\.github/(workflows/|zizmor\.yml)'; then
+if git diff --cached --name-only --diff-filter=ACM | grep -qE '^\.github/(workflows/|zizmor\.yml$)'; then
   if command -v uvx >/dev/null 2>&1; then
     uvx zizmor@1.25.2 --offline .github/workflows/ || exit 1
   elif command -v zizmor >/dev/null 2>&1; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,12 @@
-npm run format && npm run check && npm run build && npm run docs
+npm run format && npm run check && npm run build && npm run docs || exit 1
+
+# Lint GitHub Actions workflows with zizmor when any workflow/config is staged.
+if git diff --cached --name-only --diff-filter=ACM | grep -qE '^\.github/(workflows/|zizmor\.yml)'; then
+  if command -v uvx >/dev/null 2>&1; then
+    uvx zizmor@1.25.2 --offline .github/workflows/ || exit 1
+  elif command -v zizmor >/dev/null 2>&1; then
+    zizmor --offline .github/workflows/ || exit 1
+  else
+    echo "zizmor not installed (install 'uv' or 'zizmor') to lint workflows — skipping" >&2
+  fi
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,12 +1,1 @@
 npm run format && npm run check && npm run build && npm run docs || exit 1
-
-# Lint GitHub Actions workflows with zizmor when any workflow/config is staged.
-if git diff --cached --name-only --diff-filter=ACM | grep -qE '^\.github/(workflows/|zizmor\.yml$)'; then
-  if command -v uvx >/dev/null 2>&1; then
-    uvx zizmor@1.25.2 --offline .github/workflows/ || exit 1
-  elif command -v zizmor >/dev/null 2>&1; then
-    zizmor --offline .github/workflows/ || exit 1
-  else
-    echo "zizmor not installed (install 'uv' or 'zizmor') to lint workflows — skipping" >&2
-  fi
-fi


### PR DESCRIPTION
## Summary

Hardens every GitHub Actions workflow against the [`actions/missing-workflow-permissions`](https://github.com/conda-incubator/setup-miniconda/security/code-scanning) code-scanning alerts and supply-chain risks flagged by [zizmor](https://docs.zizmor.sh), then wires zizmor into CI so regressions are caught automatically.

## What changed

| Hardening | Scope |
|---|---|
| Pin every action `uses:` to a full commit SHA (with `# vX.Y.Z` comments for Dependabot) | 52 references, **0 unpinned** |
| Add least-privilege top-level `permissions: { contents: read }` | 21 workflows that lacked one |
| Set `persist-credentials: false` on `actions/checkout` | 33 steps |

## New tooling

- **`.github/workflows/zizmor.yml`** — runs zizmor on every PR and push to `develop`/`main`/`master`, uploading SARIF to code scanning. Top-level `permissions: {}` with only `contents: read` + `security-events: write` granted to the job.
- **`.github/zizmor.yml`** — auto-discovered config. Suppresses the `misfeature` finding on the 5 files that intentionally demonstrate conda activation in the Windows `cmd` shell (`shell: cmd /C CALL {0}`), a core feature of this action.
- **`.husky/pre-commit`** — hardened to fail the commit on any check error (`|| exit 1`). A local zizmor step was dropped during review, since pinning the zizmor version in the hook would drift from CI (Dependabot can't update it). CI (`zizmor.yml`) enforces zizmor on every PR and push, and migrating local hooks to [`prek`](https://github.com/j178/prek) for centrally-managed versions is tracked in #532.

## Verification

- `zizmor .github/workflows/` → **No findings to report. Good job! (8 ignored, 14 suppressed)** — exit 0
- All 33 `actions/missing-workflow-permissions` code-scanning alerts resolved
- Prettier-clean (`npm run format` / `npm run check` pass)

> [!NOTE]
> SHA pins are kept current by Dependabot's `github_actions` ecosystem updates, which preserve the trailing version comments.
