### PR TITLE
fix: look up the tool cache by tool name to fix Miniconda3 cache miss…

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -39032,7 +39032,11 @@ function ensureLocalInstaller(options) {
             info(`Checking for cached ${tool}@${version}...`);
             // tc.find returns the name of the directory in which
             // the cached file is located.
-            const cacheDirectoryPath = find(installerName, version, ...(options.arch ? [options.arch] : []));
+            // Look up the cache by the same key it is written under (`tool`), not the
+            // installer filename. Otherwise callers that set `options.tool` (the
+            // built-in Miniconda/Miniforge downloaders) never get a cache hit and
+            // re-download on every run (#197).
+            const cacheDirectoryPath = find(tool, version, ...(options.arch ? [options.arch] : []));
             if (cacheDirectoryPath !== "") {
                 info(`Found ${installerName} cache at ${cacheDirectoryPath}!`);
                 // Append the basename of the cached file to the directory

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -39035,7 +39035,9 @@ function ensureLocalInstaller(options) {
             // Look up the cache by the same key it is written under (`tool`), not the
             // installer filename. Otherwise callers that set `options.tool` (the
             // built-in Miniconda/Miniforge downloaders) never get a cache hit and
-            // re-download on every run (#197).
+            // re-download semver-compatible versions on every run (#197). Non-semver
+            // labels such as "latest" are passed through unchanged; @actions/tool-cache
+            // owns those restore semantics and will treat moving pointers as misses.
             const cacheDirectoryPath = find(tool, version, ...(options.arch ? [options.arch] : []));
             if (cacheDirectoryPath !== "") {
                 info(`Found ${installerName} cache at ${cacheDirectoryPath}!`);

--- a/src/__tests__/installer/base.test.ts
+++ b/src/__tests__/installer/base.test.ts
@@ -76,6 +76,20 @@ describe("ensureLocalInstaller", () => {
     expect(mockDownloadTool).not.toHaveBeenCalled();
   });
 
+  it("looks up the cache by tool name (the cache key), not the filename (#197)", async () => {
+    mockFind.mockReturnValue("/tmp/cache-dir");
+    const { ensureLocalInstaller } = await import("../../installer/base");
+    await ensureLocalInstaller({
+      url: "https://example.com/installer.sh",
+      tool: "Miniconda3",
+      version: "1.2.3",
+    });
+    // Must look up by `tool` (matching tc.cacheFile), so the built-in
+    // downloaders actually hit the cache instead of re-downloading every run.
+    expect(mockFind).toHaveBeenCalledWith("Miniconda3", "1.2.3");
+    expect(mockDownloadTool).not.toHaveBeenCalled();
+  });
+
   it("downloads, renames, and caches when cache misses", async () => {
     mockFind.mockReturnValue("");
     mockDownloadTool.mockResolvedValue("/tmp/raw-download");
@@ -155,7 +169,7 @@ describe("ensureLocalInstaller", () => {
     });
 
     // tc.find is called with arch as the extra spread arg
-    expect(mockFind).toHaveBeenCalledWith("installer.sh", "1.0.0", "x86_64");
+    expect(mockFind).toHaveBeenCalledWith("MyTool", "1.0.0", "x86_64");
     // tc.cacheFile is called with arch as the extra spread arg
     expect(mockCacheFile).toHaveBeenCalledWith(
       "/tmp/raw.sh",
@@ -178,8 +192,8 @@ describe("ensureLocalInstaller", () => {
       version: "1.0.0",
     });
 
-    // tc.find called without arch
-    expect(mockFind).toHaveBeenCalledWith("installer.sh", "1.0.0");
+    // tc.find called with the tool name (cache key), without arch
+    expect(mockFind).toHaveBeenCalledWith("MyTool", "1.0.0");
   });
 
   it("handles .exe extension correctly", async () => {

--- a/src/__tests__/installer/base.test.ts
+++ b/src/__tests__/installer/base.test.ts
@@ -90,6 +90,30 @@ describe("ensureLocalInstaller", () => {
     expect(mockDownloadTool).not.toHaveBeenCalled();
   });
 
+  it('passes "latest" through to tool-cache so semver restore rules decide the miss', async () => {
+    mockFind.mockReturnValue("");
+    const { ensureLocalInstaller } = await import("../../installer/base");
+    await ensureLocalInstaller({
+      url: "https://example.com/installer.sh",
+      tool: "Miniconda3",
+      version: "latest",
+      arch: "x86_64",
+    });
+    // `latest` is a moving pointer, not a semver version. This helper keeps it
+    // unchanged and lets @actions/tool-cache decide that it is not restorable.
+    expect(mockFind).toHaveBeenCalledWith("Miniconda3", "latest", "x86_64");
+    expect(mockDownloadTool).toHaveBeenCalledWith(
+      "https://example.com/installer.sh",
+    );
+    expect(mockCacheFile).toHaveBeenCalledWith(
+      "/tmp/raw-download.sh",
+      "installer.sh",
+      "Miniconda3",
+      "latest",
+      "x86_64",
+    );
+  });
+
   it("downloads, renames, and caches when cache misses", async () => {
     mockFind.mockReturnValue("");
     mockDownloadTool.mockResolvedValue("/tmp/raw-download");

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -68,8 +68,12 @@ export async function ensureLocalInstaller(
     core.info(`Checking for cached ${tool}@${version}...`);
     // tc.find returns the name of the directory in which
     // the cached file is located.
+    // Look up the cache by the same key it is written under (`tool`), not the
+    // installer filename. Otherwise callers that set `options.tool` (the
+    // built-in Miniconda/Miniforge downloaders) never get a cache hit and
+    // re-download on every run (#197).
     const cacheDirectoryPath = tc.find(
-      installerName,
+      tool,
       version,
       ...(options.arch ? [options.arch] : []),
     );

--- a/src/installer/base.ts
+++ b/src/installer/base.ts
@@ -71,7 +71,9 @@ export async function ensureLocalInstaller(
     // Look up the cache by the same key it is written under (`tool`), not the
     // installer filename. Otherwise callers that set `options.tool` (the
     // built-in Miniconda/Miniforge downloaders) never get a cache hit and
-    // re-download on every run (#197).
+    // re-download semver-compatible versions on every run (#197). Non-semver
+    // labels such as "latest" are passed through unchanged; @actions/tool-cache
+    // owns those restore semantics and will treat moving pointers as misses.
     const cacheDirectoryPath = tc.find(
       tool,
       version,


### PR DESCRIPTION
Closes #197

## Summary

For SemVer-compatible installer versions, the installer cache is written under `tool` (via `tc.cacheFile(..., tool, version, ...)`) but was looked up by the installer **filename** (`tc.find(installerName, ...)`). Whenever a caller sets `options.tool` -- which the built-in Miniconda/Miniforge downloaders always do -- the lookup key did not match the write key, so SemVer-compatible versions missed the cache and the installer was re-downloaded on every run.

Non-SemVer labels such as `latest` are intentionally passed through unchanged and delegated to `@actions/tool-cache` semantics. `latest` remains a moving pointer and is not expected to restore from the tool cache.

## Change

`src/installer/base.ts`: look up the cache by `tool` (the same key `tc.cacheFile` writes under), so built-in installers with SemVer-compatible versions hit the cache and skip the redundant re-download.

## Tests

`src/__tests__/installer/base.test.ts`:

- New test: `tc.find` is called with the tool name (the cache key), not the filename (#197).
- New test: `latest` is passed through unchanged and delegated to `@actions/tool-cache` restore semantics.
- Updated the two arch tests to expect the tool name in the `tc.find` call.

## Verification

- `npm test` -> all pass (416)
- `npm run check` -> pass (prettier + eslint)
- `npm run build` -> pass; `dist/setup/index.js` regenerated and committed

## Note

The same one-line change is also bundled in PR #536 (where it was a "bonus" fix). If this focused PR lands first, the cache change should be dropped from #536 to avoid a merge conflict.
