### PR TITLE
Centralize test action-input fixtures in a shared helper

### DIFF
--- a/src/__tests__/base-tools/index.test.ts
+++ b/src/__tests__/base-tools/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 
 // Mock @actions/core
 const mockInfo = vi.fn();
@@ -53,44 +54,9 @@ vi.mock("../../conda", async () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "conda-forge",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
+  return makeActionInputs({
     ...overrides,
+    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
   });
 }
 

--- a/src/__tests__/base-tools/index.test.ts
+++ b/src/__tests__/base-tools/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
-import { makeActionInputs } from "../helpers";
+import { makeCondaForgeActionInputs } from "../helpers";
 
 // Mock @actions/core
 const mockInfo = vi.fn();
@@ -54,10 +54,7 @@ vi.mock("../../conda", async () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return makeActionInputs({
-    ...overrides,
-    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
-  });
+  return makeCondaForgeActionInputs(overrides);
 }
 
 function makeOptions(

--- a/src/__tests__/base-tools/update-conda-build.test.ts
+++ b/src/__tests__/base-tools/update-conda-build.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 
 // Mock @actions/core
 vi.mock("@actions/core", () => ({
@@ -22,44 +23,9 @@ vi.mock("../../utils", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "conda-forge",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
+  return makeActionInputs({
     ...overrides,
+    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
   });
 }
 

--- a/src/__tests__/base-tools/update-conda-build.test.ts
+++ b/src/__tests__/base-tools/update-conda-build.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
-import { makeActionInputs } from "../helpers";
+import { makeCondaForgeActionInputs } from "../helpers";
 
 // Mock @actions/core
 vi.mock("@actions/core", () => ({
@@ -23,10 +23,7 @@ vi.mock("../../utils", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return makeActionInputs({
-    ...overrides,
-    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
-  });
+  return makeCondaForgeActionInputs(overrides);
 }
 
 function makeOptions(

--- a/src/__tests__/base-tools/update-conda.test.ts
+++ b/src/__tests__/base-tools/update-conda.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 
 // Mock @actions/core
 vi.mock("@actions/core", () => ({
@@ -22,44 +23,9 @@ vi.mock("../../utils", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "conda-forge",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
+  return makeActionInputs({
     ...overrides,
+    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
   });
 }
 

--- a/src/__tests__/base-tools/update-conda.test.ts
+++ b/src/__tests__/base-tools/update-conda.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
-import { makeActionInputs } from "../helpers";
+import { makeCondaForgeActionInputs } from "../helpers";
 
 // Mock @actions/core
 vi.mock("@actions/core", () => ({
@@ -23,10 +23,7 @@ vi.mock("../../utils", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return makeActionInputs({
-    ...overrides,
-    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
-  });
+  return makeCondaForgeActionInputs(overrides);
 }
 
 function makeOptions(

--- a/src/__tests__/base-tools/update-mamba.test.ts
+++ b/src/__tests__/base-tools/update-mamba.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 
 // Mock @actions/core
 const mockInfo = vi.fn();
@@ -54,44 +55,9 @@ vi.mock("../../utils", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "conda-forge",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
+  return makeActionInputs({
     ...overrides,
+    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
   });
 }
 

--- a/src/__tests__/base-tools/update-mamba.test.ts
+++ b/src/__tests__/base-tools/update-mamba.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
-import { makeActionInputs } from "../helpers";
+import { makeCondaForgeActionInputs } from "../helpers";
 
 // Mock @actions/core
 const mockInfo = vi.fn();
@@ -55,10 +55,7 @@ vi.mock("../../utils", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return makeActionInputs({
-    ...overrides,
-    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
-  });
+  return makeCondaForgeActionInputs(overrides);
 }
 
 function makeOptions(

--- a/src/__tests__/base-tools/update-python.test.ts
+++ b/src/__tests__/base-tools/update-python.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 
 // Mock @actions/core
 vi.mock("@actions/core", () => ({
@@ -25,44 +26,9 @@ vi.mock("../../utils", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "conda-forge",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
+  return makeActionInputs({
     ...overrides,
+    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
   });
 }
 

--- a/src/__tests__/base-tools/update-python.test.ts
+++ b/src/__tests__/base-tools/update-python.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
-import { makeActionInputs } from "../helpers";
+import { makeCondaForgeActionInputs } from "../helpers";
 
 // Mock @actions/core
 vi.mock("@actions/core", () => ({
@@ -26,10 +26,7 @@ vi.mock("../../utils", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return makeActionInputs({
-    ...overrides,
-    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
-  });
+  return makeCondaForgeActionInputs(overrides);
 }
 
 function makeOptions(

--- a/src/__tests__/conda.test.ts
+++ b/src/__tests__/conda.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as yaml from "js-yaml";
 
 import type * as types from "../types";
+import { makeActionInputs } from "./helpers";
 
 // Mock @actions/core
 vi.mock("@actions/core", () => ({
@@ -78,43 +79,11 @@ function makeInputs(
     removeProfiles: string;
   }> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
+  return makeActionInputs({
     condaRemoveDefaults: overrides.condaRemoveDefaults ?? "false",
-    pythonVersion: "",
     removeProfiles: overrides.removeProfiles ?? "true",
     runInit: overrides.runInit ?? "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: overrides.channels ?? "conda-forge",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
+    condaConfig: { channels: overrides.channels ?? "conda-forge" },
   });
 }
 

--- a/src/__tests__/conda.test.ts
+++ b/src/__tests__/conda.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as yaml from "js-yaml";
 
 import type * as types from "../types";
-import { makeActionInputs } from "./helpers";
+import { makeCondaForgeActionInputs } from "./helpers";
 
 // Mock @actions/core
 vi.mock("@actions/core", () => ({
@@ -79,11 +79,12 @@ function makeInputs(
     removeProfiles: string;
   }> = {},
 ): types.IActionInputs {
-  return makeActionInputs({
+  return makeCondaForgeActionInputs({
     condaRemoveDefaults: overrides.condaRemoveDefaults ?? "false",
     removeProfiles: overrides.removeProfiles ?? "true",
     runInit: overrides.runInit ?? "true",
-    condaConfig: { channels: overrides.channels ?? "conda-forge" },
+    condaConfig:
+      overrides.channels === undefined ? {} : { channels: overrides.channels },
   });
 }
 

--- a/src/__tests__/delete.test.ts
+++ b/src/__tests__/delete.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { makeActionInputs } from "./helpers";
+
 // ── Mocks (hoisted before any imports) ──────────────────────────────────
 
 const mockExistsSync = vi.fn();
@@ -53,44 +55,7 @@ vi.mock("../utils", () => ({
 // ── Helpers ─────────────────────────────────────────────────────────────
 
 function makeInputs(pkgsDirs: string = "") {
-  return {
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: {
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: pkgsDirs,
-    },
-  };
+  return makeActionInputs({ condaConfig: { pkgs_dirs: pkgsDirs } });
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────

--- a/src/__tests__/env/explicit.test.ts
+++ b/src/__tests__/env/explicit.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 import { ensureExplicit } from "../../env/explicit";
 
 // Mock @actions/core
@@ -29,43 +30,11 @@ function makeInputs(
     activateEnvironment: string;
   }> = {},
 ): types.IActionInputs {
-  return Object.freeze({
+  return makeActionInputs({
     activateEnvironment: overrides.activateEnvironment ?? "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
     environmentFile: overrides.environmentFile ?? "environment.lock",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
     pythonVersion: overrides.pythonVersion ?? "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "conda-forge",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
+    condaConfig: { channels: "conda-forge" },
   });
 }
 

--- a/src/__tests__/env/explicit.test.ts
+++ b/src/__tests__/env/explicit.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
-import { makeActionInputs } from "../helpers";
+import { makeCondaForgeActionInputs } from "../helpers";
 import { ensureExplicit } from "../../env/explicit";
 
 // Mock @actions/core
@@ -30,11 +30,10 @@ function makeInputs(
     activateEnvironment: string;
   }> = {},
 ): types.IActionInputs {
-  return makeActionInputs({
+  return makeCondaForgeActionInputs({
     activateEnvironment: overrides.activateEnvironment ?? "test",
     environmentFile: overrides.environmentFile ?? "environment.lock",
     pythonVersion: overrides.pythonVersion ?? "",
-    condaConfig: { channels: "conda-forge" },
   });
 }
 

--- a/src/__tests__/env/index.test.ts
+++ b/src/__tests__/env/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 
 // Mock @actions/core
 const mockInfo = vi.fn();
@@ -61,43 +62,11 @@ function makeInputs(
     pythonVersion: string;
   }> = {},
 ): types.IActionInputs {
-  return Object.freeze({
+  return makeActionInputs({
     activateEnvironment: overrides.activateEnvironment ?? "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
     environmentFile: overrides.environmentFile ?? "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
     pythonVersion: overrides.pythonVersion ?? "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "conda-forge",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
+    condaConfig: { channels: "conda-forge" },
   });
 }
 

--- a/src/__tests__/env/index.test.ts
+++ b/src/__tests__/env/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
-import { makeActionInputs } from "../helpers";
+import { makeCondaForgeActionInputs } from "../helpers";
 
 // Mock @actions/core
 const mockInfo = vi.fn();
@@ -62,11 +62,10 @@ function makeInputs(
     pythonVersion: string;
   }> = {},
 ): types.IActionInputs {
-  return makeActionInputs({
+  return makeCondaForgeActionInputs({
     activateEnvironment: overrides.activateEnvironment ?? "test",
     environmentFile: overrides.environmentFile ?? "",
     pythonVersion: overrides.pythonVersion ?? "",
-    condaConfig: { channels: "conda-forge" },
   });
 }
 

--- a/src/__tests__/env/simple.test.ts
+++ b/src/__tests__/env/simple.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 import { ensureSimple } from "../../env/simple";
 
 // Mock @actions/core
@@ -32,43 +33,10 @@ function makeInputs(
     activateEnvironment: string;
   }> = {},
 ): types.IActionInputs {
-  return Object.freeze({
+  return makeActionInputs({
     activateEnvironment: overrides.activateEnvironment ?? "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
     pythonVersion: overrides.pythonVersion ?? "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "conda-forge",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
+    condaConfig: { channels: "conda-forge" },
   });
 }
 

--- a/src/__tests__/env/simple.test.ts
+++ b/src/__tests__/env/simple.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
-import { makeActionInputs } from "../helpers";
+import { makeCondaForgeActionInputs } from "../helpers";
 import { ensureSimple } from "../../env/simple";
 
 // Mock @actions/core
@@ -33,10 +33,9 @@ function makeInputs(
     activateEnvironment: string;
   }> = {},
 ): types.IActionInputs {
-  return makeActionInputs({
+  return makeCondaForgeActionInputs({
     activateEnvironment: overrides.activateEnvironment ?? "test",
     pythonVersion: overrides.pythonVersion ?? "",
-    condaConfig: { channels: "conda-forge" },
   });
 }
 

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -7,11 +7,11 @@
  * instead of every test module that builds inputs.
  */
 
-import * as types from "../types";
+import type * as types from "../types";
 
 /**
  * Overrides accepted by {@link makeActionInputs}: any top-level input field,
- * plus a *partial* `condaConfig` that is deep-merged onto the defaults.
+ * plus a *partial* `condaConfig` that is shallow-merged onto the defaults.
  */
 export type ActionInputsOverrides = Partial<
   Omit<types.IActionInputs, "condaConfig">
@@ -28,7 +28,7 @@ export type ActionInputsOverrides = Partial<
 export function makeCondaConfig(
   overrides: Partial<types.ICondaConfig> = {},
 ): types.ICondaConfig {
-  return {
+  return Object.freeze({
     add_anaconda_token: "",
     add_pip_as_python_dependency: "",
     allow_softlinks: "",
@@ -45,13 +45,13 @@ export function makeCondaConfig(
     solver: "",
     pkgs_dirs: "",
     ...overrides,
-  };
+  });
 }
 
 /**
  * Build a complete `IActionInputs` for tests with sensible defaults.
  *
- * Top-level fields can be overridden directly; `condaConfig` is deep-merged
+ * Top-level fields can be overridden directly; `condaConfig` is shallow-merged
  * onto the defaults via {@link makeCondaConfig}.
  *
  * @param overrides - Input fields to override on top of the defaults.
@@ -61,7 +61,7 @@ export function makeActionInputs(
   overrides: ActionInputsOverrides = {},
 ): types.IActionInputs {
   const { condaConfig: condaConfigOverrides, ...rest } = overrides;
-  return {
+  return Object.freeze({
     activateEnvironment: "test",
     architecture: "x64",
     condaBuildVersion: "",
@@ -83,5 +83,5 @@ export function makeActionInputs(
     runPost: "true",
     ...rest,
     condaConfig: makeCondaConfig(condaConfigOverrides),
-  };
+  });
 }

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,0 +1,87 @@
+/**
+ * @module __tests__/helpers
+ * Shared test fixtures for building action inputs.
+ *
+ * Centralizes the default `IActionInputs` / `ICondaConfig` shape so that adding
+ * a new action input or condarc key only requires editing this one file,
+ * instead of every test module that builds inputs.
+ */
+
+import * as types from "../types";
+
+/**
+ * Overrides accepted by {@link makeActionInputs}: any top-level input field,
+ * plus a *partial* `condaConfig` that is deep-merged onto the defaults.
+ */
+export type ActionInputsOverrides = Partial<
+  Omit<types.IActionInputs, "condaConfig">
+> & {
+  condaConfig?: Partial<types.ICondaConfig>;
+};
+
+/**
+ * Build a default `ICondaConfig`, optionally overriding individual keys.
+ *
+ * @param overrides - Condarc keys to override on top of the defaults.
+ * @returns A complete `ICondaConfig`.
+ */
+export function makeCondaConfig(
+  overrides: Partial<types.ICondaConfig> = {},
+): types.ICondaConfig {
+  return {
+    add_anaconda_token: "",
+    add_pip_as_python_dependency: "",
+    allow_softlinks: "",
+    auto_activate: "false",
+    auto_update_conda: "false",
+    channel_alias: "",
+    channel_priority: "",
+    channels: "",
+    default_activation_env: "",
+    show_channel_urls: "",
+    use_only_tar_bz2: "",
+    always_yes: "true",
+    changeps1: "false",
+    solver: "",
+    pkgs_dirs: "",
+    ...overrides,
+  };
+}
+
+/**
+ * Build a complete `IActionInputs` for tests with sensible defaults.
+ *
+ * Top-level fields can be overridden directly; `condaConfig` is deep-merged
+ * onto the defaults via {@link makeCondaConfig}.
+ *
+ * @param overrides - Input fields to override on top of the defaults.
+ * @returns A complete `IActionInputs`.
+ */
+export function makeActionInputs(
+  overrides: ActionInputsOverrides = {},
+): types.IActionInputs {
+  const { condaConfig: condaConfigOverrides, ...rest } = overrides;
+  return {
+    activateEnvironment: "test",
+    architecture: "x64",
+    condaBuildVersion: "",
+    condaConfigFile: "",
+    condaVersion: "",
+    environmentFile: "",
+    installerUrl: "",
+    installationDir: "",
+    mambaVersion: "",
+    minicondaVersion: "",
+    miniforgeVariant: "",
+    miniforgeVersion: "",
+    condaRemoveDefaults: "false",
+    pythonVersion: "",
+    removeProfiles: "true",
+    runInit: "true",
+    useMamba: "",
+    cleanPatchedEnvironmentFile: "true",
+    runPost: "true",
+    ...rest,
+    condaConfig: makeCondaConfig(condaConfigOverrides),
+  };
+}

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -9,6 +9,10 @@
 
 import type * as types from "../types";
 
+function freeze<T>(value: T): T {
+  return Object.freeze(value) as T;
+}
+
 /**
  * Overrides accepted by {@link makeActionInputs}: any top-level input field,
  * plus a *partial* `condaConfig` that is shallow-merged onto the defaults.
@@ -28,7 +32,7 @@ export type ActionInputsOverrides = Partial<
 export function makeCondaConfig(
   overrides: Partial<types.ICondaConfig> = {},
 ): types.ICondaConfig {
-  return Object.freeze({
+  return freeze({
     add_anaconda_token: "",
     add_pip_as_python_dependency: "",
     allow_softlinks: "",
@@ -61,7 +65,7 @@ export function makeActionInputs(
   overrides: ActionInputsOverrides = {},
 ): types.IActionInputs {
   const { condaConfig: condaConfigOverrides, ...rest } = overrides;
-  return Object.freeze({
+  return freeze({
     activateEnvironment: "test",
     architecture: "x64",
     condaBuildVersion: "",
@@ -83,5 +87,18 @@ export function makeActionInputs(
     runPost: "true",
     ...rest,
     condaConfig: makeCondaConfig(condaConfigOverrides),
+  });
+}
+
+/**
+ * Build action inputs for tests that use `conda-forge` as the channel default.
+ */
+export function makeCondaForgeActionInputs(
+  overrides: ActionInputsOverrides = {},
+): types.IActionInputs {
+  const { condaConfig: condaConfigOverrides, ...rest } = overrides;
+  return makeActionInputs({
+    ...rest,
+    condaConfig: { channels: "conda-forge", ...condaConfigOverrides },
   });
 }

--- a/src/__tests__/installer/bundled-miniconda.test.ts
+++ b/src/__tests__/installer/bundled-miniconda.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -22,45 +23,7 @@ vi.mock("../../constants", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
-    ...overrides,
-  }) as types.IActionInputs;
+  return makeActionInputs(overrides);
 }
 
 function makeOptions(

--- a/src/__tests__/installer/download-miniconda.test.ts
+++ b/src/__tests__/installer/download-miniconda.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -52,45 +53,7 @@ vi.mock("../../constants", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
-    ...overrides,
-  }) as types.IActionInputs;
+  return makeActionInputs(overrides);
 }
 
 function makeOptions(

--- a/src/__tests__/installer/download-miniforge.test.ts
+++ b/src/__tests__/installer/download-miniforge.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -45,45 +46,7 @@ vi.mock("../../constants", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
-    ...overrides,
-  }) as types.IActionInputs;
+  return makeActionInputs(overrides);
 }
 
 function makeOptions(

--- a/src/__tests__/installer/download-url.test.ts
+++ b/src/__tests__/installer/download-url.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -33,45 +34,7 @@ vi.mock("../../installer/base", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
-    ...overrides,
-  }) as types.IActionInputs;
+  return makeActionInputs(overrides);
 }
 
 function makeOptions(

--- a/src/__tests__/installer/index.test.ts
+++ b/src/__tests__/installer/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../../types";
+import { makeActionInputs } from "../helpers";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -70,45 +71,7 @@ vi.mock("../../installer/download-miniconda", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
-    ...overrides,
-  }) as types.IActionInputs;
+  return makeActionInputs(overrides);
 }
 
 function makeOptions(

--- a/src/__tests__/outputs.test.ts
+++ b/src/__tests__/outputs.test.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../types";
+import { makeActionInputs } from "./helpers";
 
 // Mock @actions/core
 const mockAddPath = vi.fn();
@@ -42,44 +43,9 @@ vi.mock("../constants", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "conda-forge",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
+  return makeActionInputs({
     ...overrides,
+    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
   });
 }
 

--- a/src/__tests__/outputs.test.ts
+++ b/src/__tests__/outputs.test.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../types";
-import { makeActionInputs } from "./helpers";
+import { makeCondaForgeActionInputs } from "./helpers";
 
 // Mock @actions/core
 const mockAddPath = vi.fn();
@@ -43,10 +43,7 @@ vi.mock("../constants", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return makeActionInputs({
-    ...overrides,
-    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
-  });
+  return makeCondaForgeActionInputs(overrides);
 }
 
 function makeOptions(

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../types";
+import { makeActionInputs } from "./helpers";
 
 // ---------------------------------------------------------------------------
 // Mocks — vi.mock() calls are hoisted above imports by vitest, so these
@@ -95,45 +96,10 @@ vi.mock("../constants", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return {
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
-    environmentFile: "",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
-    pythonVersion: "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: {
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "conda-forge",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    },
+  return makeActionInputs({
     ...overrides,
-  };
+    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
+  });
 }
 
 function defaultInstallerInfo(

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type * as types from "../types";
-import { makeActionInputs } from "./helpers";
+import { makeCondaForgeActionInputs } from "./helpers";
 
 // ---------------------------------------------------------------------------
 // Mocks — vi.mock() calls are hoisted above imports by vitest, so these
@@ -96,10 +96,7 @@ vi.mock("../constants", () => ({
 function makeInputs(
   overrides: Partial<types.IActionInputs> = {},
 ): types.IActionInputs {
-  return makeActionInputs({
-    ...overrides,
-    condaConfig: { channels: "conda-forge", ...overrides.condaConfig },
-  });
+  return makeCondaForgeActionInputs(overrides);
 }
 
 function defaultInstallerInfo(

--- a/src/__tests__/yaml.test.ts
+++ b/src/__tests__/yaml.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as yaml from "js-yaml";
 
 import type * as types from "../types";
+import { makeActionInputs } from "./helpers";
 import { ensureYaml } from "../env/yaml";
 
 // Mock @actions/core
@@ -53,43 +54,10 @@ vi.mock("../outputs", () => ({
 function makeInputs(
   overrides: Partial<{ pythonVersion: string; environmentFile: string }> = {},
 ): types.IActionInputs {
-  return Object.freeze({
-    activateEnvironment: "test",
-    architecture: "x64",
-    condaBuildVersion: "",
-    condaConfigFile: "",
-    condaVersion: "",
+  return makeActionInputs({
     environmentFile: overrides.environmentFile ?? "environment.yml",
-    installerUrl: "",
-    installationDir: "",
-    mambaVersion: "",
-    minicondaVersion: "",
-    miniforgeVariant: "",
-    miniforgeVersion: "",
-    condaRemoveDefaults: "false",
     pythonVersion: overrides.pythonVersion ?? "",
-    removeProfiles: "true",
-    runInit: "true",
-    useMamba: "",
-    cleanPatchedEnvironmentFile: "true",
-    runPost: "true",
-    condaConfig: Object.freeze({
-      add_anaconda_token: "",
-      add_pip_as_python_dependency: "",
-      allow_softlinks: "",
-      auto_activate: "false",
-      auto_update_conda: "false",
-      channel_alias: "",
-      channel_priority: "",
-      channels: "conda-forge",
-      default_activation_env: "",
-      show_channel_urls: "",
-      use_only_tar_bz2: "",
-      always_yes: "true",
-      changeps1: "false",
-      solver: "",
-      pkgs_dirs: "",
-    }),
+    condaConfig: { channels: "conda-forge" },
   });
 }
 

--- a/src/__tests__/yaml.test.ts
+++ b/src/__tests__/yaml.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as yaml from "js-yaml";
 
 import type * as types from "../types";
-import { makeActionInputs } from "./helpers";
+import { makeCondaForgeActionInputs } from "./helpers";
 import { ensureYaml } from "../env/yaml";
 
 // Mock @actions/core
@@ -54,10 +54,9 @@ vi.mock("../outputs", () => ({
 function makeInputs(
   overrides: Partial<{ pythonVersion: string; environmentFile: string }> = {},
 ): types.IActionInputs {
-  return makeActionInputs({
+  return makeCondaForgeActionInputs({
     environmentFile: overrides.environmentFile ?? "environment.yml",
     pythonVersion: overrides.pythonVersion ?? "",
-    condaConfig: { channels: "conda-forge" },
   });
 }
 


### PR DESCRIPTION
## Summary

- Add `src/__tests__/helpers.ts` as the single source of truth for test fixtures, exporting `makeActionInputs()`, `makeCondaConfig()`, `makeCondaForgeActionInputs()`, and the `ActionInputsOverrides` type.
- Replace every per-file `makeInputs()` builder that duplicated the full `IActionInputs` / `condaConfig` literal with thin delegation to the shared helper. Each builder keeps its existing signature, so no call sites change.
- Keep fixture outputs frozen to match production input behavior, with a small typed freeze helper so the declared mutable test fixture return types remain stable.
- `condaConfig` overrides are shallow-merged onto the defaults via `makeCondaConfig`, so a test can override a single condarc key without respecifying the whole object.
- Add `makeCondaForgeActionInputs()` for tests that use `conda-forge` as their channel default, removing repeated local merge patterns while preserving blank-channel defaults elsewhere.

## Why

Adding a new action input or condarc key previously meant editing the input literal in every test module. Now common fixture shape changes touch only `helpers.ts`, while tests with a `conda-forge` channel default use a named shared helper.

## Notes

- Test-only change. Test files are excluded from the ncc `dist/` bundle, so no rebuild is required.
- Net diff: 19 files changed, 143 insertions(+), 678 deletions(-).

## Test plan

- [x] `npm test` -> 416 tests pass (22 files)
- [x] `npm run check` -> prettier + eslint clean