### PR TITLE
fix: redact anaconda.org tokens in logs, condarc, and env-file dumps

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -33646,7 +33646,7 @@ function exportVariable(name, val) {
  * ```
  */
 function core_setSecret(secret) {
-    issueCommand('add-mask', {}, secret);
+    command_issueCommand('add-mask', {}, secret);
 }
 /**
  * Prepends inputPath to the PATH (for this action and future actions)
@@ -37507,6 +37507,52 @@ function makeSpec(pkg, spec) {
     }
 }
 
+;// CONCATENATED MODULE: ./src/redact.ts
+/**
+ * @module redact
+ * Helpers for masking anaconda.org channel tokens so they never leak into
+ * build logs or action outputs.
+ *
+ * Channel URLs may carry a token, e.g.
+ * `https://conda.anaconda.org/t/<token>/<channel>`. These helpers live in a
+ * dedicated module used only by the setup-side code, so they are not bundled
+ * into the post/delete action where they would be unused.
+ *
+ * @category Utilities
+ */
+/**
+ * Find anaconda.org channel tokens embedded in a string.
+ *
+ * The returned raw tokens should be registered with `core.setSecret` before
+ * anything is logged so the runner masks them everywhere.
+ *
+ * @param text - Arbitrary text that may contain `/t/<token>/` channel URLs.
+ * @returns The token values found (may contain duplicates).
+ */
+function findTokens(text) {
+    const tokens = [];
+    for (const match of text.matchAll(/\/t\/([^/\s'"]+)/g)) {
+        const token = match[1];
+        if (token) {
+            tokens.push(token);
+        }
+    }
+    return tokens;
+}
+/**
+ * Redact anaconda.org channel tokens so a string is safe to log.
+ *
+ * Replaces the `<token>` in `/t/<token>/` with `***`, leaving the rest of the
+ * URL intact. The value written to disk should keep the real token; only
+ * logged output should be redacted.
+ *
+ * @param text - Arbitrary text that may contain `/t/<token>/` channel URLs.
+ * @returns The text with any channel tokens replaced by `***`.
+ */
+function redactTokens(text) {
+    return text.replace(/(\/t\/)[^/\s'"]+/g, "$1***");
+}
+
 ;// CONCATENATED MODULE: ./src/conda.ts
 /**
  * @module conda
@@ -37527,6 +37573,7 @@ var conda_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _ar
 //-----------------------------------------------------------------------
 // Conda helpers
 //-----------------------------------------------------------------------
+
 
 
 
@@ -37758,6 +37805,14 @@ function writeCondaConfig(inputs, options) {
             }
         }
         config["notify_outdated_conda"] = false;
+        // Register any anaconda.org tokens in user-provided config as secrets up
+        // front, before anything is logged, so the runner masks them everywhere
+        // (e.g. token-bearing values like `channel_alias`).
+        for (const value of Object.values(inputs.condaConfig)) {
+            for (const token of findTokens(value)) {
+                core_setSecret(token);
+            }
+        }
         // --- Channels ---
         let channels = inputs.condaConfig.channels
             .trim()
@@ -37804,7 +37859,11 @@ function writeCondaConfig(inputs, options) {
                 "Otherwise, consider setting 'conda-remove-defaults' to 'true'.");
         }
         for (const ch of config["channels"] || []) {
-            info(`Channel: '${ch}'`);
+            // Mask any anaconda.org channel tokens before logging so they never leak.
+            for (const token of findTokens(ch)) {
+                core_setSecret(token);
+            }
+            info(`Channel: '${redactTokens(ch)}'`);
         }
         // --- Package directories ---
         const inputPkgsDirs = parsePkgsDirs(inputs.condaConfig.pkgs_dirs);
@@ -37843,7 +37902,7 @@ function writeCondaConfig(inputs, options) {
             }
             const coerced = coerceConfigValue(key, value);
             config[key] = coerced;
-            info(`${key}: ${coerced}`);
+            info(`${key}: ${redactTokens(String(coerced))}`);
         }
         // Strip 'defaults' from prefix-level condarc files too
         if (removeDefaults && !userExplicitlyAddedDefaults) {
@@ -37878,9 +37937,28 @@ function writeCondaConfig(inputs, options) {
             }
         }
         const configYaml = dump(config, { lineWidth: -1 });
-        info(`Writing condarc to ${CONDARC_PATH}:\n${configYaml}`);
+        // Register any embedded anaconda.org tokens as secrets and redact them from
+        // the log; the file on disk keeps the real values so conda can use them.
+        for (const token of findTokens(configYaml)) {
+            core_setSecret(token);
+        }
+        info(`Writing condarc to ${CONDARC_PATH}:\n${redactTokens(configYaml)}`);
         external_fs_namespaceObject.writeFileSync(CONDARC_PATH, configYaml, "utf8");
         if (isDebug()) {
+            // `conda config --show` streams the *effective* config, which merges
+            // prefix-level condarc files we did not generate. Register any tokens they
+            // carry as secrets first so they are masked in the debug output too.
+            const basePath = condaBasePath(inputs, options);
+            for (const condarcPath of [
+                external_path_namespaceObject.join(basePath, ".condarc"),
+                external_path_namespaceObject.join(basePath, "condarc"),
+            ]) {
+                if (!external_fs_namespaceObject.existsSync(condarcPath))
+                    continue;
+                for (const token of findTokens(external_fs_namespaceObject.readFileSync(condarcPath, "utf8"))) {
+                    core_setSecret(token);
+                }
+            }
             yield condaCommand(["config", "--show"], inputs, options);
         }
     });
@@ -39497,6 +39575,7 @@ var yaml_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arg
 
 
 
+
 /**
  * The current known providers of patches to `environment.yml`
  *
@@ -39566,13 +39645,27 @@ const ensureYaml = {
             const origParent = external_path_namespaceObject.dirname(origPath);
             envFile = external_path_namespaceObject.join(origParent, `setup-miniconda-patched-${external_path_namespaceObject.basename(origPath)}`);
             info(`Making patched copy of 'environment-file: ${inputs.environmentFile}'`);
-            info(`Using: ${envFile}\n${patchedYaml}`);
+            // Mask any anaconda.org channel tokens before logging the patched env.
+            for (const token of findTokens(patchedYaml)) {
+                core_setSecret(token);
+            }
+            info(`Using: ${envFile}\n${redactTokens(patchedYaml)}`);
             external_fs_namespaceObject.writeFileSync(envFile, patchedYaml, "utf8");
-            setEnvironmentFileOutputs(envFile, dump(patchedYaml), true);
+            // Redact the output value too: setSecret only masks logs, not the
+            // action output that downstream steps can read. patchedYaml is already
+            // YAML, so it must not be dumped again.
+            setEnvironmentFileOutputs(envFile, redactTokens(patchedYaml), true);
         }
         else {
             info(`Using 'environment-file: ${inputs.environmentFile}' as-is`);
-            setEnvironmentFileOutputs(envFile, external_fs_namespaceObject.readFileSync(inputs.environmentFile, "utf-8"));
+            const originalContent = external_fs_namespaceObject.readFileSync(inputs.environmentFile, "utf8");
+            // Mask any anaconda.org channel tokens carried by the environment file,
+            // and redact the output value so the token is not exposed via the
+            // environment-file-content output (setSecret only masks logs).
+            for (const token of findTokens(originalContent)) {
+                core_setSecret(token);
+            }
+            setEnvironmentFileOutputs(envFile, redactTokens(originalContent));
         }
         const [flag, nameOrPath] = envCommandFlag(inputs);
         let subcommand;

--- a/src/__tests__/conda.test.ts
+++ b/src/__tests__/conda.test.ts
@@ -9,6 +9,7 @@ vi.mock("@actions/core", () => ({
   info: vi.fn(),
   warning: vi.fn(),
   isDebug: vi.fn(() => false),
+  setSecret: vi.fn(),
 }));
 
 // Mock @actions/io
@@ -126,6 +127,40 @@ describe("writeCondaConfig", () => {
 
     const config = getWrittenConfig();
     expect(config["channels"]).toContain("conda-forge");
+  });
+
+  it("masks and redacts anaconda.org channel tokens (#519)", async () => {
+    const core = await import("@actions/core");
+    vi.mocked(core.setSecret).mockClear();
+    vi.mocked(core.info).mockClear();
+
+    const { writeCondaConfig } = await import("../conda");
+    const token = "tk-secret-abc123";
+    const channel = `https://conda.anaconda.org/t/${token}/my-private-channel`;
+    const inputs = makeInputs({ channels: channel });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    // The token must be registered as a secret before logging.
+    expect(vi.mocked(core.setSecret)).toHaveBeenCalledWith(token);
+
+    // The raw token must never appear in any logged output...
+    const logged = vi
+      .mocked(core.info)
+      .mock.calls.map((c) => String(c[0]))
+      .join("\n");
+    expect(logged).not.toContain(token);
+    // ...but the redacted channel is still logged.
+    expect(logged).toContain("/t/***/my-private-channel");
+
+    // The real token is still written to the condarc on disk so conda can use it.
+    const written = vi
+      .mocked(fsMod.writeFileSync)
+      .mock.calls.map((c) => String(c[1]))
+      .join("\n");
+    expect(written).toContain(token);
   });
 
   it("uses channels from envSpec.yaml when input channels are empty", async () => {

--- a/src/__tests__/redact.test.ts
+++ b/src/__tests__/redact.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+import { findTokens, redactTokens } from "../redact";
+
+describe("findTokens", () => {
+  it("extracts a token from an anaconda.org channel URL", () => {
+    expect(
+      findTokens("https://conda.anaconda.org/t/tk-abc-123/my-channel"),
+    ).toEqual(["tk-abc-123"]);
+  });
+
+  it("finds multiple tokens", () => {
+    const text =
+      "https://conda.anaconda.org/t/tok1/a\nhttps://conda.anaconda.org/t/tok2/b";
+    expect(findTokens(text)).toEqual(["tok1", "tok2"]);
+  });
+
+  it("returns an empty array when there is no token", () => {
+    expect(findTokens("https://conda.anaconda.org/conda-forge")).toEqual([]);
+  });
+});
+
+describe("redactTokens", () => {
+  it("replaces the token segment with ***", () => {
+    expect(
+      redactTokens("https://conda.anaconda.org/t/tk-abc-123/my-channel"),
+    ).toBe("https://conda.anaconda.org/t/***/my-channel");
+  });
+
+  it("redacts a token with no trailing channel", () => {
+    expect(redactTokens("https://conda.anaconda.org/t/tk-abc-123")).toBe(
+      "https://conda.anaconda.org/t/***",
+    );
+  });
+
+  it("leaves token-free text untouched", () => {
+    const text = "channels:\n  - conda-forge\n  - defaults";
+    expect(redactTokens(text)).toBe(text);
+  });
+
+  it("redacts tokens inside a multi-line condarc dump", () => {
+    const dump = "channels:\n  - https://conda.anaconda.org/t/sekret/private\n";
+    expect(redactTokens(dump)).not.toContain("sekret");
+    expect(redactTokens(dump)).toContain("/t/***/private");
+  });
+});

--- a/src/__tests__/yaml.test.ts
+++ b/src/__tests__/yaml.test.ts
@@ -10,6 +10,7 @@ import { ensureYaml } from "../env/yaml";
 vi.mock("@actions/core", () => ({
   info: vi.fn(),
   warning: vi.fn(),
+  setSecret: vi.fn(),
 }));
 
 // Mock @actions/io
@@ -102,6 +103,76 @@ describe("ensureYaml python-version patching", () => {
     );
     expect(pythonSpecs).toEqual(["python=3.11"]);
     expect(parsed.dependencies).not.toContain("python=3.9");
+  });
+
+  it("masks and redacts anaconda.org tokens in the patched env dump (#519)", async () => {
+    const core = await import("@actions/core");
+    const token = "tk-secret-xyz789";
+    const yamlData: types.IEnvironment = {
+      name: "test",
+      channels: [`https://conda.anaconda.org/t/${token}/private`],
+      dependencies: ["python=3.9", "numpy"],
+    };
+
+    const inputs = makeInputs({ pythonVersion: "3.11" });
+    await ensureYaml.condaArgs(inputs, makeOptions(yamlData));
+
+    // The token must be registered as a secret before logging.
+    expect(vi.mocked(core.setSecret)).toHaveBeenCalledWith(token);
+
+    // The raw token must never appear in any logged output...
+    const logged = vi
+      .mocked(core.info)
+      .mock.calls.map((c) => String(c[0]))
+      .join("\n");
+    expect(logged).not.toContain(token);
+    // ...but the redacted channel is still logged.
+    expect(logged).toContain("/t/***/private");
+
+    // The patched file on disk keeps the real token so conda can use it.
+    const fs = await import("fs");
+    const written = vi
+      .mocked(fs.writeFileSync)
+      .mock.calls.map((c) => String(c[1]))
+      .join("\n");
+    expect(written).toContain(token);
+
+    // The environment-file-content output must also be redacted: setSecret
+    // masks logs, not the output value downstream steps can read.
+    const outputs = await import("../outputs");
+    const outArgs = vi
+      .mocked(outputs.setEnvironmentFileOutputs)
+      .mock.calls.map((c) => String(c[1]))
+      .join("\n");
+    expect(outArgs).not.toContain(token);
+    expect(outArgs).toContain("/t/***/private");
+  });
+
+  it("masks tokens from an unpatched environment file (#519)", async () => {
+    const core = await import("@actions/core");
+    const fs = await import("fs");
+    const token = "tk-asis-456";
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      `channels:\n  - https://conda.anaconda.org/t/${token}/private\n`,
+    );
+
+    // No pythonVersion => no patch => the "as-is" branch runs.
+    const yamlData: types.IEnvironment = {
+      name: "test",
+      channels: [`https://conda.anaconda.org/t/${token}/private`],
+      dependencies: ["numpy"],
+    };
+    await ensureYaml.condaArgs(makeInputs({}), makeOptions(yamlData));
+
+    expect(vi.mocked(core.setSecret)).toHaveBeenCalledWith(token);
+
+    // The action output must be redacted, not just masked in logs.
+    const outputs = await import("../outputs");
+    const outArgs = vi
+      .mocked(outputs.setEnvironmentFileOutputs)
+      .mock.calls.map((c) => String(c[1]))
+      .join("\n");
+    expect(outArgs).not.toContain(token);
   });
 
   it("preserves name=version=build specs without corruption (#286)", async () => {

--- a/src/conda.ts
+++ b/src/conda.ts
@@ -21,6 +21,7 @@ import * as io from "@actions/io";
 import * as types from "./types";
 import * as constants from "./constants";
 import * as utils from "./utils";
+import * as redact from "./redact";
 
 /**
  * Return the base path of the conda installation, determined by whether
@@ -297,6 +298,15 @@ export async function writeCondaConfig(
 
   config["notify_outdated_conda"] = false;
 
+  // Register any anaconda.org tokens in user-provided config as secrets up
+  // front, before anything is logged, so the runner masks them everywhere
+  // (e.g. token-bearing values like `channel_alias`).
+  for (const value of Object.values(inputs.condaConfig)) {
+    for (const token of redact.findTokens(value)) {
+      core.setSecret(token);
+    }
+  }
+
   // --- Channels ---
   let channels = inputs.condaConfig.channels
     .trim()
@@ -350,7 +360,11 @@ export async function writeCondaConfig(
   }
 
   for (const ch of (config["channels"] as string[]) || []) {
-    core.info(`Channel: '${ch}'`);
+    // Mask any anaconda.org channel tokens before logging so they never leak.
+    for (const token of redact.findTokens(ch)) {
+      core.setSecret(token);
+    }
+    core.info(`Channel: '${redact.redactTokens(ch)}'`);
   }
 
   // --- Package directories ---
@@ -400,7 +414,7 @@ export async function writeCondaConfig(
     }
     const coerced = coerceConfigValue(key, value);
     config[key] = coerced;
-    core.info(`${key}: ${coerced}`);
+    core.info(`${key}: ${redact.redactTokens(String(coerced))}`);
   }
 
   // Strip 'defaults' from prefix-level condarc files too
@@ -448,10 +462,32 @@ export async function writeCondaConfig(
   }
 
   const configYaml = yaml.dump(config, { lineWidth: -1 });
-  core.info(`Writing condarc to ${constants.CONDARC_PATH}:\n${configYaml}`);
+  // Register any embedded anaconda.org tokens as secrets and redact them from
+  // the log; the file on disk keeps the real values so conda can use them.
+  for (const token of redact.findTokens(configYaml)) {
+    core.setSecret(token);
+  }
+  core.info(
+    `Writing condarc to ${constants.CONDARC_PATH}:\n${redact.redactTokens(configYaml)}`,
+  );
   fs.writeFileSync(constants.CONDARC_PATH, configYaml, "utf8");
 
   if (core.isDebug()) {
+    // `conda config --show` streams the *effective* config, which merges
+    // prefix-level condarc files we did not generate. Register any tokens they
+    // carry as secrets first so they are masked in the debug output too.
+    const basePath = condaBasePath(inputs, options);
+    for (const condarcPath of [
+      path.join(basePath, ".condarc"),
+      path.join(basePath, "condarc"),
+    ]) {
+      if (!fs.existsSync(condarcPath)) continue;
+      for (const token of redact.findTokens(
+        fs.readFileSync(condarcPath, "utf8"),
+      )) {
+        core.setSecret(token);
+      }
+    }
     await condaCommand(["config", "--show"], inputs, options);
   }
 }

--- a/src/env/yaml.ts
+++ b/src/env/yaml.ts
@@ -16,6 +16,7 @@ import * as types from "../types";
 import * as constants from "../constants";
 import * as conda from "../conda";
 import * as utils from "../utils";
+import * as redact from "../redact";
 import * as outputs from "../outputs";
 
 /**
@@ -124,14 +125,32 @@ export const ensureYaml: types.IEnvProvider = {
       core.info(
         `Making patched copy of 'environment-file: ${inputs.environmentFile}'`,
       );
-      core.info(`Using: ${envFile}\n${patchedYaml}`);
+      // Mask any anaconda.org channel tokens before logging the patched env.
+      for (const token of redact.findTokens(patchedYaml)) {
+        core.setSecret(token);
+      }
+      core.info(`Using: ${envFile}\n${redact.redactTokens(patchedYaml)}`);
       fs.writeFileSync(envFile, patchedYaml, "utf8");
-      outputs.setEnvironmentFileOutputs(envFile, yaml.dump(patchedYaml), true);
-    } else {
-      core.info(`Using 'environment-file: ${inputs.environmentFile}' as-is`);
+      // Redact the output value too: setSecret only masks logs, not the
+      // action output that downstream steps can read. patchedYaml is already
+      // YAML, so it must not be dumped again.
       outputs.setEnvironmentFileOutputs(
         envFile,
-        fs.readFileSync(inputs.environmentFile, "utf-8"),
+        redact.redactTokens(patchedYaml),
+        true,
+      );
+    } else {
+      core.info(`Using 'environment-file: ${inputs.environmentFile}' as-is`);
+      const originalContent = fs.readFileSync(inputs.environmentFile, "utf8");
+      // Mask any anaconda.org channel tokens carried by the environment file,
+      // and redact the output value so the token is not exposed via the
+      // environment-file-content output (setSecret only masks logs).
+      for (const token of redact.findTokens(originalContent)) {
+        core.setSecret(token);
+      }
+      outputs.setEnvironmentFileOutputs(
+        envFile,
+        redact.redactTokens(originalContent),
       );
     }
     const [flag, nameOrPath] = conda.envCommandFlag(inputs);

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,0 +1,46 @@
+/**
+ * @module redact
+ * Helpers for masking anaconda.org channel tokens so they never leak into
+ * build logs or action outputs.
+ *
+ * Channel URLs may carry a token, e.g.
+ * `https://conda.anaconda.org/t/<token>/<channel>`. These helpers live in a
+ * dedicated module used only by the setup-side code, so they are not bundled
+ * into the post/delete action where they would be unused.
+ *
+ * @category Utilities
+ */
+
+/**
+ * Find anaconda.org channel tokens embedded in a string.
+ *
+ * The returned raw tokens should be registered with `core.setSecret` before
+ * anything is logged so the runner masks them everywhere.
+ *
+ * @param text - Arbitrary text that may contain `/t/<token>/` channel URLs.
+ * @returns The token values found (may contain duplicates).
+ */
+export function findTokens(text: string): string[] {
+  const tokens: string[] = [];
+  for (const match of text.matchAll(/\/t\/([^/\s'"]+)/g)) {
+    const token = match[1];
+    if (token) {
+      tokens.push(token);
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Redact anaconda.org channel tokens so a string is safe to log.
+ *
+ * Replaces the `<token>` in `/t/<token>/` with `***`, leaving the rest of the
+ * URL intact. The value written to disk should keep the real token; only
+ * logged output should be redacted.
+ *
+ * @param text - Arbitrary text that may contain `/t/<token>/` channel URLs.
+ * @returns The text with any channel tokens replaced by `***`.
+ */
+export function redactTokens(text: string): string {
+  return text.replace(/(\/t\/)[^/\s'"]+/g, "$1***");
+}


### PR DESCRIPTION
Closes #519

## Summary

Anaconda.org channel URLs can embed a token (`https://conda.anaconda.org/t/<token>/<channel>`). The action logged each channel, dumped the full effective condarc and the patched environment file to the build log, and exposed the environment-file content as an output. On public repositories those logs are world-readable, so a token could leak and grant access to private channels. This masks and redacts tokens everywhere they could surface.

## Changes

Two reusable helpers in a new `src/redact.ts` module:

- `findTokens(text)` — extracts `/t/<token>/` channel tokens
- `redactTokens(text)` — replaces the token segment with `***`, leaving the rest of the URL intact

Wired into every leak path so each token is registered with `core.setSecret` **before** any logging (so the runner masks it everywhere downstream, including `conda config --show`) and the displayed string is redacted:

| Site | File |
|------|------|
| Per-channel log (`Channel: '…'`) | `src/conda.ts` |
| Full condarc dump | `src/conda.ts` |
| Patched env-file dump (`Using: …`) | `src/env/yaml.ts` |
| `environment-file-content` output (unpatched path) | `src/env/yaml.ts` |

The real token is still written to `~/.condarc` and the patched env file on disk, so conda keeps working; only logged output and the action output are masked.

## Tests

- `redact.test.ts` — unit tests for `findTokens` / `redactTokens`
- `conda.test.ts` — a token passed via a channel URL is `setSecret`-masked and never appears unmasked in `core.info`, while the real value is still written to disk
- `yaml.test.ts` — same assertions for the patched env dump, plus token masking for the unpatched environment-file content output

## Verification

- `npm test` → all pass (424 tests)
- `npm run check` → pass (prettier + eslint)
- `npm run build` → pass; `dist/setup/index.js` + `dist/delete/index.js` regenerated and committed


