### PR TITLE
docs: clarify python-version/installer-url inputs and caching caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,10 +753,11 @@ jobs:
 
 > [!NOTE]
 >
-> - GitHub hosted Windows runners are currently faster during cache
->   decompression when configuring the package directories on the `D:` drive as
->   shown above. Make sure to use the `enableCrossOsArchive` cache config option
->   as well.
+> - Placing the package directories on the `D:` drive (as shown above) is
+>   sometimes faster during cache decompression on GitHub-hosted Windows
+>   runners, but this has been inconsistent in practice and the speedup is not
+>   guaranteed. If you use this layout, also set the `enableCrossOsArchive`
+>   cache config option.
 
 If you are using pip to resolve any dependencies in your conda environment then
 you may want to
@@ -824,6 +825,16 @@ not exist.
     etc/example-environment-caching.yml
   if: steps.cache.outputs.cache-hit != 'true'
 ```
+
+> [!IMPORTANT]
+>
+> If the environment file passed to `conda env update` / `mamba env update`
+> constrains `python` (for example `python>=3.10` instead of an exact
+> `python=3.10.4`), that step installs the newest `python` allowed by the range,
+> which can override the `python-version` requested on the `setup-miniconda`
+> step. To keep a specific version, pin an exact `python` in the file, omit
+> `python` from it, or restore the cached environment without re-running
+> `env update`.
 
 ### Use a default shell
 

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,9 @@ inputs:
   installer-url:
     description:
       "If provided, this installer will be used instead of a miniconda
-      installer, and cached based on its full URL Visit
+      installer, and cached based on its full URL. To use a local installer
+      file, pass a file:// URL with an absolute path; on Windows use forward
+      slashes, for example file:///D:/path/to/installer.exe. Visit
       https://github.com/conda/constructor for more information on creating
       installers"
     required: false
@@ -95,9 +97,12 @@ inputs:
     default: "test"
   python-version:
     description:
-      'Exact version of a Python version to use on "activate-environment". If
-      provided, this will be installed before the "environment-file". See
-      https://anaconda.org/anaconda/python for available "python" versions.'
+      'Python version to use on "activate-environment". A bare version such as
+      "3.11" becomes "python=3.11"; a value starting with a match operator is
+      used as-is, so a full conda spec also works, for example
+      "=3.10[build=*_pypy]" to install PyPy. If provided, this is installed
+      before the "environment-file". See https://anaconda.org/anaconda/python
+      for available "python" versions.'
     required: false
     default: ""
   add-anaconda-token:


### PR DESCRIPTION
## Summary

Documentation-only changes that resolve four long-standing doc-gap issues. No code or behavior changes; only `README.md` prose and `action.yml` input descriptions.

## Changes

- **`python-version` accepts a full conda spec** (`action.yml`): clarified that a bare version like `3.11` becomes `python=3.11`, while a value starting with a match operator is used as-is, e.g. `=3.10[build=*_pypy]` to install PyPy. Closes #170.
- **Local `installer-url` on Windows** (`action.yml`): documented that a `file://` URL with an absolute path and forward slashes works, e.g. `file:///D:/path/to/installer.exe`. Closes #341.
- **Cached env can override `python-version`** (`README.md`): added a note that a `python` range in the env file used by `conda env update` / `mamba env update` can override the requested `python-version`, plus how to avoid it. Closes #361.
- **`D:` drive package cache performance** (`README.md`): softened the note to reflect that the speedup is inconsistent and not guaranteed, matching the benchmarking discussion in the issue. Closes #406.

## Notes

- All four were documentation gaps; the underlying behavior already works as described (verified against `src/env/yaml.ts`, `src/env/simple.ts`, and `src/utils.ts`).
- `npm run check` passes (prettier + eslint).
