### PR TITLE
test: cover add-anaconda-token, channel-alias, use-only-tar-bz2 inputs

### DIFF
--- a/src/__tests__/conda.test.ts
+++ b/src/__tests__/conda.test.ts
@@ -77,14 +77,29 @@ function makeInputs(
     condaRemoveDefaults: string;
     runInit: string;
     removeProfiles: string;
+    add_anaconda_token: string;
+    channel_alias: string;
+    use_only_tar_bz2: string;
   }> = {},
 ): types.IActionInputs {
   return makeCondaForgeActionInputs({
     condaRemoveDefaults: overrides.condaRemoveDefaults ?? "false",
     removeProfiles: overrides.removeProfiles ?? "true",
     runInit: overrides.runInit ?? "true",
-    condaConfig:
-      overrides.channels === undefined ? {} : { channels: overrides.channels },
+    condaConfig: {
+      ...(overrides.channels === undefined
+        ? {}
+        : { channels: overrides.channels }),
+      ...(overrides.add_anaconda_token === undefined
+        ? {}
+        : { add_anaconda_token: overrides.add_anaconda_token }),
+      ...(overrides.channel_alias === undefined
+        ? {}
+        : { channel_alias: overrides.channel_alias }),
+      ...(overrides.use_only_tar_bz2 === undefined
+        ? {}
+        : { use_only_tar_bz2: overrides.use_only_tar_bz2 }),
+    },
   });
 }
 
@@ -126,6 +141,40 @@ describe("writeCondaConfig", () => {
 
     const config = getWrittenConfig();
     expect(config["channels"]).toContain("conda-forge");
+  });
+
+  it("writes add-anaconda-token to condarc as a boolean (#525)", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ add_anaconda_token: "true" });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    expect(getWrittenConfig()["add_anaconda_token"]).toBe(true);
+  });
+
+  it("writes channel-alias to condarc as a string (#525)", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const alias = "https://conda.example.com";
+    const inputs = makeInputs({ channel_alias: alias });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    expect(getWrittenConfig()["channel_alias"]).toBe(alias);
+  });
+
+  it("writes use-only-tar-bz2 to condarc as a boolean (#525)", async () => {
+    const { writeCondaConfig } = await import("../conda");
+    const inputs = makeInputs({ use_only_tar_bz2: "true" });
+
+    vi.mocked(fsMod.readFileSync).mockReturnValue(yaml.dump({}));
+
+    await writeCondaConfig(inputs, makeOptions());
+
+    expect(getWrittenConfig()["use_only_tar_bz2"]).toBe(true);
   });
 
   it("uses channels from envSpec.yaml when input channels are empty", async () => {


### PR DESCRIPTION
## Summary

Closes #525. Several action inputs had no asserted behavior in the suite -- effectively trust-me paths that could regress silently. This adds unit assertions for the inputs that lacked them, verifying each lands correctly in the generated condarc.

## Coverage added (`src/__tests__/conda.test.ts`)

- `add-anaconda-token` -> `add_anaconda_token: true` (boolean-coerced)
- `channel-alias` -> `channel_alias: "<url>"` (string)
- `use-only-tar-bz2` -> `use_only_tar_bz2: true` (boolean-coerced)

(`makeInputs` was extended to accept these condaConfig overrides.)

## Already covered (verified, not duplicated)

The rest of the issue's list already had assertions, so I confirmed rather than re-adding:

- `architecture` -> `download-miniconda.test.ts` (arch->URL mapping, invalid arch) + `base.test.ts` (arch passed to `tc.find` / `tc.cacheFile`)
- `file://` / query-param `installer-url` -> `base.test.ts`
- `pkgs-dirs` -> `conda.test.ts` (merge into condarc) + `utils.test.ts` (`parsePkgsDirs`)

## Notes

- Test-only change; no `src`/`dist` modified.
- `npm test` (417) and `npm run check` pass.
- Deferred: the published "input -> coverage matrix" (the issue's second acceptance bullet) is a docs artifact better tracked on its own; happy to add it as a follow-up.
