### PR TITLE
docs: add issue forms and a pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,113 @@
+name: Bug report
+description: Report a problem with the setup-miniconda action
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report!
+
+        To help us reproduce and fix the issue quickly, please fill in as much
+        detail as you can. The **exact YAML** you call the action with and the
+        **runner OS** are the most important pieces of information.
+  - type: checkboxes
+    id: prechecks
+    attributes:
+      label: Before you start
+      options:
+        - label:
+            I have read the
+            [README](https://github.com/conda-incubator/setup-miniconda#readme),
+            including the
+            [IMPORTANT](https://github.com/conda-incubator/setup-miniconda#important)
+            section on shell activation.
+          required: true
+        - label:
+            I have searched [existing
+            issues](https://github.com/conda-incubator/setup-miniconda/issues)
+            and this has not been reported yet.
+          required: true
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Exact action configuration (YAML)
+      description:
+        The exact step and `with:` block you are calling the action with.
+        Without this we usually cannot help.
+      render: yaml
+      placeholder: |
+        - uses: conda-incubator/setup-miniconda@v4
+          with:
+            miniforge-version: latest
+            environment-file: environment.yml
+            python-version: "3.11"
+    validations:
+      required: true
+  - type: input
+    id: action-version
+    attributes:
+      label: Action version
+      description:
+        Which version or ref of `conda-incubator/setup-miniconda` are you using?
+      placeholder: v4.0.1
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Runner operating system
+      multiple: true
+      options:
+        - Ubuntu / Linux
+        - macOS
+        - Windows
+        - Self-hosted
+    validations:
+      required: true
+  - type: input
+    id: runner
+    attributes:
+      label: Runner image / label
+      description:
+        e.g. `ubuntu-latest`, `windows-2022`, `macos-14`, or your self-hosted
+        runner labels.
+      placeholder: ubuntu-latest
+    validations:
+      required: false
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened?
+      description:
+        Include the relevant error output. For private repositories or
+        self-hosted runners, please provide a public reproducer or redacted
+        logs.
+    validations:
+      required: true
+  - type: input
+    id: reproducer
+    attributes:
+      label: Link to a failing run or minimal reproducer
+      description:
+        A link to a public workflow run or a small demo repository makes this
+        much easier to debug.
+      placeholder: https://github.com/<you>/<repo>/actions/runs/<id>
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description:
+        Paste relevant (redacted) logs here. Enabling [step debug
+        logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging)
+        gives more detail.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation (README)
+    url: https://github.com/conda-incubator/setup-miniconda#readme
+    about:
+      Please read the README first, especially the IMPORTANT section on shell
+      activation. Many questions are answered there.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,41 @@
+name: Documentation issue
+description: Report missing, unclear, or incorrect documentation
+labels: ["task:documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the docs!
+  - type: checkboxes
+    id: prechecks
+    attributes:
+      label: Before you start
+      options:
+        - label:
+            I have read the relevant parts of the
+            [README](https://github.com/conda-incubator/setup-miniconda#readme),
+            including the
+            [IMPORTANT](https://github.com/conda-incubator/setup-miniconda#important)
+            section, and the information is still missing, unclear, or wrong.
+          required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Which docs are affected?
+      description:
+        Link to the section or file (for example a README anchor) that is
+        missing, unclear, or incorrect.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is missing, unclear, or incorrect?
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: Feature request
+description: Suggest an idea or enhancement for the action
+labels: ["type:enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please describe the problem you
+        are trying to solve and how the change could be validated.
+  - type: checkboxes
+    id: prechecks
+    attributes:
+      label: Before you start
+      options:
+        - label:
+            I have read the
+            [README](https://github.com/conda-incubator/setup-miniconda#readme)
+            and this is not already supported.
+          required: true
+        - label:
+            I have searched [existing
+            issues](https://github.com/conda-incubator/setup-miniconda/issues)
+            and this has not been requested yet.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and what is getting in the way?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description:
+        What would you like the action to do? A new input, behavior, or docs?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Would you be willing to contribute this?
+      description:
+        Is this a request, or are you planning to open a pull request?
+      options:
+        - This is a request for the maintainers to consider
+        - I am planning to open a pull request
+        - I could help with guidance
+    validations:
+      required: true
+  - type: textarea
+    id: testing
+    attributes:
+      label: How could this be tested?
+      description:
+        How would we verify the feature works, e.g. a new example workflow under
+        `.github/workflows/example-*.yml`?
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+Thanks for contributing! Please keep the description short and focused, and
+fill in the checklist below. See CONTRIBUTING.md for details.
+-->
+
+## Description
+
+<!-- What does this PR do and why? -->
+
+## Related issue
+
+<!--
+For larger changes, please open an issue to discuss first.
+Link the issue this addresses, e.g. "Closes #123".
+-->
+
+Closes #
+
+## Checklist
+
+- [ ] For a large change, I opened an issue first to discuss it
+- [ ] This PR targets the `main` branch
+- [ ] I ran `npm run format` and `npm run check` (lint and format pass)
+- [ ] I ran `npm run build` and committed the rebuilt `dist/` files
+- [ ] I updated `CHANGELOG.md`
+- [ ] I updated the docs (`README.md`) and/or added an example workflow where
+      relevant
+- [ ] I added or updated tests and they pass (`npm test`)


### PR DESCRIPTION
## Summary

Adds GitHub issue forms and a pull request template, as requested in #159. No code changes.

## What's included

- **`.github/PULL_REQUEST_TEMPLATE.md`** — checklist covering: open an issue first for large changes, link the fixed issue, target `main`, run `npm run format` / `npm run check`, run `npm run build` and commit `dist/`, update `CHANGELOG.md`, update docs/examples, and add/run tests.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — requires the exact `with:` YAML (rendered as YAML) and the runner OS, and asks for a public reproducer or redacted logs for private/self-hosted runners. Auto-labels `type:bug`.
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — asks whether it is a request or a planned PR, and how the feature could be tested. Auto-labels `type:enhancement`.
- **`.github/ISSUE_TEMPLATE/documentation.yml`** — requires confirming the README / IMPORTANT section was read first. Auto-labels `task:documentation`.
- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues and links to the README. Discussions are disabled on this repo, so there is no Discussions link.

## Notes

- The issue chooser and PR template render once this is on the default branch (`main`).
- The PR checklist targets `main`, updating the 2021 reference to a `dev` branch in #159 to match the current `CONTRIBUTING.md`.
- `npm run check` passes.

Closes #159
