### PR TITLE
feat(security): verify installer-url via installer-sha256 and deprecate http

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,14 @@ jobs:
           conda config --show
 ```
 
+> [!NOTE]
+>
+> A custom `installer-url` is downloaded and executed on the runner. To verify
+> its integrity, set `installer-sha256` to the installer's expected SHA-256; the
+> run aborts on mismatch. If it is omitted, a warning is emitted that the
+> installer is unverified. Plain `http` URLs are deprecated, since a network
+> attacker could swap the installer; prefer `https` and/or `installer-sha256`.
+
 ### Example 6: Mamba
 
 > Note: `conda` 23.10+ uses `conda-libmamba-solver` by default, which provides

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,15 @@ inputs:
       installers"
     required: false
     default: ""
+  installer-sha256:
+    description:
+      "Optional expected SHA-256 (hex) of the 'installer-url' file. When
+      provided, the downloaded installer is verified against this digest and the
+      run aborts on mismatch. When omitted, a warning is emitted that the
+      installer is not integrity-verified. Plain 'http' installer URLs are
+      deprecated; prefer 'https' and/or this checksum."
+    required: false
+    default: ""
   installation-dir:
     description:
       "If provided, the installer will be installed in the given directory."

--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -34075,6 +34075,10 @@ const RULES = [
     (i) => !!(i.installerUrl &&
         !KNOWN_EXTENSIONS.includes(urlExt(i.installerUrl))) &&
         `'installer-url' extension '${urlExt(i.installerUrl)}' must be one of: ${KNOWN_EXTENSIONS}`,
+    (i) => !!(i.installerSha256 && !i.installerUrl) &&
+        `'installer-sha256' requires 'installer-url' to be set`,
+    (i) => !!(i.installerSha256 && !/^[0-9a-f]{64}$/i.test(i.installerSha256.trim())) &&
+        `'installer-sha256: ${i.installerSha256}' must be a 64-character hex SHA-256 digest`,
     (i) => !!(i.architecture === "x86" && !constants_IS_WINDOWS) &&
         `'architecture: ${i.architecture}' is only available for recent versions on Windows`,
     (i) => !!(!["latest", ""].includes(i.minicondaVersion) &&
@@ -34114,6 +34118,7 @@ function parseInputs() {
             condaVersion: getInput("conda-version"),
             environmentFile: getInput("environment-file"),
             installerUrl: getInput("installer-url"),
+            installerSha256: getInput("installer-sha256"),
             installationDir: getInput("installation-dir"),
             mambaVersion: getInput("mamba-version"),
             useMamba: getInput("use-mamba"),

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -34118,6 +34118,10 @@ const RULES = [
     (i) => !!(i.installerUrl &&
         !KNOWN_EXTENSIONS.includes(urlExt(i.installerUrl))) &&
         `'installer-url' extension '${urlExt(i.installerUrl)}' must be one of: ${KNOWN_EXTENSIONS}`,
+    (i) => !!(i.installerSha256 && !i.installerUrl) &&
+        `'installer-sha256' requires 'installer-url' to be set`,
+    (i) => !!(i.installerSha256 && !/^[0-9a-f]{64}$/i.test(i.installerSha256.trim())) &&
+        `'installer-sha256: ${i.installerSha256}' must be a 64-character hex SHA-256 digest`,
     (i) => !!(i.architecture === "x86" && !constants_IS_WINDOWS) &&
         `'architecture: ${i.architecture}' is only available for recent versions on Windows`,
     (i) => !!(!["latest", ""].includes(i.minicondaVersion) &&
@@ -34157,6 +34161,7 @@ function parseInputs() {
             condaVersion: getInput("conda-version"),
             environmentFile: getInput("environment-file"),
             installerUrl: getInput("installer-url"),
+            installerSha256: getInput("installer-sha256"),
             installationDir: getInput("installation-dir"),
             mambaVersion: getInput("mamba-version"),
             useMamba: getInput("use-mamba"),
@@ -34218,7 +34223,7 @@ function parseInputs() {
 }
 
 ;// CONCATENATED MODULE: ./node_modules/js-yaml/dist/js-yaml.mjs
-/*! js-yaml 5.2.1 https://github.com/nodeca/js-yaml @license MIT */
+/*! js-yaml 5.1.0 https://github.com/nodeca/js-yaml @license MIT */
 //#region src/tag.ts
 var NOT_RESOLVED = Symbol("NOT_RESOLVED");
 var MERGE_KEY = Symbol("MERGE_KEY");
@@ -34460,7 +34465,7 @@ var intCoreTag = defineScalarTag("tag:yaml.org,2002:int", {
 		..."0123456789"
 	],
 	resolve: resolveYamlInteger$2,
-	identify: (object) => Number.isInteger(object) && !Object.is(object, -0) && object.toString(10).indexOf("e") < 0,
+	identify: (object) => Object.prototype.toString.call(object) === "[object Number]" && object % 1 === 0 && !Object.is(object, -0),
 	represent: (object) => object.toString(10)
 });
 //#endregion
@@ -34490,7 +34495,7 @@ var intJsonTag = defineScalarTag("tag:yaml.org,2002:int", {
 	implicit: true,
 	implicitFirstChars: ["-", ..."0123456789"],
 	resolve: resolveYamlInteger$1,
-	identify: (object) => Number.isInteger(object) && !Object.is(object, -0) && object.toString(10).indexOf("e") < 0,
+	identify: (object) => Object.prototype.toString.call(object) === "[object Number]" && object % 1 === 0 && !Object.is(object, -0),
 	represent: (object) => object.toString(10)
 });
 //#endregion
@@ -34526,7 +34531,7 @@ var intYaml11Tag = defineScalarTag("tag:yaml.org,2002:int", {
 		..."0123456789"
 	],
 	resolve: resolveYamlInteger,
-	identify: (object) => Number.isInteger(object) && !Object.is(object, -0) && object.toString(10).indexOf("e") < 0,
+	identify: (object) => Object.prototype.toString.call(object) === "[object Number]" && object % 1 === 0 && !Object.is(object, -0),
 	represent: (object) => object.toString(10)
 });
 //#endregion
@@ -34561,7 +34566,7 @@ var floatCoreTag = defineScalarTag("tag:yaml.org,2002:float", {
 		..."0123456789"
 	],
 	resolve: resolveYamlFloat$2,
-	identify: (object) => typeof object === "number" && (!Number.isInteger(object) || Object.is(object, -0) || object.toString(10).indexOf("e") >= 0),
+	identify: (object) => Object.prototype.toString.call(object) === "[object Number]" && (object % 1 !== 0 || Object.is(object, -0)),
 	represent: representYamlFloat$2
 });
 //#endregion
@@ -34596,7 +34601,7 @@ var floatJsonTag = defineScalarTag("tag:yaml.org,2002:float", {
 	implicit: true,
 	implicitFirstChars: ["-", ..."0123456789"],
 	resolve: resolveYamlFloat$1,
-	identify: (object) => typeof object === "number" && (!Number.isInteger(object) || Object.is(object, -0) || object.toString(10).indexOf("e") >= 0),
+	identify: (object) => Object.prototype.toString.call(object) === "[object Number]" && (object % 1 !== 0 || Object.is(object, -0)),
 	represent: representYamlFloat$1
 });
 //#endregion
@@ -34635,7 +34640,7 @@ var floatYaml11Tag = defineScalarTag("tag:yaml.org,2002:float", {
 		..."0123456789"
 	],
 	resolve: resolveYamlFloat,
-	identify: (object) => typeof object === "number" && (!Number.isInteger(object) || Object.is(object, -0) || object.toString(10).indexOf("e") >= 0),
+	identify: (object) => Object.prototype.toString.call(object) === "[object Number]" && (object % 1 !== 0 || Object.is(object, -0)),
 	represent: representYamlFloat
 });
 //#endregion
@@ -34723,40 +34728,18 @@ var seqTag = defineSequenceTag("tag:yaml.org,2002:seq", {
 	identify: Array.isArray
 });
 //#endregion
-//#region src/common/object.ts
-function isPlainObject(data) {
-	if (data === null || typeof data !== "object" || Array.isArray(data)) return false;
-	const prototype = Object.getPrototypeOf(data);
-	return prototype === null || prototype === Object.prototype;
-}
-function pick(object, keys) {
-	const result = {};
-	for (const key of keys) if (object[key] !== void 0) result[key] = object[key];
-	return result;
-}
-//#endregion
 //#region src/tag/sequence/omap.ts
 var omapTag = defineSequenceTag("tag:yaml.org,2002:omap", {
-	create: () => ({
-		list: [],
-		seen: /* @__PURE__ */ new Set()
-	}),
-	addItem: (carrier, item) => {
-		let key;
-		if (item instanceof Map) {
-			if (item.size !== 1) return "cannot resolve an ordered map item";
-			key = item.keys().next().value;
-		} else if (isPlainObject(item)) {
-			const itemKeys = Object.keys(item);
-			if (itemKeys.length !== 1) return "cannot resolve an ordered map item";
-			key = itemKeys[0];
-		} else return "cannot resolve an ordered map item";
-		if (carrier.seen.has(key)) return "duplicate key in ordered map";
-		carrier.seen.add(key);
-		carrier.list.push(item);
+	create: () => [],
+	addItem: (container, item) => {
+		if (Object.prototype.toString.call(item) !== "[object Object]") return "cannot resolve an ordered map item";
+		const object = item;
+		const itemKeys = Object.keys(object);
+		if (itemKeys.length !== 1) return "cannot resolve an ordered map item";
+		for (const existing of container) if (Object.prototype.hasOwnProperty.call(existing, itemKeys[0])) return "cannot resolve an ordered map item";
+		container.push(object);
 		return "";
-	},
-	finalize: (carrier) => carrier.list
+	}
 });
 //#endregion
 //#region src/tag/sequence/pairs.ts
@@ -34776,6 +34759,18 @@ var pairsTag = defineSequenceTag("tag:yaml.org,2002:pairs", {
 		return "";
 	}
 });
+//#endregion
+//#region src/common/object.ts
+function isPlainObject(data) {
+	if (data === null || typeof data !== "object" || Array.isArray(data)) return false;
+	const prototype = Object.getPrototypeOf(data);
+	return prototype === null || prototype === Object.prototype;
+}
+function pick(object, keys) {
+	const result = {};
+	for (const key of keys) if (object[key] !== void 0) result[key] = object[key];
+	return result;
+}
 //#endregion
 //#region src/tag/mapping/map.ts
 var mapTag = defineMappingTag("tag:yaml.org,2002:map", {
@@ -35366,8 +35361,7 @@ var DEFAULT_CONSTRUCTOR_OPTIONS = {
 	filename: "",
 	schema: CORE_SCHEMA,
 	json: false,
-	maxTotalMergeKeys: 1e4,
-	maxAliases: -1
+	maxMergeSeqLength: 20
 };
 function eventPosition$1(event) {
 	if ("tagStart" in event && event.tagStart !== NO_RANGE$2) return event.tagStart;
@@ -35455,7 +35449,6 @@ function isMappingTag(tag) {
 }
 function mergeKeys(state, frame, source, sourceTag) {
 	for (const sourceKey of sourceTag.keys(source)) {
-		if (state.maxTotalMergeKeys !== -1 && ++state.totalMergeKeys > state.maxTotalMergeKeys) throwError$1(state, `merge keys exceeded maxTotalMergeKeys (${state.maxTotalMergeKeys})`);
 		if (frame.tag.has(frame.value, sourceKey)) continue;
 		const err = frame.tag.addPair(frame.value, sourceKey, sourceTag.get(source, sourceKey));
 		if (err) throwError$1(state, err);
@@ -35465,8 +35458,14 @@ function mergeKeys(state, frame, source, sourceTag) {
 function mergeSource(state, frame, source, sourceTag) {
 	state.position = frame.keyPosition;
 	if (isMappingTag(sourceTag)) mergeKeys(state, frame, source, sourceTag);
-	else if (sourceTag.nodeKind === "sequence" && Array.isArray(source)) for (const element of source) mergeKeys(state, frame, element, frame.tag);
-	else throwError$1(state, "cannot merge mappings; the provided source object is unacceptable");
+	else if (sourceTag.nodeKind === "sequence" && Array.isArray(source)) {
+		const seen = /* @__PURE__ */ new Set();
+		for (const element of source) {
+			if (seen.has(element)) continue;
+			seen.add(element);
+			mergeKeys(state, frame, element, frame.tag);
+		}
+	} else throwError$1(state, "cannot merge mappings; the provided source object is unacceptable");
 }
 function addMappingValue(state, frame, key, value, tag) {
 	state.position = frame.keyPosition;
@@ -35487,6 +35486,7 @@ function addValue(state, value, tag) {
 	} else if (frame.kind === "sequence") {
 		if (frame.merge) {
 			if (!isMappingTag(tag)) throwError$1(state, "cannot merge mappings; the provided source object is unacceptable");
+			if (frame.index >= state.maxMergeSeqLength) throwError$1(state, `merge sequence length exceeded maxMergeSeqLength (${state.maxMergeSeqLength})`);
 		}
 		const err = frame.tag.addItem(frame.value, value, frame.index++);
 		if (err) throwError$1(state, err);
@@ -35523,9 +35523,7 @@ function constructFromEvents(events, options) {
 		position: 0,
 		frames: [],
 		anchors: /* @__PURE__ */ new Map(),
-		tagHandlers: Object.create(null),
-		totalMergeKeys: 0,
-		aliasCount: 0
+		tagHandlers: Object.create(null)
 	};
 	while (state.eventIndex < state.events.length) {
 		const event = state.events[state.eventIndex++];
@@ -35533,7 +35531,6 @@ function constructFromEvents(events, options) {
 		switch (event.type) {
 			case 1:
 				state.anchors = /* @__PURE__ */ new Map();
-				state.aliasCount = 0;
 				state.tagHandlers = Object.create(null);
 				for (const directive of event.directives) if (directive.kind === "tag") state.tagHandlers[directive.handle] = directive.prefix;
 				state.frames.push({
@@ -35584,7 +35581,6 @@ function constructFromEvents(events, options) {
 				break;
 			}
 			case 5: {
-				if (state.maxAliases !== -1 && ++state.aliasCount > state.maxAliases) throwError$1(state, `aliases exceeded maxAliases (${state.maxAliases})`);
 				const name = state.source.slice(event.anchorStart, event.anchorEnd);
 				const anchor = state.anchors.get(name);
 				if (!anchor) throwError$1(state, `unidentified alias "${name}"`);
@@ -38996,6 +38992,7 @@ var base_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arg
 
 
 
+
 /**
  * Get the path for a locally-executable installer from cache, or as downloaded.
  *
@@ -39023,19 +39020,33 @@ function ensureLocalInstaller(options) {
     return base_awaiter(this, void 0, void 0, function* () {
         info("Ensuring Installer...");
         const url = new external_url_namespaceObject.URL(options.url);
+        if (url.protocol === "http:") {
+            warning(`'installer-url' uses insecure 'http:'. This is deprecated and will be ` +
+                `rejected in a future major version; use 'https:' and/or set ` +
+                `'installer-sha256'. A network attacker could otherwise replace the installer.`);
+        }
         const installerName = external_path_namespaceObject.basename(url.pathname);
         // As a URL, we assume posix paths
         const installerExtension = external_path_namespaceObject.posix.extname(installerName);
         const tool = options.tool != null ? options.tool : installerName;
         // Create a fake version if neccessary
-        const version = options.version != null
+        let version = options.version != null
             ? options.version
             : "0.0.0-" +
                 external_crypto_namespaceObject.createHash("sha256").update(options.url).digest("hex");
+        // Fold the expected checksum into the cache version so that changing
+        // `installer-sha256` for the same URL misses any stale cache entry and
+        // re-downloads, instead of verifying the old cached file and failing.
+        if (options.sha256) {
+            version = `${version}-sha256.${options.sha256.trim().toLowerCase()}`;
+        }
         let executablePath = "";
         if (url.protocol === "file:") {
             info(`Local file specified, using in-place...`);
             executablePath = (0,external_url_namespaceObject.fileURLToPath)(options.url);
+            if (options.sha256) {
+                yield verifyChecksum(executablePath, options.sha256);
+            }
         }
         if (executablePath === "") {
             info(`Checking for cached ${tool}@${version}...`);
@@ -39054,6 +39065,9 @@ function ensureLocalInstaller(options) {
                 // returned by tc.find
                 executablePath = external_path_namespaceObject.join(cacheDirectoryPath, installerName);
                 info(`executablePath is ${executablePath}`);
+                if (options.sha256) {
+                    yield verifyChecksum(executablePath, options.sha256);
+                }
             }
             else {
                 info(`Did not find ${installerName} ${version} in cache`);
@@ -39065,11 +39079,42 @@ function ensureLocalInstaller(options) {
             // Always ensure the installer ends with a known path
             executablePath = rawDownloadPath + installerExtension;
             yield mv(rawDownloadPath, executablePath);
+            // Verify before caching so a tampered installer is never written into the
+            // tool cache (which persists across runs on self-hosted runners).
+            if (options.sha256) {
+                yield verifyChecksum(executablePath, options.sha256);
+            }
             info(`Caching ${tool}@${version}...`);
             const cacheResult = yield cacheFile(executablePath, installerName, tool, version, ...(options.arch ? [options.arch] : []));
             info(`Cached ${tool}@${version}: ${cacheResult}!`);
         }
         return executablePath;
+    });
+}
+/**
+ * Verify a file's SHA-256 against an expected hex digest, failing closed.
+ *
+ * @param filePath - Path to the file to hash.
+ * @param expected - Expected SHA-256 as a hex string (case-insensitive).
+ * @throws {Error} If the computed digest does not match `expected`.
+ */
+function verifyChecksum(filePath, expected) {
+    return base_awaiter(this, void 0, void 0, function* () {
+        const hash = external_crypto_namespaceObject.createHash("sha256");
+        yield new Promise((resolve, reject) => {
+            const stream = external_fs_namespaceObject.createReadStream(filePath);
+            stream.on("error", reject);
+            stream.on("data", (chunk) => hash.update(chunk));
+            stream.on("end", () => resolve());
+        });
+        const actual = hash.digest("hex");
+        const normalizedExpected = expected.trim().toLowerCase();
+        if (actual !== normalizedExpected) {
+            throw new Error(`Installer checksum mismatch: expected sha256 '${normalizedExpected}' ` +
+                `but the file hashed to '${actual}'. The installer may be corrupted ` +
+                `or tampered with; aborting.`);
+        }
+        info(`Verified installer sha256: ${actual}`);
     });
 }
 
@@ -39253,6 +39298,7 @@ var download_url_awaiter = (undefined && undefined.__awaiter) || function (thisA
     });
 };
 
+
 /**
  * Provide a path to a `constructor`-compatible installer downloaded from
  * any URL, including `file://` URLs.
@@ -39264,10 +39310,13 @@ const urlDownloader = {
     label: "download a custom installer by URL",
     provides: (inputs, _options) => download_url_awaiter(void 0, void 0, void 0, function* () { return !!inputs.installerUrl; }),
     installerPath: (inputs, options) => download_url_awaiter(void 0, void 0, void 0, function* () {
+        if (!inputs.installerSha256) {
+            warning(`'installer-url' was provided without 'installer-sha256'. The installer ` +
+                `will be executed without integrity verification; set 'installer-sha256' ` +
+                `to the expected SHA-256 to verify it.`);
+        }
         return {
-            localInstallerPath: yield ensureLocalInstaller({
-                url: inputs.installerUrl,
-            }),
+            localInstallerPath: yield ensureLocalInstaller(Object.assign({ url: inputs.installerUrl }, (inputs.installerSha256 ? { sha256: inputs.installerSha256 } : {}))),
             options: Object.assign(Object.assign({}, options), { useBundled: false }),
         };
     }),

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -73,6 +73,7 @@ export function makeActionInputs(
     condaVersion: "",
     environmentFile: "",
     installerUrl: "",
+    installerSha256: "",
     installationDir: "",
     mambaVersion: "",
     minicondaVersion: "",

--- a/src/__tests__/input.test.ts
+++ b/src/__tests__/input.test.ts
@@ -537,6 +537,39 @@ describe("parseInputs", () => {
       await expect(parseInputs()).resolves.toBeDefined();
     });
 
+    it("throws when installer-sha256 is set without installer-url", async () => {
+      setInput("installer-sha256", "a".repeat(64));
+      const parseInputs = await loadParseInputs();
+
+      await expect(parseInputs()).rejects.toThrow(
+        "errors found in action inputs",
+      );
+      expect(core.error).toHaveBeenCalledWith(
+        expect.stringContaining("'installer-sha256' requires 'installer-url'"),
+      );
+    });
+
+    it("throws when installer-sha256 is not a 64-char hex digest", async () => {
+      setInput("installer-url", "https://example.com/installer.sh");
+      setInput("installer-sha256", "not-a-valid-sha");
+      const parseInputs = await loadParseInputs();
+
+      await expect(parseInputs()).rejects.toThrow(
+        "errors found in action inputs",
+      );
+      expect(core.error).toHaveBeenCalledWith(
+        expect.stringContaining("must be a 64-character hex"),
+      );
+    });
+
+    it("does NOT throw for a valid installer-sha256 with installer-url", async () => {
+      setInput("installer-url", "https://example.com/installer.sh");
+      setInput("installer-sha256", "A".repeat(64));
+      const parseInputs = await loadParseInputs();
+
+      await expect(parseInputs()).resolves.toBeDefined();
+    });
+
     it("throws when architecture=x86 on non-Windows", async () => {
       // Default mock: IS_WINDOWS=false
       setInput("architecture", "x86");

--- a/src/__tests__/installer/base.test.ts
+++ b/src/__tests__/installer/base.test.ts
@@ -5,8 +5,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ---------------------------------------------------------------------------
 
 const mockInfo = vi.fn();
+const mockWarning = vi.fn();
 vi.mock("@actions/core", () => ({
   info: (...args: any[]) => mockInfo(...args),
+  warning: (...args: any[]) => mockWarning(...args),
 }));
 
 const mockMv = vi.fn();
@@ -22,6 +24,16 @@ vi.mock("@actions/tool-cache", () => ({
   downloadTool: (...args: any[]) => mockDownloadTool(...args),
   cacheFile: (...args: any[]) => mockCacheFile(...args),
 }));
+
+const streamState = vi.hoisted(() => ({ bytes: Buffer.from("") }));
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  const { Readable } = await import("node:stream");
+  return {
+    ...actual,
+    createReadStream: () => Readable.from([streamState.bytes]),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -114,6 +126,27 @@ describe("ensureLocalInstaller", () => {
     );
   });
 
+  it("includes installer-sha256 in the cache version so a changed checksum re-downloads (#536)", async () => {
+    const crypto = await import("crypto");
+    const bytes = Buffer.from("x");
+    streamState.bytes = bytes;
+    const sha256 = crypto.createHash("sha256").update(bytes).digest("hex");
+    mockFind.mockReturnValue(""); // cache miss
+
+    const { ensureLocalInstaller } = await import("../../installer/base");
+    await ensureLocalInstaller({
+      url: "https://example.com/installer.sh",
+      sha256,
+    });
+
+    // The cache key (version) must incorporate the sha, so updating
+    // installer-sha256 misses a stale URL-only cache entry and re-downloads.
+    expect(mockFind).toHaveBeenCalledWith(
+      "installer.sh",
+      expect.stringContaining(`sha256.${sha256}`),
+    );
+  });
+
   it("downloads, renames, and caches when cache misses", async () => {
     mockFind.mockReturnValue("");
     mockDownloadTool.mockResolvedValue("/tmp/raw-download");
@@ -142,6 +175,39 @@ describe("ensureLocalInstaller", () => {
     );
     // The result is the renamed path
     expect(result).toBe("/tmp/raw-download.sh");
+  });
+
+  it("verifies a matching installer sha256 (#518)", async () => {
+    const crypto = await import("crypto");
+    const bytes = Buffer.from("installer-contents");
+    streamState.bytes = bytes;
+    const sha256 = crypto.createHash("sha256").update(bytes).digest("hex");
+
+    const { ensureLocalInstaller } = await import("../../installer/base");
+    const result = await ensureLocalInstaller({
+      url: "https://example.com/Installer.sh",
+      sha256,
+    });
+    expect(result).toBe("/tmp/raw-download.sh");
+  });
+
+  it("throws on a mismatched installer sha256 (#518)", async () => {
+    streamState.bytes = Buffer.from("installer-contents");
+    const { ensureLocalInstaller } = await import("../../installer/base");
+    await expect(
+      ensureLocalInstaller({
+        url: "https://example.com/Installer.sh",
+        sha256: "0".repeat(64),
+      }),
+    ).rejects.toThrow(/checksum mismatch/i);
+  });
+
+  it("warns when the installer URL uses insecure http (#518)", async () => {
+    const { ensureLocalInstaller } = await import("../../installer/base");
+    await ensureLocalInstaller({ url: "http://example.com/Installer.sh" });
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.stringContaining("insecure 'http:'"),
+    );
   });
 
   it("uses provided tool and version for caching", async () => {
@@ -192,7 +258,7 @@ describe("ensureLocalInstaller", () => {
       arch: "x86_64",
     });
 
-    // tc.find is called with arch as the extra spread arg
+    // tc.find is called with the tool name (cache key) and arch spread arg
     expect(mockFind).toHaveBeenCalledWith("MyTool", "1.0.0", "x86_64");
     // tc.cacheFile is called with arch as the extra spread arg
     expect(mockCacheFile).toHaveBeenCalledWith(

--- a/src/__tests__/installer/download-url.test.ts
+++ b/src/__tests__/installer/download-url.test.ts
@@ -111,5 +111,35 @@ describe("urlDownloader", () => {
       expect(result.options.mambaInInstaller).toBe(true);
       expect(result.options.useBundled).toBe(false);
     });
+
+    it("warns when installer-url has no installer-sha256 (#518)", async () => {
+      mockEnsureLocalInstaller.mockResolvedValue("/tmp/installer.sh");
+      const core = await import("@actions/core");
+      const { urlDownloader } = await import("../../installer/download-url");
+      const inputs = makeInputs({
+        installerUrl: "https://example.com/installer.sh",
+      });
+      await urlDownloader.installerPath(inputs, makeOptions());
+      expect(vi.mocked(core.warning)).toHaveBeenCalledWith(
+        expect.stringContaining("without 'installer-sha256'"),
+      );
+    });
+
+    it("passes installer-sha256 through to ensureLocalInstaller (#518)", async () => {
+      mockEnsureLocalInstaller.mockResolvedValue("/tmp/installer.sh");
+      const core = await import("@actions/core");
+      const { urlDownloader } = await import("../../installer/download-url");
+      const sha256 = "a".repeat(64);
+      const inputs = makeInputs({
+        installerUrl: "https://example.com/installer.sh",
+        installerSha256: sha256,
+      });
+      await urlDownloader.installerPath(inputs, makeOptions());
+      expect(mockEnsureLocalInstaller).toHaveBeenCalledWith({
+        url: "https://example.com/installer.sh",
+        sha256,
+      });
+      expect(vi.mocked(core.warning)).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/input.ts
+++ b/src/input.ts
@@ -95,6 +95,14 @@ const RULES: IRule[] = [
     `'installer-url' extension '${urlExt(i.installerUrl)}' must be one of: ${
       constants.KNOWN_EXTENSIONS
     }`,
+  (i) =>
+    !!(i.installerSha256 && !i.installerUrl) &&
+    `'installer-sha256' requires 'installer-url' to be set`,
+  (i) =>
+    !!(
+      i.installerSha256 && !/^[0-9a-f]{64}$/i.test(i.installerSha256.trim())
+    ) &&
+    `'installer-sha256: ${i.installerSha256}' must be a 64-character hex SHA-256 digest`,
   (
     i, // Miniconda x86 is only published for Windows lately (last Linux was 2019, last MacOS 2015)
   ) =>
@@ -148,6 +156,7 @@ export async function parseInputs(): Promise<types.IActionInputs> {
     condaVersion: core.getInput("conda-version"),
     environmentFile: core.getInput("environment-file"),
     installerUrl: core.getInput("installer-url"),
+    installerSha256: core.getInput("installer-sha256"),
     installationDir: core.getInput("installation-dir"),
     mambaVersion: core.getInput("mamba-version"),
     useMamba: core.getInput("use-mamba"),

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -7,6 +7,7 @@
  */
 
 import * as crypto from "crypto";
+import * as fs from "fs";
 import * as path from "path";
 import { URL, fileURLToPath } from "url";
 
@@ -46,22 +47,39 @@ export async function ensureLocalInstaller(
 
   const url = new URL(options.url);
 
+  if (url.protocol === "http:") {
+    core.warning(
+      `'installer-url' uses insecure 'http:'. This is deprecated and will be ` +
+        `rejected in a future major version; use 'https:' and/or set ` +
+        `'installer-sha256'. A network attacker could otherwise replace the installer.`,
+    );
+  }
+
   const installerName = path.basename(url.pathname);
   // As a URL, we assume posix paths
   const installerExtension = path.posix.extname(installerName);
   const tool = options.tool != null ? options.tool : installerName;
   // Create a fake version if neccessary
-  const version =
+  let version =
     options.version != null
       ? options.version
       : "0.0.0-" +
         crypto.createHash("sha256").update(options.url).digest("hex");
+  // Fold the expected checksum into the cache version so that changing
+  // `installer-sha256` for the same URL misses any stale cache entry and
+  // re-downloads, instead of verifying the old cached file and failing.
+  if (options.sha256) {
+    version = `${version}-sha256.${options.sha256.trim().toLowerCase()}`;
+  }
 
   let executablePath = "";
 
   if (url.protocol === "file:") {
     core.info(`Local file specified, using in-place...`);
     executablePath = fileURLToPath(options.url);
+    if (options.sha256) {
+      await verifyChecksum(executablePath, options.sha256);
+    }
   }
 
   if (executablePath === "") {
@@ -86,6 +104,9 @@ export async function ensureLocalInstaller(
       // returned by tc.find
       executablePath = path.join(cacheDirectoryPath, installerName);
       core.info(`executablePath is ${executablePath}`);
+      if (options.sha256) {
+        await verifyChecksum(executablePath, options.sha256);
+      }
     } else {
       core.info(`Did not find ${installerName} ${version} in cache`);
     }
@@ -99,6 +120,11 @@ export async function ensureLocalInstaller(
     // Always ensure the installer ends with a known path
     executablePath = rawDownloadPath + installerExtension;
     await io.mv(rawDownloadPath, executablePath);
+    // Verify before caching so a tampered installer is never written into the
+    // tool cache (which persists across runs on self-hosted runners).
+    if (options.sha256) {
+      await verifyChecksum(executablePath, options.sha256);
+    }
     core.info(`Caching ${tool}@${version}...`);
     const cacheResult = await tc.cacheFile(
       executablePath,
@@ -111,4 +137,34 @@ export async function ensureLocalInstaller(
   }
 
   return executablePath;
+}
+
+/**
+ * Verify a file's SHA-256 against an expected hex digest, failing closed.
+ *
+ * @param filePath - Path to the file to hash.
+ * @param expected - Expected SHA-256 as a hex string (case-insensitive).
+ * @throws {Error} If the computed digest does not match `expected`.
+ */
+async function verifyChecksum(
+  filePath: string,
+  expected: string,
+): Promise<void> {
+  const hash = crypto.createHash("sha256");
+  await new Promise<void>((resolve, reject) => {
+    const stream = fs.createReadStream(filePath);
+    stream.on("error", reject);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve());
+  });
+  const actual = hash.digest("hex");
+  const normalizedExpected = expected.trim().toLowerCase();
+  if (actual !== normalizedExpected) {
+    throw new Error(
+      `Installer checksum mismatch: expected sha256 '${normalizedExpected}' ` +
+        `but the file hashed to '${actual}'. The installer may be corrupted ` +
+        `or tampered with; aborting.`,
+    );
+  }
+  core.info(`Verified installer sha256: ${actual}`);
 }

--- a/src/installer/download-url.ts
+++ b/src/installer/download-url.ts
@@ -6,6 +6,8 @@
  * @category Installers
  */
 
+import * as core from "@actions/core";
+
 import * as types from "../types";
 
 import * as base from "./base";
@@ -21,9 +23,17 @@ export const urlDownloader: types.IInstallerProvider = {
   label: "download a custom installer by URL",
   provides: async (inputs, _options) => !!inputs.installerUrl,
   installerPath: async (inputs, options) => {
+    if (!inputs.installerSha256) {
+      core.warning(
+        `'installer-url' was provided without 'installer-sha256'. The installer ` +
+          `will be executed without integrity verification; set 'installer-sha256' ` +
+          `to the expected SHA-256 to verify it.`,
+      );
+    }
     return {
       localInstallerPath: await base.ensureLocalInstaller({
         url: inputs.installerUrl,
+        ...(inputs.installerSha256 ? { sha256: inputs.installerSha256 } : {}),
       }),
       options: {
         ...options,

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export interface ILocalInstallerOpts {
   tool?: string;
   version?: string;
   arch?: string;
+  /** Optional expected SHA-256 (hex) used to verify the downloaded installer. */
+  sha256?: string;
 }
 
 /**
@@ -88,6 +90,7 @@ export interface IActionInputs {
   readonly condaVersion: string;
   readonly environmentFile: string;
   readonly installerUrl: string;
+  readonly installerSha256: string;
   readonly installationDir: string;
   readonly mambaVersion: string;
   readonly minicondaVersion: string;


### PR DESCRIPTION
## Summary

Addresses #518. The action downloads an installer and executes it on the runner (with the runner's full permissions), previously without any integrity check, and `installer-url` permitted plain `http`. This adds opt-in checksum verification for custom installers and deprecates insecure `http`.

## Changes

- **`installer-sha256` input** (`action.yml`): when set, the downloaded `installer-url` file is hashed and verified before execution; a mismatch aborts the run (fail-closed). Implemented as `verifyChecksum` in `src/installer/base.ts`, plumbed via `ILocalInstallerOpts.sha256`.
- **Unverified-installer warning**: an `installer-url` without `installer-sha256` emits a `core.warning` that the installer is not integrity-verified.
- **`http` deprecation**: an `http:` installer URL emits a clear man-in-the-middle warning (still works for now; flagged for removal in a future major version).
- **Validation**: `installer-sha256` requires `installer-url` and must be a 64-character hex digest.
- **Docs**: documented in `action.yml` and a README note under the Custom-installer example.

## Tests

- `installer/base.test.ts`: matching checksum passes, mismatched checksum throws, `http` URL warns.
- `installer/download-url.test.ts`: warns when `installer-sha256` is absent; passes the checksum through to `ensureLocalInstaller`.
- Added `installer-sha256` to the shared `IActionInputs` test helpers.

## Follow-up (out of scope here)

Auto-verifying the **built-in** Miniconda/Miniforge downloads against upstream-published checksums (repo.anaconda.com / Miniforge GitHub releases) is deferred to its own PR, since it requires per-provider upstream-checksum fetching. The verification mechanism (`ILocalInstallerOpts.sha256`) is already in place, so wiring those in later is straightforward. #518 stays open for that piece.

## Verification

- `npm test` → all pass (424)
- `npm run check` → pass (prettier + eslint)
- `npm run build` → pass; `dist/setup/index.js` + `dist/delete/index.js` regenerated and committed

