### PR TITLE
fix: suppress harmless auto_activate_base alias deprecation warning

### DIFF
--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -33644,6 +33644,9 @@ const IGNORED_WARNINGS = (/* unused pure expression or super */ null && ([
     `cygpath is not available, fallback to manual path conversion`,
     // Harmless warning for older Conda versions use auto_activate instead of auto_activate_base
     `'auto_activate': unknown parameter`,
+    // We write `auto_activate_base` by default for compatibility with conda
+    // <25.5.0; conda >=25.5.0 treats it as a deprecated alias and emits this.
+    `Key auto_activate_base is an alias of auto_activate`,
 ]));
 /**
  * Warnings that should be errors.

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -33685,6 +33685,9 @@ const IGNORED_WARNINGS = [
     `cygpath is not available, fallback to manual path conversion`,
     // Harmless warning for older Conda versions use auto_activate instead of auto_activate_base
     `'auto_activate': unknown parameter`,
+    // We write `auto_activate_base` by default for compatibility with conda
+    // <25.5.0; conda >=25.5.0 treats it as a deprecated alias and emits this.
+    `Key auto_activate_base is an alias of auto_activate`,
 ];
 /**
  * Warnings that should be errors.

--- a/src/__tests__/constants.test.ts
+++ b/src/__tests__/constants.test.ts
@@ -312,6 +312,14 @@ describe("IGNORED_WARNINGS", () => {
   it("includes cygpath fallback warning", () => {
     expect(IGNORED_WARNINGS.some((w) => w.includes("cygpath"))).toBe(true);
   });
+
+  it("includes the auto_activate_base alias warning", () => {
+    expect(
+      IGNORED_WARNINGS.some((w) =>
+        w.includes("Key auto_activate_base is an alias of auto_activate"),
+      ),
+    ).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -101,6 +101,9 @@ export const IGNORED_WARNINGS = [
   `cygpath is not available, fallback to manual path conversion`,
   // Harmless warning for older Conda versions use auto_activate instead of auto_activate_base
   `'auto_activate': unknown parameter`,
+  // We write `auto_activate_base` by default for compatibility with conda
+  // <25.5.0; conda >=25.5.0 treats it as a deprecated alias and emits this.
+  `Key auto_activate_base is an alias of auto_activate`,
 ];
 
 /**


### PR DESCRIPTION
## Summary

conda >= 25.5.0 treats `auto_activate_base` as a deprecated alias of `auto_activate` and emits:

> WARNING conda.cli.main_config:_set_key(451): Key auto_activate_base is an alias of auto_activate; setting value with latter

We intentionally write `auto_activate_base` by default for compatibility with conda < 25.5.0 (which does not know `auto_activate`), so the warning is harmless but noisy. This adds the stable substring to `IGNORED_WARNINGS` so it is filtered, mirroring the existing `'auto_activate': unknown parameter` suppression for the inverse (old-conda) case.

Fully dropping the `auto_activate_base` key is deferred to v5 (#510).

## Changes

- `src/constants.ts` — add `Key auto_activate_base is an alias of auto_activate` to `IGNORED_WARNINGS`
- `src/__tests__/constants.test.ts` — assert the new entry is present
- `dist/` — rebuilt

## Test plan

- [x] `npm test` (415 passing)
- [x] `npm run check` (prettier + eslint clean)

Closes #430