### PR TITLE
fix(errors): surface command output and OOM hint when conda/mamba fail

### DIFF
--- a/dist/delete/index.js
+++ b/dist/delete/index.js
@@ -34261,6 +34261,23 @@ function isBaseEnv(envName) {
 function execute(command_1) {
     return utils_awaiter(this, arguments, void 0, function* (command, env = {}, captureOutput = false) {
         let capturedOutput = "";
+        // First detected FORCED_ERROR marker. Thrown after exec resolves rather than
+        // from inside the stream listener, where an exception could escape as an
+        // uncaught error and bypass the controlled-failure path (#116 review).
+        let forcedError = "";
+        // Keep a bounded tail of recent output so a failure can surface *why* the
+        // underlying conda/mamba command failed (see #116).
+        const MAX_OUTPUT_TAIL = 4000;
+        let outputTail = "";
+        const appendTail = (tail, chunk) => {
+            // If a single chunk already exceeds the cap, keep only its tail to avoid
+            // building a large `tail + chunk` intermediate string.
+            if (chunk.length >= MAX_OUTPUT_TAIL) {
+                return chunk.slice(-MAX_OUTPUT_TAIL);
+            }
+            const next = tail + chunk;
+            return next.length > MAX_OUTPUT_TAIL ? next.slice(-MAX_OUTPUT_TAIL) : next;
+        };
         const options = {
             errStream: new stream.Writable(),
             listeners: {
@@ -34269,9 +34286,13 @@ function execute(command_1) {
                     if (captureOutput) {
                         capturedOutput += stringData;
                     }
-                    for (const forced_error of constants.FORCED_ERRORS) {
-                        if (stringData.includes(forced_error)) {
-                            throw new Error(`"${command}" failed with "${forced_error}"`);
+                    outputTail = appendTail(outputTail, stringData);
+                    if (!forcedError) {
+                        for (const forced_error of constants.FORCED_ERRORS) {
+                            if (stringData.includes(forced_error)) {
+                                forcedError = forced_error;
+                                break;
+                            }
                         }
                     }
                     return data;
@@ -34283,18 +34304,59 @@ function execute(command_1) {
                             return;
                         }
                     }
+                    // Only keep non-ignored stderr in the failure tail so suppressed,
+                    // known-spurious warnings don't pollute the error message.
+                    outputTail = appendTail(outputTail, stringData);
                     core.warning(stringData);
                 },
             },
             env: Object.assign(Object.assign({}, process.env), env),
+            // Handle the exit code ourselves so we can attach a descriptive message
+            // instead of @actions/exec's generic "failed with exit code N" (#116).
+            ignoreReturnCode: true,
         };
         const exe = command[0];
         if (!exe) {
             throw new Error("execute() called with empty command array");
         }
         const rc = yield exec.exec(exe, command.slice(1), options);
+        // Display-only: quote args containing whitespace or quotes so the failed
+        // command reads clearly and stays balanced. We select a quote style rather
+        // than escaping (this string is never executed; args go to exec separately),
+        // which keeps embedded quotes and Windows paths (C:\...) intact and avoids
+        // the incomplete-escaping pattern.
+        const quoteArg = (arg) => {
+            if (!/[\s"']/.test(arg)) {
+                return arg;
+            }
+            // Choose a quote style that needs no escaping, so backslashes (Windows
+            // paths) stay intact and there is no incomplete-escaping pattern.
+            if (!arg.includes('"')) {
+                return `"${arg}"`;
+            }
+            if (!arg.includes("'")) {
+                return `'${arg}'`;
+            }
+            // Rare: the arg contains both quote types. JSON.stringify keeps it balanced
+            // (a complete encoder, not an incomplete-escaping sink).
+            return JSON.stringify(arg);
+        };
+        const displayCommand = command.map(quoteArg).join(" ");
+        if (forcedError) {
+            throw new Error(`${displayCommand} failed with "${forcedError}"`);
+        }
         if (rc !== 0) {
-            throw new Error(`${exe} return error code ${rc}`);
+            const oomHint = rc === null
+                ? " A null exit code means the process was terminated by a signal, " +
+                    "most commonly the OS out-of-memory killer while solving the " +
+                    "environment. Consider using the libmamba solver, reducing the " +
+                    "environment size, or a runner with more memory."
+                : "";
+            // Trim trailing whitespace/newlines only, so leading indentation of error
+            // blocks in the captured output is preserved.
+            const tail = outputTail.trimEnd();
+            throw new Error(`${displayCommand} failed with exit code ${rc}.${oomHint}` +
+                (tail ? `\n\n--- last output before failure ---\n${tail}` : ""));
         }
         if (captureOutput) {
             return capturedOutput;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -37441,6 +37441,23 @@ function isBaseEnv(envName) {
 function execute(command_1) {
     return utils_awaiter(this, arguments, void 0, function* (command, env = {}, captureOutput = false) {
         let capturedOutput = "";
+        // First detected FORCED_ERROR marker. Thrown after exec resolves rather than
+        // from inside the stream listener, where an exception could escape as an
+        // uncaught error and bypass the controlled-failure path (#116 review).
+        let forcedError = "";
+        // Keep a bounded tail of recent output so a failure can surface *why* the
+        // underlying conda/mamba command failed (see #116).
+        const MAX_OUTPUT_TAIL = 4000;
+        let outputTail = "";
+        const appendTail = (tail, chunk) => {
+            // If a single chunk already exceeds the cap, keep only its tail to avoid
+            // building a large `tail + chunk` intermediate string.
+            if (chunk.length >= MAX_OUTPUT_TAIL) {
+                return chunk.slice(-MAX_OUTPUT_TAIL);
+            }
+            const next = tail + chunk;
+            return next.length > MAX_OUTPUT_TAIL ? next.slice(-MAX_OUTPUT_TAIL) : next;
+        };
         const options = {
             errStream: new external_stream_namespaceObject.Writable(),
             listeners: {
@@ -37449,9 +37466,13 @@ function execute(command_1) {
                     if (captureOutput) {
                         capturedOutput += stringData;
                     }
-                    for (const forced_error of FORCED_ERRORS) {
-                        if (stringData.includes(forced_error)) {
-                            throw new Error(`"${command}" failed with "${forced_error}"`);
+                    outputTail = appendTail(outputTail, stringData);
+                    if (!forcedError) {
+                        for (const forced_error of FORCED_ERRORS) {
+                            if (stringData.includes(forced_error)) {
+                                forcedError = forced_error;
+                                break;
+                            }
                         }
                     }
                     return data;
@@ -37463,18 +37484,59 @@ function execute(command_1) {
                             return;
                         }
                     }
+                    // Only keep non-ignored stderr in the failure tail so suppressed,
+                    // known-spurious warnings don't pollute the error message.
+                    outputTail = appendTail(outputTail, stringData);
                     warning(stringData);
                 },
             },
             env: Object.assign(Object.assign({}, process.env), env),
+            // Handle the exit code ourselves so we can attach a descriptive message
+            // instead of @actions/exec's generic "failed with exit code N" (#116).
+            ignoreReturnCode: true,
         };
         const exe = command[0];
         if (!exe) {
             throw new Error("execute() called with empty command array");
         }
         const rc = yield exec_exec(exe, command.slice(1), options);
+        // Display-only: quote args containing whitespace or quotes so the failed
+        // command reads clearly and stays balanced. We select a quote style rather
+        // than escaping (this string is never executed; args go to exec separately),
+        // which keeps embedded quotes and Windows paths (C:\...) intact and avoids
+        // the incomplete-escaping pattern.
+        const quoteArg = (arg) => {
+            if (!/[\s"']/.test(arg)) {
+                return arg;
+            }
+            // Choose a quote style that needs no escaping, so backslashes (Windows
+            // paths) stay intact and there is no incomplete-escaping pattern.
+            if (!arg.includes('"')) {
+                return `"${arg}"`;
+            }
+            if (!arg.includes("'")) {
+                return `'${arg}'`;
+            }
+            // Rare: the arg contains both quote types. JSON.stringify keeps it balanced
+            // (a complete encoder, not an incomplete-escaping sink).
+            return JSON.stringify(arg);
+        };
+        const displayCommand = command.map(quoteArg).join(" ");
+        if (forcedError) {
+            throw new Error(`${displayCommand} failed with "${forcedError}"`);
+        }
         if (rc !== 0) {
-            throw new Error(`${exe} return error code ${rc}`);
+            const oomHint = rc === null
+                ? " A null exit code means the process was terminated by a signal, " +
+                    "most commonly the OS out-of-memory killer while solving the " +
+                    "environment. Consider using the libmamba solver, reducing the " +
+                    "environment size, or a runner with more memory."
+                : "";
+            // Trim trailing whitespace/newlines only, so leading indentation of error
+            // blocks in the captured output is preserved.
+            const tail = outputTail.trimEnd();
+            throw new Error(`${displayCommand} failed with exit code ${rc}.${oomHint}` +
+                (tail ? `\n\n--- last output before failure ---\n${tail}` : ""));
         }
         if (captureOutput) {
             return capturedOutput;

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -143,12 +143,87 @@ describe("execute", () => {
     expect(result).toBe("captured line 1\ncaptured line 2\n");
   });
 
-  it("throws on non-zero exit code", async () => {
+  it("throws a descriptive error on non-zero exit code", async () => {
     mockedExec.mockResolvedValue(1);
 
     await expect(execute(["conda", "bad-command"])).rejects.toThrow(
-      "conda return error code 1",
+      /conda bad-command failed with exit code 1/,
     );
+  });
+
+  it("passes ignoreReturnCode so exec returns the code instead of throwing", async () => {
+    mockedExec.mockResolvedValue(0);
+
+    await execute(["conda", "info"]);
+
+    const options = mockedExec.mock.calls[0][2] as exec.ExecOptions;
+    expect(options.ignoreReturnCode).toBe(true);
+  });
+
+  it("adds an out-of-memory hint when the process is killed (exit code null) (#116)", async () => {
+    mockedExec.mockResolvedValue(null as unknown as number);
+
+    await expect(execute(["conda", "env", "create"])).rejects.toThrow(
+      /out-of-memory/i,
+    );
+  });
+
+  it("includes recent command output in the failure message (#116)", async () => {
+    mockedExec.mockImplementation(async (_cmd, _args, options) => {
+      const listeners = (options as exec.ExecOptions).listeners;
+      listeners?.stdout?.(Buffer.from("Solving environment: failed\n"));
+      listeners?.stderr?.(Buffer.from("ResolvePackageNotFound: foo\n"));
+      return 1;
+    });
+
+    await expect(execute(["conda", "env", "create"])).rejects.toThrow(
+      /ResolvePackageNotFound: foo/,
+    );
+  });
+
+  it("quotes an argument containing whitespace in the failure message", async () => {
+    mockedExec.mockResolvedValue(1);
+
+    await expect(
+      execute(["conda", "create", "--prefix", "/my path/env"]),
+    ).rejects.toThrow('conda create --prefix "/my path/env"');
+  });
+
+  it("preserves backslashes in quoted Windows-style paths", async () => {
+    mockedExec.mockResolvedValue(1);
+
+    await expect(
+      execute(["conda", "create", "--prefix", "C:\\Program Files\\env"]),
+    ).rejects.toThrow('"C:\\Program Files\\env"');
+  });
+
+  it("keeps args with embedded double quotes balanced via single quotes", async () => {
+    mockedExec.mockResolvedValue(1);
+
+    await expect(execute(["conda", "create", '--flag="x y"'])).rejects.toThrow(
+      `'--flag="x y"'`,
+    );
+  });
+
+  it("uses a balanced representation for args containing both quote types", async () => {
+    mockedExec.mockResolvedValue(1);
+
+    await expect(execute(["conda", "create", `a"b'c`])).rejects.toThrow(
+      JSON.stringify(`a"b'c`),
+    );
+  });
+
+  it("excludes ignored stderr warnings from the failure output", async () => {
+    mockedExec.mockImplementation(async (_cmd, _args, options) => {
+      const listeners = (options as exec.ExecOptions).listeners;
+      listeners?.stderr?.(Buffer.from("menuinst_win32 noise\n"));
+      listeners?.stderr?.(Buffer.from("ResolvePackageNotFound: bar\n"));
+      return 1;
+    });
+
+    const err = (await execute(["conda", "x"]).catch((e) => e)) as Error;
+    expect(err.message).toContain("ResolvePackageNotFound: bar");
+    expect(err.message).not.toContain("menuinst_win32");
   });
 
   it("throws when stdout contains a FORCED_ERROR", async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,6 +82,23 @@ export async function execute(
   captureOutput: boolean = false,
 ): Promise<void | string> {
   let capturedOutput = "";
+  // First detected FORCED_ERROR marker. Thrown after exec resolves rather than
+  // from inside the stream listener, where an exception could escape as an
+  // uncaught error and bypass the controlled-failure path (#116 review).
+  let forcedError = "";
+  // Keep a bounded tail of recent output so a failure can surface *why* the
+  // underlying conda/mamba command failed (see #116).
+  const MAX_OUTPUT_TAIL = 4000;
+  let outputTail = "";
+  const appendTail = (tail: string, chunk: string): string => {
+    // If a single chunk already exceeds the cap, keep only its tail to avoid
+    // building a large `tail + chunk` intermediate string.
+    if (chunk.length >= MAX_OUTPUT_TAIL) {
+      return chunk.slice(-MAX_OUTPUT_TAIL);
+    }
+    const next = tail + chunk;
+    return next.length > MAX_OUTPUT_TAIL ? next.slice(-MAX_OUTPUT_TAIL) : next;
+  };
 
   const options: exec.ExecOptions = {
     errStream: new stream.Writable(),
@@ -91,9 +108,13 @@ export async function execute(
         if (captureOutput) {
           capturedOutput += stringData;
         }
-        for (const forced_error of constants.FORCED_ERRORS) {
-          if (stringData.includes(forced_error)) {
-            throw new Error(`"${command}" failed with "${forced_error}"`);
+        outputTail = appendTail(outputTail, stringData);
+        if (!forcedError) {
+          for (const forced_error of constants.FORCED_ERRORS) {
+            if (stringData.includes(forced_error)) {
+              forcedError = forced_error;
+              break;
+            }
           }
         }
         return data;
@@ -105,19 +126,63 @@ export async function execute(
             return;
           }
         }
+        // Only keep non-ignored stderr in the failure tail so suppressed,
+        // known-spurious warnings don't pollute the error message.
+        outputTail = appendTail(outputTail, stringData);
         core.warning(stringData);
       },
     },
     env: { ...process.env, ...env },
+    // Handle the exit code ourselves so we can attach a descriptive message
+    // instead of @actions/exec's generic "failed with exit code N" (#116).
+    ignoreReturnCode: true,
   };
 
   const exe = command[0];
   if (!exe) {
     throw new Error("execute() called with empty command array");
   }
-  const rc = await exec.exec(exe, command.slice(1), options);
+  const rc: number | null = await exec.exec(exe, command.slice(1), options);
+  // Display-only: quote args containing whitespace or quotes so the failed
+  // command reads clearly and stays balanced. We select a quote style rather
+  // than escaping (this string is never executed; args go to exec separately),
+  // which keeps embedded quotes and Windows paths (C:\...) intact and avoids
+  // the incomplete-escaping pattern.
+  const quoteArg = (arg: string): string => {
+    if (!/[\s"']/.test(arg)) {
+      return arg;
+    }
+    // Choose a quote style that needs no escaping, so backslashes (Windows
+    // paths) stay intact and there is no incomplete-escaping pattern.
+    if (!arg.includes('"')) {
+      return `"${arg}"`;
+    }
+    if (!arg.includes("'")) {
+      return `'${arg}'`;
+    }
+    // Rare: the arg contains both quote types. JSON.stringify keeps it balanced
+    // (a complete encoder, not an incomplete-escaping sink).
+    return JSON.stringify(arg);
+  };
+  const displayCommand = command.map(quoteArg).join(" ");
+  if (forcedError) {
+    throw new Error(`${displayCommand} failed with "${forcedError}"`);
+  }
   if (rc !== 0) {
-    throw new Error(`${exe} return error code ${rc}`);
+    const oomHint =
+      rc === null
+        ? " A null exit code means the process was terminated by a signal, " +
+          "most commonly the OS out-of-memory killer while solving the " +
+          "environment. Consider using the libmamba solver, reducing the " +
+          "environment size, or a runner with more memory."
+        : "";
+    // Trim trailing whitespace/newlines only, so leading indentation of error
+    // blocks in the captured output is preserved.
+    const tail = outputTail.trimEnd();
+    throw new Error(
+      `${displayCommand} failed with exit code ${rc}.${oomHint}` +
+        (tail ? `\n\n--- last output before failure ---\n${tail}` : ""),
+    );
   }
   if (captureOutput) {
     return capturedOutput;


### PR DESCRIPTION
## Summary

Closes #116. When a `conda`/`mamba` command failed, the action surfaced only `@actions/exec`'s generic `The process '...' failed with exit code null`, with no indication of _why_. An exit code of `null` means the process was killed by a signal, which on CI runners almost always means the OS out-of-memory killer during environment solving (exactly the scenario in #116).

## Changes

`src/utils.ts` (`execute`):

- Set `ignoreReturnCode: true` so the action controls the failure instead of `@actions/exec` throwing its generic message first.
- Keep a bounded 4 KB tail of recent stdout + stderr.
- On a non-zero or `null` exit, throw a descriptive error including the full command, the exit code, an out-of-memory hint when the code is `null`, and the last output before failure (so the real conda/mamba error, e.g. `ResolvePackageNotFound`, is shown inline).

## Tests

`src/__tests__/utils.test.ts`: revised the exit-code test and added coverage for `ignoreReturnCode`, the OOM hint on a `null` exit, and the captured output appearing in the failure message.

## Verification

- `npm test` → all pass (417)
- `npm run check` → pass (prettier + eslint)
- `npm run build` → pass; `dist/setup/index.js` + `dist/delete/index.js` regenerated and committed
