### PR TITLE
feat: add use-sharded-repodata input and deep-merge nested condarc

### DIFF
--- a/README.md
+++ b/README.md
@@ -887,6 +887,29 @@ jobs:
           python my_script.py
 ```
 
+### Example 18: Disable sharded repodata
+
+Recent versions of `conda` (through `conda-libmamba-solver`) fetch
+[sharded repodata](https://conda.github.io/conda-libmamba-solver/user-guide/configuration/)
+by default. If your channels are served by a mirror or proxy that does not yet
+provide the sharded layout, set `use-sharded-repodata: "false"` to fall back to
+the classic `repodata.json`. The value is written to the nested
+`plugins.use_sharded_repodata` key in `.condarc`.
+
+```yaml
+jobs:
+  no-sharded-repodata:
+    name: Disable sharded repodata
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: conda-incubator/setup-miniconda@v4
+        with:
+          activate-environment: myenv
+          environment-file: environment.yml
+          use-sharded-repodata: "false"
+```
+
 ## IMPORTANT
 
 - Conda activation does not correctly work on `sh`. Please use `bash`.

--- a/action.yml
+++ b/action.yml
@@ -244,6 +244,17 @@ inputs:
       for more information.'
     required: false
     default: ""
+  use-sharded-repodata:
+    description:
+      'Conda configuration. Whether conda-libmamba-solver should fetch sharded
+      repodata. Set to "false" to disable sharded repodata, for example when a
+      channel mirror or proxy does not serve it. This is written to the nested
+      "plugins.use_sharded_repodata" key in .condarc; leaving it empty keeps
+      conda''s own default. See
+      https://conda.github.io/conda-libmamba-solver/user-guide/configuration/
+      for more information.'
+    required: false
+    default: ""
   remove-profiles:
     description:
       'Advanced. Prior to runnning "conda init" all shell profiles will be

--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -34138,6 +34138,7 @@ function parseInputs() {
                 default_activation_env: "", // Needed for type definition
                 show_channel_urls: getInput("show-channel-urls"),
                 use_only_tar_bz2: getInput("use-only-tar-bz2"),
+                use_sharded_repodata: getInput("use-sharded-repodata"),
                 solver: getInput("conda-solver"),
                 pkgs_dirs: getInput("pkgs-dirs"),
                 // These are always set to avoid terminal issues

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -34181,6 +34181,7 @@ function parseInputs() {
                 default_activation_env: "", // Needed for type definition
                 show_channel_urls: getInput("show-channel-urls"),
                 use_only_tar_bz2: getInput("use-only-tar-bz2"),
+                use_sharded_repodata: getInput("use-sharded-repodata"),
                 solver: getInput("conda-solver"),
                 pkgs_dirs: getInput("pkgs-dirs"),
                 // These are always set to avoid terminal issues
@@ -34218,7 +34219,7 @@ function parseInputs() {
 }
 
 ;// CONCATENATED MODULE: ./node_modules/js-yaml/dist/js-yaml.mjs
-/*! js-yaml 5.2.1 https://github.com/nodeca/js-yaml @license MIT */
+/*! js-yaml 5.1.0 https://github.com/nodeca/js-yaml @license MIT */
 //#region src/tag.ts
 var NOT_RESOLVED = Symbol("NOT_RESOLVED");
 var MERGE_KEY = Symbol("MERGE_KEY");
@@ -34460,7 +34461,7 @@ var intCoreTag = defineScalarTag("tag:yaml.org,2002:int", {
 		..."0123456789"
 	],
 	resolve: resolveYamlInteger$2,
-	identify: (object) => Number.isInteger(object) && !Object.is(object, -0) && object.toString(10).indexOf("e") < 0,
+	identify: (object) => Object.prototype.toString.call(object) === "[object Number]" && object % 1 === 0 && !Object.is(object, -0),
 	represent: (object) => object.toString(10)
 });
 //#endregion
@@ -34490,7 +34491,7 @@ var intJsonTag = defineScalarTag("tag:yaml.org,2002:int", {
 	implicit: true,
 	implicitFirstChars: ["-", ..."0123456789"],
 	resolve: resolveYamlInteger$1,
-	identify: (object) => Number.isInteger(object) && !Object.is(object, -0) && object.toString(10).indexOf("e") < 0,
+	identify: (object) => Object.prototype.toString.call(object) === "[object Number]" && object % 1 === 0 && !Object.is(object, -0),
 	represent: (object) => object.toString(10)
 });
 //#endregion
@@ -34526,7 +34527,7 @@ var intYaml11Tag = defineScalarTag("tag:yaml.org,2002:int", {
 		..."0123456789"
 	],
 	resolve: resolveYamlInteger,
-	identify: (object) => Number.isInteger(object) && !Object.is(object, -0) && object.toString(10).indexOf("e") < 0,
+	identify: (object) => Object.prototype.toString.call(object) === "[object Number]" && object % 1 === 0 && !Object.is(object, -0),
 	represent: (object) => object.toString(10)
 });
 //#endregion
@@ -34561,7 +34562,7 @@ var floatCoreTag = defineScalarTag("tag:yaml.org,2002:float", {
 		..."0123456789"
 	],
 	resolve: resolveYamlFloat$2,
-	identify: (object) => typeof object === "number" && (!Number.isInteger(object) || Object.is(object, -0) || object.toString(10).indexOf("e") >= 0),
+	identify: (object) => Object.prototype.toString.call(object) === "[object Number]" && (object % 1 !== 0 || Object.is(object, -0)),
 	represent: representYamlFloat$2
 });
 //#endregion
@@ -34596,7 +34597,7 @@ var floatJsonTag = defineScalarTag("tag:yaml.org,2002:float", {
 	implicit: true,
 	implicitFirstChars: ["-", ..."0123456789"],
 	resolve: resolveYamlFloat$1,
-	identify: (object) => typeof object === "number" && (!Number.isInteger(object) || Object.is(object, -0) || object.toString(10).indexOf("e") >= 0),
+	identify: (object) => Object.prototype.toString.call(object) === "[object Number]" && (object % 1 !== 0 || Object.is(object, -0)),
 	represent: representYamlFloat$1
 });
 //#endregion
@@ -34635,7 +34636,7 @@ var floatYaml11Tag = defineScalarTag("tag:yaml.org,2002:float", {
 		..."0123456789"
 	],
 	resolve: resolveYamlFloat,
-	identify: (object) => typeof object === "number" && (!Number.isInteger(object) || Object.is(object, -0) || object.toString(10).indexOf("e") >= 0),
+	identify: (object) => Object.prototype.toString.call(object) === "[object Number]" && (object % 1 !== 0 || Object.is(object, -0)),
 	represent: representYamlFloat
 });
 //#endregion
@@ -34723,40 +34724,18 @@ var seqTag = defineSequenceTag("tag:yaml.org,2002:seq", {
 	identify: Array.isArray
 });
 //#endregion
-//#region src/common/object.ts
-function isPlainObject(data) {
-	if (data === null || typeof data !== "object" || Array.isArray(data)) return false;
-	const prototype = Object.getPrototypeOf(data);
-	return prototype === null || prototype === Object.prototype;
-}
-function pick(object, keys) {
-	const result = {};
-	for (const key of keys) if (object[key] !== void 0) result[key] = object[key];
-	return result;
-}
-//#endregion
 //#region src/tag/sequence/omap.ts
 var omapTag = defineSequenceTag("tag:yaml.org,2002:omap", {
-	create: () => ({
-		list: [],
-		seen: /* @__PURE__ */ new Set()
-	}),
-	addItem: (carrier, item) => {
-		let key;
-		if (item instanceof Map) {
-			if (item.size !== 1) return "cannot resolve an ordered map item";
-			key = item.keys().next().value;
-		} else if (isPlainObject(item)) {
-			const itemKeys = Object.keys(item);
-			if (itemKeys.length !== 1) return "cannot resolve an ordered map item";
-			key = itemKeys[0];
-		} else return "cannot resolve an ordered map item";
-		if (carrier.seen.has(key)) return "duplicate key in ordered map";
-		carrier.seen.add(key);
-		carrier.list.push(item);
+	create: () => [],
+	addItem: (container, item) => {
+		if (Object.prototype.toString.call(item) !== "[object Object]") return "cannot resolve an ordered map item";
+		const object = item;
+		const itemKeys = Object.keys(object);
+		if (itemKeys.length !== 1) return "cannot resolve an ordered map item";
+		for (const existing of container) if (Object.prototype.hasOwnProperty.call(existing, itemKeys[0])) return "cannot resolve an ordered map item";
+		container.push(object);
 		return "";
-	},
-	finalize: (carrier) => carrier.list
+	}
 });
 //#endregion
 //#region src/tag/sequence/pairs.ts
@@ -34776,6 +34755,18 @@ var pairsTag = defineSequenceTag("tag:yaml.org,2002:pairs", {
 		return "";
 	}
 });
+//#endregion
+//#region src/common/object.ts
+function isPlainObject(data) {
+	if (data === null || typeof data !== "object" || Array.isArray(data)) return false;
+	const prototype = Object.getPrototypeOf(data);
+	return prototype === null || prototype === Object.prototype;
+}
+function pick(object, keys) {
+	const result = {};
+	for (const key of keys) if (object[key] !== void 0) result[key] = object[key];
+	return result;
+}
 //#endregion
 //#region src/tag/mapping/map.ts
 var mapTag = defineMappingTag("tag:yaml.org,2002:map", {
@@ -35366,8 +35357,7 @@ var DEFAULT_CONSTRUCTOR_OPTIONS = {
 	filename: "",
 	schema: CORE_SCHEMA,
 	json: false,
-	maxTotalMergeKeys: 1e4,
-	maxAliases: -1
+	maxMergeSeqLength: 20
 };
 function eventPosition$1(event) {
 	if ("tagStart" in event && event.tagStart !== NO_RANGE$2) return event.tagStart;
@@ -35455,7 +35445,6 @@ function isMappingTag(tag) {
 }
 function mergeKeys(state, frame, source, sourceTag) {
 	for (const sourceKey of sourceTag.keys(source)) {
-		if (state.maxTotalMergeKeys !== -1 && ++state.totalMergeKeys > state.maxTotalMergeKeys) throwError$1(state, `merge keys exceeded maxTotalMergeKeys (${state.maxTotalMergeKeys})`);
 		if (frame.tag.has(frame.value, sourceKey)) continue;
 		const err = frame.tag.addPair(frame.value, sourceKey, sourceTag.get(source, sourceKey));
 		if (err) throwError$1(state, err);
@@ -35465,8 +35454,14 @@ function mergeKeys(state, frame, source, sourceTag) {
 function mergeSource(state, frame, source, sourceTag) {
 	state.position = frame.keyPosition;
 	if (isMappingTag(sourceTag)) mergeKeys(state, frame, source, sourceTag);
-	else if (sourceTag.nodeKind === "sequence" && Array.isArray(source)) for (const element of source) mergeKeys(state, frame, element, frame.tag);
-	else throwError$1(state, "cannot merge mappings; the provided source object is unacceptable");
+	else if (sourceTag.nodeKind === "sequence" && Array.isArray(source)) {
+		const seen = /* @__PURE__ */ new Set();
+		for (const element of source) {
+			if (seen.has(element)) continue;
+			seen.add(element);
+			mergeKeys(state, frame, element, frame.tag);
+		}
+	} else throwError$1(state, "cannot merge mappings; the provided source object is unacceptable");
 }
 function addMappingValue(state, frame, key, value, tag) {
 	state.position = frame.keyPosition;
@@ -35487,6 +35482,7 @@ function addValue(state, value, tag) {
 	} else if (frame.kind === "sequence") {
 		if (frame.merge) {
 			if (!isMappingTag(tag)) throwError$1(state, "cannot merge mappings; the provided source object is unacceptable");
+			if (frame.index >= state.maxMergeSeqLength) throwError$1(state, `merge sequence length exceeded maxMergeSeqLength (${state.maxMergeSeqLength})`);
 		}
 		const err = frame.tag.addItem(frame.value, value, frame.index++);
 		if (err) throwError$1(state, err);
@@ -35523,9 +35519,7 @@ function constructFromEvents(events, options) {
 		position: 0,
 		frames: [],
 		anchors: /* @__PURE__ */ new Map(),
-		tagHandlers: Object.create(null),
-		totalMergeKeys: 0,
-		aliasCount: 0
+		tagHandlers: Object.create(null)
 	};
 	while (state.eventIndex < state.events.length) {
 		const event = state.events[state.eventIndex++];
@@ -35533,7 +35527,6 @@ function constructFromEvents(events, options) {
 		switch (event.type) {
 			case 1:
 				state.anchors = /* @__PURE__ */ new Map();
-				state.aliasCount = 0;
 				state.tagHandlers = Object.create(null);
 				for (const directive of event.directives) if (directive.kind === "tag") state.tagHandlers[directive.handle] = directive.prefix;
 				state.frames.push({
@@ -35584,7 +35577,6 @@ function constructFromEvents(events, options) {
 				break;
 			}
 			case 5: {
-				if (state.maxAliases !== -1 && ++state.aliasCount > state.maxAliases) throwError$1(state, `aliases exceeded maxAliases (${state.maxAliases})`);
 				const name = state.source.slice(event.anchorStart, event.anchorEnd);
 				const anchor = state.anchors.get(name);
 				if (!anchor) throwError$1(state, `unidentified alias "${name}"`);
@@ -37680,6 +37672,7 @@ const BOOLEAN_CONDARC_KEYS = new Set([
     "auto_update_conda",
     "show_channel_urls",
     "use_only_tar_bz2",
+    "use_sharded_repodata",
     "always_yes",
     "changeps1",
     "notify_outdated_conda",
@@ -37700,6 +37693,7 @@ const KNOWN_CONDARC_KEYS = new Set([
     "envs_dirs",
     "override_channels_enabled",
     "pkgs_dirs",
+    "plugins",
     "proxy_servers",
     "local_repodata_ttl",
     "repodata_threads",
@@ -37730,6 +37724,40 @@ function coerceConfigValue(key, value) {
     return value;
 }
 /**
+ * Type guard for a plain (non-array, non-null) object suitable for deep merging.
+ *
+ * @param value - The value to test.
+ * @returns `true` if `value` is a non-null, non-array object.
+ */
+function conda_isPlainObject(value) {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+/**
+ * Recursively merge `source` over `target`, returning a new object.
+ *
+ * Nested plain objects such as condarc's `plugins:` section are merged key by
+ * key so that setting one nested value does not clobber its siblings. Arrays
+ * and scalars from `source` replace those in `target` without element-wise
+ * array merging, matching conda's last-writer-wins semantics for list keys.
+ *
+ * @param target - The base configuration.
+ * @param source - Values to layer on top of `target`.
+ * @returns A new object with `source` deeply merged over `target`.
+ */
+function deepMerge(target, source) {
+    const result = Object.assign({}, target);
+    for (const [key, sourceValue] of Object.entries(source)) {
+        const targetValue = result[key];
+        if (conda_isPlainObject(targetValue) && conda_isPlainObject(sourceValue)) {
+            result[key] = deepMerge(targetValue, sourceValue);
+        }
+        else {
+            result[key] = sourceValue;
+        }
+    }
+    return result;
+}
+/**
  * Build the complete conda configuration and write it directly to ~/.condarc.
  *
  * This replaces the old approach of spawning N `conda config --set/--add`
@@ -37754,7 +37782,7 @@ function writeCondaConfig(inputs, options) {
             info(`Reading user condarc from "${sourcePath}"...`);
             const userConfig = load(external_fs_namespaceObject.readFileSync(sourcePath, "utf8"));
             if (userConfig) {
-                config = Object.assign(Object.assign({}, config), userConfig);
+                config = deepMerge(config, userConfig);
             }
         }
         config["notify_outdated_conda"] = false;
@@ -37835,6 +37863,8 @@ function writeCondaConfig(inputs, options) {
             "pkgs_dirs",
             "auto_activate",
             "default_activation_env",
+            // Written as the nested `plugins.use_sharded_repodata` key below.
+            "use_sharded_repodata",
         ]);
         const configEntries = Object.entries(inputs.condaConfig);
         for (const [key, value] of configEntries) {
@@ -37844,6 +37874,20 @@ function writeCondaConfig(inputs, options) {
             const coerced = coerceConfigValue(key, value);
             config[key] = coerced;
             info(`${key}: ${coerced}`);
+        }
+        // --- Plugins (nested condarc section) ---
+        // conda-libmamba-solver's sharded repodata is configured under the nested
+        // `plugins.use_sharded_repodata` key, not a flat top-level key, so it needs
+        // dedicated handling (#503). deepMerge preserves any sibling plugin settings
+        // already present from an existing .condarc or condarc-file. An empty input
+        // leaves conda's own default in place.
+        const useShardedRepodata = inputs.condaConfig.use_sharded_repodata;
+        if (useShardedRepodata.trim().length > 0) {
+            const coerced = coerceConfigValue("use_sharded_repodata", useShardedRepodata);
+            config = deepMerge(config, {
+                plugins: { use_sharded_repodata: coerced },
+            });
+            info(`plugins.use_sharded_repodata: ${coerced}`);
         }
         // Strip 'defaults' from prefix-level condarc files too
         if (removeDefaults && !userExplicitlyAddedDefaults) {

--- a/src/__tests__/conda.test.ts
+++ b/src/__tests__/conda.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as yaml from "js-yaml";
 
 import type * as types from "../types";
-import { makeCondaForgeActionInputs } from "./helpers";
+import { makeActionInputs, makeCondaForgeActionInputs } from "./helpers";
 
 // Mock @actions/core
 vi.mock("@actions/core", () => ({
@@ -389,6 +389,105 @@ describe("writeCondaConfig", () => {
 
     const config = getWrittenConfig();
     expect(config["channels"]).toContain("conda-forge");
+  });
+
+  it("writes use_sharded_repodata as a nested plugins key, not a flat one", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeActionInputs({
+      condaConfig: { channels: "conda-forge", use_sharded_repodata: "false" },
+    });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["plugins"]).toEqual({ use_sharded_repodata: false });
+    // conda ignores a flat top-level use_sharded_repodata, so it must not appear.
+    expect(config).not.toHaveProperty("use_sharded_repodata");
+  });
+
+  it("coerces use_sharded_repodata 'true' to a boolean", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeActionInputs({
+      condaConfig: { channels: "conda-forge", use_sharded_repodata: "true" },
+    });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["plugins"]).toEqual({ use_sharded_repodata: true });
+  });
+
+  it("omits the plugins section when use_sharded_repodata is empty", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeActionInputs({
+      condaConfig: { channels: "conda-forge" },
+    });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config).not.toHaveProperty("plugins");
+  });
+
+  it("merges into an existing plugins section without clobbering siblings", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeActionInputs({
+      condaConfig: { channels: "conda-forge", use_sharded_repodata: "false" },
+    });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(
+      yaml.dump({ plugins: { some_other_plugin: true } }),
+    );
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    expect(config["plugins"]).toEqual({
+      some_other_plugin: true,
+      use_sharded_repodata: false,
+    });
+  });
+
+  it("deep-merges nested plugins from condaConfigFile and existing condarc", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeActionInputs({
+      condaConfig: { channels: "conda-forge", use_sharded_repodata: "false" },
+      condaConfigFile: "my-condarc.yml",
+    });
+
+    const originalWorkspace = process.env["GITHUB_WORKSPACE"];
+    process.env["GITHUB_WORKSPACE"] = "/workspace";
+
+    vi.mocked(fsMod.readFileSync).mockImplementation((p: unknown) => {
+      const pStr = p as string;
+      if (pStr.includes("my-condarc.yml")) {
+        return yaml.dump({ plugins: { foo: 1, use_sharded_repodata: true } });
+      }
+      return yaml.dump({ plugins: { bar: 2 } });
+    });
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    const config = getWrittenConfig();
+    // Existing condarc + condarc-file plugins deep-merge, and the action input
+    // wins for use_sharded_repodata. No sibling keys are lost.
+    expect(config["plugins"]).toEqual({
+      bar: 2,
+      foo: 1,
+      use_sharded_repodata: false,
+    });
+
+    if (originalWorkspace !== undefined) {
+      process.env["GITHUB_WORKSPACE"] = originalWorkspace;
+    } else {
+      delete process.env["GITHUB_WORKSPACE"];
+    }
   });
 });
 

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -44,6 +44,7 @@ export function makeCondaConfig(
     default_activation_env: "",
     show_channel_urls: "",
     use_only_tar_bz2: "",
+    use_sharded_repodata: "",
     always_yes: "true",
     changeps1: "false",
     solver: "",

--- a/src/__tests__/input.test.ts
+++ b/src/__tests__/input.test.ts
@@ -39,6 +39,7 @@ function setDefaults() {
     channels: "conda-forge",
     "show-channel-urls": "",
     "use-only-tar-bz2": "",
+    "use-sharded-repodata": "",
     "conda-solver": "",
     "pkgs-dirs": "",
     "clean-patched-environment-file": "true",
@@ -151,6 +152,14 @@ describe("parseInputs", () => {
       const result = await parseInputs();
 
       expect(result.condaConfig.solver).toBe("libmamba");
+    });
+
+    it("reads use-sharded-repodata from input", async () => {
+      setInput("use-sharded-repodata", "false");
+      const parseInputs = await loadParseInputs();
+      const result = await parseInputs();
+
+      expect(result.condaConfig.use_sharded_repodata).toBe("false");
     });
 
     it("reads channel-priority from input", async () => {

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -202,6 +202,7 @@ const BOOLEAN_CONDARC_KEYS = new Set([
   "auto_update_conda",
   "show_channel_urls",
   "use_only_tar_bz2",
+  "use_sharded_repodata",
   "always_yes",
   "changeps1",
   "notify_outdated_conda",
@@ -223,6 +224,7 @@ const KNOWN_CONDARC_KEYS = new Set([
   "envs_dirs",
   "override_channels_enabled",
   "pkgs_dirs",
+  "plugins",
   "proxy_servers",
   "local_repodata_ttl",
   "repodata_threads",
@@ -251,6 +253,44 @@ function coerceConfigValue(key: string, value: string): boolean | string {
     if (FALSY_VALUES.has(lower)) return false;
   }
   return value;
+}
+
+/**
+ * Type guard for a plain (non-array, non-null) object suitable for deep merging.
+ *
+ * @param value - The value to test.
+ * @returns `true` if `value` is a non-null, non-array object.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Recursively merge `source` over `target`, returning a new object.
+ *
+ * Nested plain objects such as condarc's `plugins:` section are merged key by
+ * key so that setting one nested value does not clobber its siblings. Arrays
+ * and scalars from `source` replace those in `target` without element-wise
+ * array merging, matching conda's last-writer-wins semantics for list keys.
+ *
+ * @param target - The base configuration.
+ * @param source - Values to layer on top of `target`.
+ * @returns A new object with `source` deeply merged over `target`.
+ */
+function deepMerge(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...target };
+  for (const [key, sourceValue] of Object.entries(source)) {
+    const targetValue = result[key];
+    if (isPlainObject(targetValue) && isPlainObject(sourceValue)) {
+      result[key] = deepMerge(targetValue, sourceValue);
+    } else {
+      result[key] = sourceValue;
+    }
+  }
+  return result;
 }
 
 /**
@@ -291,7 +331,7 @@ export async function writeCondaConfig(
       unknown
     > | null;
     if (userConfig) {
-      config = { ...config, ...userConfig };
+      config = deepMerge(config, userConfig);
     }
   }
 
@@ -388,6 +428,8 @@ export async function writeCondaConfig(
     "pkgs_dirs",
     "auto_activate",
     "default_activation_env",
+    // Written as the nested `plugins.use_sharded_repodata` key below.
+    "use_sharded_repodata",
   ]);
   const configEntries = Object.entries(inputs.condaConfig) as [
     keyof types.ICondaConfig,
@@ -401,6 +443,24 @@ export async function writeCondaConfig(
     const coerced = coerceConfigValue(key, value);
     config[key] = coerced;
     core.info(`${key}: ${coerced}`);
+  }
+
+  // --- Plugins (nested condarc section) ---
+  // conda-libmamba-solver's sharded repodata is configured under the nested
+  // `plugins.use_sharded_repodata` key, not a flat top-level key, so it needs
+  // dedicated handling (#503). deepMerge preserves any sibling plugin settings
+  // already present from an existing .condarc or condarc-file. An empty input
+  // leaves conda's own default in place.
+  const useShardedRepodata = inputs.condaConfig.use_sharded_repodata;
+  if (useShardedRepodata.trim().length > 0) {
+    const coerced = coerceConfigValue(
+      "use_sharded_repodata",
+      useShardedRepodata,
+    );
+    config = deepMerge(config, {
+      plugins: { use_sharded_repodata: coerced },
+    });
+    core.info(`plugins.use_sharded_repodata: ${coerced}`);
   }
 
   // Strip 'defaults' from prefix-level condarc files too

--- a/src/input.ts
+++ b/src/input.ts
@@ -175,6 +175,7 @@ export async function parseInputs(): Promise<types.IActionInputs> {
       default_activation_env: "", // Needed for type definition
       show_channel_urls: core.getInput("show-channel-urls"),
       use_only_tar_bz2: core.getInput("use-only-tar-bz2"),
+      use_sharded_repodata: core.getInput("use-sharded-repodata"),
       solver: core.getInput("conda-solver"),
       pkgs_dirs: core.getInput("pkgs-dirs"),
       // These are always set to avoid terminal issues

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export interface ICondaConfig {
   default_activation_env: string;
   show_channel_urls: string;
   use_only_tar_bz2: string;
+  use_sharded_repodata: string;
   always_yes: string;
   changeps1: string;
   solver: string;


### PR DESCRIPTION
## Summary

Adds a `use-sharded-repodata` action input so workflows can disable conda-libmamba-solver's sharded repodata (Closes #503). This helps when a channel is served by a mirror or proxy that does not yet provide the sharded layout.

The setting lives under conda's **nested** `plugins.use_sharded_repodata` key, not a flat top-level key, so the condarc writer now handles nested sections correctly:

- New `deepMerge` helper recursively merges nested plain objects (such as `plugins:`) so setting one nested value never clobbers its siblings; arrays and scalars stay last-writer-wins.
- The `condarc-file` is now deep-merged over the existing `.condarc` instead of shallow-spread. This also fixes a latent bug where a user `condarc-file` carrying any nested section (`plugins`, `proxy_servers`, `channel_settings`, etc.) would have wiped out that whole section from an existing `.condarc`.
- `use-sharded-repodata` is written **only** as the nested `plugins.use_sharded_repodata` key (never flat, which conda ignores), and `"true"`/`"false"` are coerced to real booleans.

Wiring: new `use-sharded-repodata` input in `action.yml`, `ICondaConfig` field in `types.ts`, parse mapping in `input.ts`, shared test fixture default in `helpers.ts`, and README "Example 18: Disable sharded repodata".

## Test plan

- [x] `npm test` (added 6 `conda.test.ts` cases: nested write, boolean coercion, empty-input omission, sibling-preserving merge, deep-merge across existing condarc + condarc-file; plus an `input.test.ts` parse case)
- [x] `npx tsc --noEmit`
- [x] `npm run check` (prettier + eslint)
- [x] `npm run build` (dist regenerated)
- [ ] Manual: run with `use-sharded-repodata: "false"` and confirm `~/.condarc` contains a nested `plugins:` with `use_sharded_repodata: false`